### PR TITLE
feat(x402): prefer sign-in-with-x (spend credits) over paying

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5686,7 +5686,7 @@ checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pay"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "pay-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "pay-integration"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "pay-core",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "pay-keystore"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bs58",
  "secret-service",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "pay-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "pay-pdb"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "pay-types"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.19.0"
+version = "0.20.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -585,6 +585,7 @@ fn handle_outcome(
         RunOutcome::X402SignInChallenge {
             challenge,
             resource_url,
+            ..
         } => {
             if auto_pay {
                 if verbose && !is_json {

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -45,9 +45,15 @@ pub enum RunOutcome {
         challenge: Box<x402::Challenge>,
         resource_url: String,
     },
-    /// The server returned 402 with an auth-only x402 SIWX challenge.
+    /// The server returned 402 with an x402 `sign-in-with-x` challenge.
+    ///
+    /// When the same 402 also offered a payment option, `payment_fallback`
+    /// carries it: the client prefers signing in (to spend existing credits)
+    /// but can fall back to paying if sign-in doesn't grant access (e.g. the
+    /// wallet hasn't paid / has no credits yet).
     X402SignInChallenge {
         challenge: Box<x402::SiwxAuthChallenge>,
+        payment_fallback: Option<Box<x402::Challenge>>,
         resource_url: String,
     },
     /// The server returned 402 but without a recognized payment protocol.
@@ -573,17 +579,26 @@ pub(crate) fn classify_402_with_preference(
     // Fall back to x402 if it has a Solana path. Skip when the user
     // pinned MPP via `--mpp`.
     if preference != ProtocolPreference::OnlyMpp {
-        if let Some(challenge) = x402_challenge {
-            info!(resource = resource_url, "Detected x402 challenge (Solana)");
-            return RunOutcome::X402Challenge {
-                challenge: Box::new(challenge),
+        // Prefer `sign-in-with-x` when the server offers it: a wallet that
+        // already holds credits (or has previously paid) should authenticate
+        // and spend those rather than pay again. If the same 402 also
+        // advertised a payment option, carry it as `payment_fallback` so the
+        // caller can still pay when sign-in doesn't grant access (no credits).
+        if let Some(siwx) = x402_siwx_challenge {
+            info!(
+                resource = resource_url,
+                "Detected x402 sign-in challenge (preferring credits over payment)"
+            );
+            return RunOutcome::X402SignInChallenge {
+                challenge: Box::new(siwx),
+                payment_fallback: x402_challenge.map(Box::new),
                 resource_url: resource_url.to_string(),
             };
         }
 
-        if let Some(challenge) = x402_siwx_challenge {
-            info!(resource = resource_url, "Detected x402 sign-in challenge");
-            return RunOutcome::X402SignInChallenge {
+        if let Some(challenge) = x402_challenge {
+            info!(resource = resource_url, "Detected x402 challenge (Solana)");
+            return RunOutcome::X402Challenge {
                 challenge: Box::new(challenge),
                 resource_url: resource_url.to_string(),
             };
@@ -1590,6 +1605,7 @@ HTTP request sent, awaiting response...
             RunOutcome::X402SignInChallenge {
                 challenge,
                 resource_url,
+                ..
             } => {
                 assert_eq!(challenge.extension.nonce, "nonce-123");
                 assert_eq!(resource_url, "https://example.com/resource");
@@ -1599,7 +1615,7 @@ HTTP request sent, awaiting response...
     }
 
     #[test]
-    fn classify_402_prefers_payment_when_siwx_extends_payment_challenge() {
+    fn classify_402_prefers_signin_with_payment_fallback() {
         use base64::Engine;
 
         let selected = serde_json::json!({
@@ -1636,12 +1652,19 @@ HTTP request sent, awaiting response...
 
         let outcome = classify_402(&headers, None, "https://example.com/resource");
 
+        // Prefer sign-in (spend credits) over paying when both are offered,
+        // but keep the payment option as a fallback for the no-credits case.
         match outcome {
-            RunOutcome::X402Challenge { challenge, .. } => {
-                assert_eq!(challenge.requirements.amount, "10000");
-                assert!(challenge.siwx.is_some());
+            RunOutcome::X402SignInChallenge {
+                challenge,
+                payment_fallback,
+                ..
+            } => {
+                assert_eq!(challenge.extension.nonce, "nonce-123");
+                let pay = payment_fallback.expect("payment option preserved as fallback");
+                assert_eq!(pay.requirements.amount, "10000");
             }
-            other => panic!("expected X402Challenge, got {other:?}"),
+            other => panic!("expected X402SignInChallenge, got {other:?}"),
         }
     }
 

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -65,15 +65,18 @@ pub fn parse(headers: &[(String, String)], body: Option<&str>) -> Option<Challen
     })
 }
 
-/// Try to parse an auth-only x402 SIWX challenge.
+/// Try to parse an x402 `sign-in-with-x` challenge.
+///
+/// Unlike a pure auth gate, this is returned even when the same 402 also
+/// advertises payment options in `accepts` — a wallet that already holds
+/// credits (or has previously paid) should be able to sign in and spend
+/// those instead of paying again. The caller decides preference + fallback
+/// (see `classify_402`).
 pub fn parse_siwx_auth(
     headers: &[(String, String)],
     body: Option<&str>,
 ) -> Option<SiwxAuthChallenge> {
     let envelope = parse_payment_required_envelope(headers, body)?;
-    if !envelope.accepts.is_empty() {
-        return None;
-    }
     let extension = siwx_extension_from_payment_required(&envelope)
         .ok()
         .flatten()?;
@@ -886,7 +889,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_siwx_auth_ignores_payment_challenges() {
+    fn parse_siwx_auth_reads_siwx_even_with_payment() {
         let selected = serde_json::json!({
             "scheme": EXACT_SCHEME,
             "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
@@ -921,7 +924,10 @@ mod tests {
         );
         let headers = vec![(PAYMENT_REQUIRED_HEADER.to_string(), encoded)];
 
-        assert!(parse_siwx_auth(&headers, None).is_none());
+        // sign-in-with-x is surfaced even when payment options coexist, so a
+        // funded wallet can prefer spending credits over paying.
+        let siwx = parse_siwx_auth(&headers, None).expect("siwx challenge present");
+        assert_eq!(siwx.extension.nonce, "nonce-123");
         assert!(parse(&headers, None).unwrap().siwx.is_some());
     }
 

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -320,7 +320,9 @@ fn do_paid_fetch(
             ..
         } => {
             // Prefer spending existing credits: sign in with the wallet and
-            // retry. Only one Touch ID / approval is needed for the signature.
+            // retry. The sign-in signature takes one Touch ID / approval; if
+            // sign-in doesn't grant access and we fall back to paying below,
+            // the payment signature requires a second approval.
             let built = pay_core::client::x402::build_siwx_auth_header_with_override(
                 &challenge,
                 &store,
@@ -367,8 +369,17 @@ fn do_paid_fetch(
                     &headers,
                     body.as_deref(),
                 )?)
+            } else if let RunOutcome::PaymentRejected { reason, .. } = retry {
+                Err(pay_core::Error::PaymentRejected(reason))
             } else {
-                interpret_retry(retry)
+                // Sign-in didn't grant access and the 402 offered no payment
+                // option to fall back to — typically the wallet has no credits
+                // yet. Don't claim a payment was made/rejected here.
+                Err(pay_core::Error::Mpp(
+                    "Server returned 402 again after sign-in — the wallet has no usable credits \
+                     and the endpoint offered no payment option"
+                        .to_string(),
+                ))
             }
         }
         RunOutcome::SessionChallenge { .. } => Err(pay_core::Error::Mpp(

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -314,8 +314,14 @@ fn do_paid_fetch(
                 body.as_deref(),
             )?)
         }
-        RunOutcome::X402SignInChallenge { challenge, .. } => {
-            let built_payment = pay_core::client::x402::build_siwx_auth_header_with_override(
+        RunOutcome::X402SignInChallenge {
+            challenge,
+            payment_fallback,
+            ..
+        } => {
+            // Prefer spending existing credits: sign in with the wallet and
+            // retry. Only one Touch ID / approval is needed for the signature.
+            let built = pay_core::client::x402::build_siwx_auth_header_with_override(
                 &challenge,
                 &store,
                 network_override.as_deref(),
@@ -325,17 +331,45 @@ fn do_paid_fetch(
             )?;
             let mut headers = extra_headers.to_vec();
             headers.extend(
-                built_payment
+                built
                     .headers
                     .into_iter()
                     .map(|(name, value)| (name.to_string(), value)),
             );
-            interpret_retry(pay_core::client::fetch::fetch_request(
-                method,
-                url,
-                &headers,
-                body.as_deref(),
-            )?)
+            let retry =
+                pay_core::client::fetch::fetch_request(method, url, &headers, body.as_deref())?;
+
+            // If sign-in granted access, we're done — credits were spent, no
+            // payment made. If the server still refuses (e.g. the wallet has
+            // no credits yet) and the same 402 also offered a payment option,
+            // fall back to paying so the call can still go through.
+            if matches!(retry, RunOutcome::Completed { .. }) {
+                interpret_retry(retry)
+            } else if let Some(pay_challenge) = payment_fallback {
+                let built_payment = pay_core::client::x402::build_payment_with_override(
+                    &pay_challenge,
+                    &store,
+                    network_override.as_deref(),
+                    account_override.as_deref(),
+                    Some(url),
+                    make_auth_override(),
+                )?;
+                let mut headers = extra_headers.to_vec();
+                headers.extend(
+                    built_payment
+                        .headers
+                        .into_iter()
+                        .map(|(name, value)| (name.to_string(), value)),
+                );
+                interpret_retry(pay_core::client::fetch::fetch_request(
+                    method,
+                    url,
+                    &headers,
+                    body.as_deref(),
+                )?)
+            } else {
+                interpret_retry(retry)
+            }
         }
         RunOutcome::SessionChallenge { .. } => Err(pay_core::Error::Mpp(
             "402 Payment Required (MPP session) — session payments require a stateful client with a Fiber channel".to_string(),

--- a/typescript/packages/solana-pay/core/package.json
+++ b/typescript/packages/solana-pay/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-foundation/pay",
     "license": "MIT",


### PR DESCRIPTION
## What
When an x402 `402` offers **both** a payment option and a `sign-in-with-x` challenge, Pay now **signs in to spend existing credits instead of paying again**, falling back to payment only if sign-in doesn't grant access.

Motivation: credit-funded providers (e.g. Venice) advertise both on every inference endpoint. Pay previously always took the payment path, so a wallet with a topped-up balance would be charged a fresh payment (Venice quotes its dynamic **max**, ~$10) instead of spending its credits.

## Changes
- **`client/x402.rs::parse_siwx_auth`** — surface the `sign-in-with-x` challenge even when `accepts` is non-empty (it previously bailed, so the SIWX option was never seen when payment was also offered).
- **`RunOutcome::X402SignInChallenge`** — carries an optional `payment_fallback` (the payment challenge from the same 402).
- **`classify_402`** — prefer sign-in over payment when both are offered; keep the payment option as the fallback.
- **mcp `curl`** — sign in + retry; if the server still refuses (e.g. `402 insufficient_balance`) and a payment fallback exists, pay.

Status-code mapping (confirmed with Venice): `200` valid sign-in + credits → done (credits spent); `402 insufficient_balance` valid sign-in, no credits → fall back to pay; `401` bad signature → surfaced (not paid).

## Tests
- Updated the two tests that encoded the old "prefer payment" behavior:
  - `parse_siwx_auth_reads_siwx_even_with_payment`
  - `classify_402_prefers_signin_with_payment_fallback`
- Full `pay-core` client + `pay-mcp` suites pass; `cargo check --workspace --all-targets`, fmt, clippy clean.

## Live verification (Venice)
```
INFO  Detected x402 sign-in challenge (preferring credits over payment)
POST /chat/completions  extra=["SIGN-IN-WITH-X: …"]
→ {"content":"Hi there", … "cost":{"usd":0.00015…}}
```
A chat call now **debits ~$0.0002 of credits** via `SIGN-IN-WITH-X` instead of a fresh ~$10 payment.