### PR TITLE
fix(server): fail closed when metered endpoint has no payment backend (#373)

### DIFF
--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -222,8 +222,30 @@ pub async fn payment_middleware<S: PaymentState>(
 
     let mpps = state.mpps();
     if mpps.is_empty() {
-        tracing::warn!("Metered endpoint hit but MPP not configured — passing through");
-        return next.run(req).await;
+        // Fail closed (issue #373): this endpoint declares a price, but the
+        // server has no MPP payment backend configured, so we can neither
+        // issue a 402 challenge nor verify a credential. Forwarding to the
+        // protected upstream would serve a paid resource for free, turning a
+        // misconfiguration into a silent fail-open. Reject with a server error
+        // and an error-level event instead.
+        //
+        // This does not affect local development: `pay --sandbox server start`
+        // auto-configures an ephemeral MPP, and a non-sandbox boot without a
+        // resolvable signer/recipient already fails at startup.
+        tracing::error!(
+            subdomain = %subdomain,
+            path = %path,
+            "Metered endpoint hit but no MPP payment backend is configured — failing closed",
+        );
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(json!({
+                "error": "payment_backend_unconfigured",
+                "message": "This endpoint requires payment, but the server has no payment backend \
+                    configured. Failing closed instead of serving the resource without payment.",
+            })),
+        )
+            .into_response();
     }
 
     match auth_header {

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -241,8 +241,7 @@ pub async fn payment_middleware<S: PaymentState>(
             StatusCode::INTERNAL_SERVER_ERROR,
             axum::Json(json!({
                 "error": "payment_backend_unconfigured",
-                "message": "This endpoint requires payment, but the server has no payment backend \
-                    configured. Failing closed instead of serving the resource without payment.",
+                "message": "This endpoint requires payment, but the server has no payment backend configured. Failing closed instead of serving the resource without payment.",
             })),
         )
             .into_response();

--- a/rust/crates/core/tests/server_tests.rs
+++ b/rust/crates/core/tests/server_tests.rs
@@ -619,10 +619,12 @@ async fn middleware_garbage_auth_includes_message() {
 // =============================================================================
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn middleware_passes_through_without_mpp() {
+async fn middleware_fails_closed_without_mpp() {
     let (url, _h) = start_test_server(false).await;
     let client = reqwest::Client::new();
-    // Metered endpoint but no MPP → pass through
+    // Metered endpoint but no MPP configured → fail closed (issue #373).
+    // Forwarding here would serve a paid resource for free, so the
+    // middleware must reject rather than pass through.
     let resp = client
         .post(format!("{url}/v1/simple/echo"))
         .headers(client_with_host("testapi"))
@@ -630,7 +632,13 @@ async fn middleware_passes_through_without_mpp() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.status(),
+        500,
+        "metered endpoint with no payment backend must fail closed, not pass through"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"], "payment_backend_unconfigured");
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #373.

## Problem
The payment middleware (`rust/crates/core/src/server/payment.rs`) forwarded a request straight to the protected upstream when `state.mpps()` was empty:

```rust
let mpps = state.mpps();
if mpps.is_empty() {
    tracing::warn!("Metered endpoint hit but MPP not configured — passing through");
    return next.run(req).await;   // fail-open
}
```

For an endpoint that declares a price, a production misconfiguration that left MPP unconfigured would **serve the paid resource for free** — a silent fail-open, as reported by @chenshj73.

## Fix
Fail **closed**: return HTTP 500 `payment_backend_unconfigured` with an error-level (high-severity) tracing event instead of passing through.

This does not affect local development:
- `pay --sandbox server start` auto-configures an ephemeral MPP (so `mpps` is non-empty), and
- a non-sandbox boot without a resolvable signer/recipient already fails at startup.

The branch only triggers for endpoints that explicitly declare `metering` (we're past the no-metering early return), so it never penalises free routes.

## Tests
Flipped the existing `middleware_passes_through_without_mpp` (asserted 200) to **`middleware_fails_closed_without_mpp`** — asserts 500 + `payment_backend_unconfigured`. Full `server_tests` suite passes.