### PR TITLE
fix(types): validate split-recipient uniqueness per payment method

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,6 +38,7 @@ install *args:
 
     case "${target}" in
         pay)
+            {{ just_executable() }} _check-native-build-deps
             build_pdb
             if [ "$#" -gt 0 ]; then
                 cargo install "$@"
@@ -107,10 +108,12 @@ build target='all':
     case "{{ target }}" in
         all)
             cd typescript && pnpm --filter @solana/pay build && cd ..
+            {{ just_executable() }} _check-native-build-deps
             build_pdb
             cd rust && cargo build --release
             ;;
         pay)
+            {{ just_executable() }} _check-native-build-deps
             build_pdb
             cd rust && cargo build --release
             ;;
@@ -118,6 +121,7 @@ build target='all':
             build_pdb
             ;;
         rust)
+            {{ just_executable() }} _check-native-build-deps
             cd rust && cargo build --release
             ;;
         typescript|ts)
@@ -129,6 +133,43 @@ build target='all':
             exit 1
             ;;
     esac
+
+_check-native-build-deps:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    missing=()
+    for tool in cc make cmake; do
+        if ! command -v "${tool}" >/dev/null 2>&1; then
+            missing+=("${tool}")
+        fi
+    done
+
+    if [ "${#missing[@]}" -eq 0 ]; then
+        exit 0
+    fi
+
+    echo "Missing native build tool(s): ${missing[*]}"
+    echo
+    echo "pay currently builds native TLS/compression dependencies through Pingora/rustls."
+    case "$(uname -s)" in
+        Darwin)
+            echo "Install Xcode Command Line Tools for cc/make:"
+            echo "  xcode-select --install"
+            echo "Install CMake with Homebrew:"
+            echo "  brew install cmake"
+            ;;
+        Linux)
+            echo "Debian/Ubuntu:"
+            echo "  sudo apt-get install build-essential cmake pkg-config"
+            echo "Fedora:"
+            echo "  sudo dnf install gcc gcc-c++ make cmake pkgconf-pkg-config"
+            ;;
+        *)
+            echo "Install a C compiler, make, and cmake for your platform."
+            ;;
+    esac
+    exit 1
 
 # Format everything
 fmt:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=main#463b21177a84cb90910fe7cc5d196f3e9ec88db6"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#cdc89dbf6084925ed4c45f93bbeea10438b616ab"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#f03225e446a9b563a984279e0d9cd16f5457641c"
+source = "git+https://github.com/solana-foundation/pay-kit?rev=7a215519414c4d0f6bea30376113640c905a0bc5#7a215519414c4d0f6bea30376113640c905a0bc5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5863,7 +5863,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7179,7 +7179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10657,8 +10657,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=7a215519414c4d0f6bea30376113640c905a0bc5#7a215519414c4d0f6bea30376113640c905a0bc5"
+version = "0.2.0"
+source = "git+https://github.com/solana-foundation/pay-kit?rev=2d23880f7e8026ea636b9a000c4698be8dbb38cb#2d23880f7e8026ea636b9a000c4698be8dbb38cb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15295,7 +15295,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=main#463b21177a84cb90910fe7cc5d196f3e9ec88db6"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=fix%2Fsettlement-worker-skip-preflight#fb6f8fc585a5b508f8b229c92ce0282a3d968b36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=2d23880f7e8026ea636b9a000c4698be8dbb38cb#2d23880f7e8026ea636b9a000c4698be8dbb38cb"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=main#463b21177a84cb90910fe7cc5d196f3e9ec88db6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5863,7 +5863,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7181,7 +7181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=fix%2Fsettlement-worker-skip-preflight#fb6f8fc585a5b508f8b229c92ce0282a3d968b36"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=main#b8b2fd467ec363dd715a0523cf95e679a7169a69"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15297,7 +15297,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#a44c4cae88fdff9091d8493c78f47881b4e948e8"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#f03225e446a9b563a984279e0d9cd16f5457641c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5863,7 +5863,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6481,10 +6481,12 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes 1.12.0",
+ "futures-util",
  "http 1.4.2",
  "pay-core",
  "pay-types",
  "pingora",
+ "reqwest 0.12.28",
  "rustls 0.23.40",
  "solana-pay-kit",
  "tracing",
@@ -7179,7 +7181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10658,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#cdc89dbf6084925ed4c45f93bbeea10438b616ab"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=main#463b21177a84cb90910fe7cc5d196f3e9ec88db6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15295,7 +15297,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3211,12 +3211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,7 +3845,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -3859,11 +3853,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hcl-edit"
@@ -6753,7 +6742,7 @@ dependencies = [
  "serde",
  "serde_yaml 0.8.26",
  "sfv",
- "socket2 0.6.4",
+ "socket2 0.4.10",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tokio",
@@ -6835,8 +6824,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f1c33f6ce9ca9b8e81190796f7d4d543d1ab2a310097d884ebe48ce5d33c4d"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.1",
- "parking_lot 0.12.5",
+ "hashbrown 0.13.2",
+ "parking_lot 0.11.2",
  "rand 0.8.6",
 ]
 
@@ -7190,7 +7179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10669,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#14cff5e7deddb6cfedb705f5ba894b1d3816ebad"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#a44c4cae88fdff9091d8493c78f47881b4e948e8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6296,7 +6296,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pay"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "pay-core"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "pay-integration"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.22.1",
  "pay-core",
@@ -6414,7 +6414,7 @@ dependencies = [
 
 [[package]]
 name = "pay-keystore"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bs58",
  "secret-service",
@@ -6431,7 +6431,7 @@ dependencies = [
 
 [[package]]
 name = "pay-mcp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "pay-pdb"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "pay-proxy"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "pay-types"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -10660,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?branch=main#b8b2fd467ec363dd715a0523cf95e679a7169a69"
+source = "git+https://github.com/solana-foundation/pay-kit?rev=b8b2fd467ec363dd715a0523cf95e679a7169a69#b8b2fd467ec363dd715a0523cf95e679a7169a69"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6509,24 +6509,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "solana-pay-core",
-]
-
-[[package]]
-name = "payment-channels-client"
-version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
-dependencies = [
- "borsh 1.7.0",
- "num-derive",
- "num-traits",
- "solana-account-info 3.1.1",
- "solana-address 2.5.0",
- "solana-client 4.0.0",
- "solana-cpi 3.1.0",
- "solana-instruction 3.2.0",
- "solana-program-error 3.0.1",
- "thiserror 2.0.18",
+ "solana-pay-kit",
 ]
 
 [[package]]
@@ -10207,8 +10190,9 @@ dependencies = [
 
 [[package]]
 name = "solana-keychain"
-version = "1.3.0"
-source = "git+https://github.com/solana-foundation/solana-keychain?rev=d788028edbe02a94ef5eee7585d0230ad771296e#d788028edbe02a94ef5eee7585d0230ad771296e"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6faefd705bf8e950cf15d7ab0690246abfaf3b898b556e8be3482b21ed2f95a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10510,56 +10494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-mpp"
-version = "0.6.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "blake3",
- "borsh 1.7.0",
- "bs58",
- "bytemuck",
- "ed25519-dalek 2.2.0",
- "five8_core 0.1.2",
- "hmac 0.12.1",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "sha2 0.10.9",
- "solana-address 2.5.0",
- "solana-commitment-config",
- "solana-hash 3.1.0",
- "solana-instruction 3.2.0",
- "solana-keychain",
- "solana-keypair",
- "solana-message 3.1.0",
- "solana-pay-core",
- "solana-pubkey 3.0.0",
- "solana-rpc-client 4.0.0",
- "solana-signature",
- "solana-signer",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "solana-transaction-status-client-types 4.0.0",
- "solana-zero-copy",
- "solana-zk-elgamal-proof-interface",
- "solana-zk-sdk 7.0.1",
- "solana-zk-sdk-pod",
- "spl-associated-token-account",
- "spl-record",
- "spl-token-2022",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation 0.6.1",
- "subscriptions-client",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "solana-msg"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10733,52 +10667,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-pay-core"
+name = "solana-pay-kit"
 version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
+source = "git+https://github.com/solana-foundation/pay-kit?branch=feat%2Fblockhash-cache-main#14cff5e7deddb6cfedb705f5ba894b1d3816ebad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
+ "blake3",
  "borsh 1.7.0",
  "bs58",
+ "bytemuck",
  "ed25519-dalek 2.2.0",
  "five8_core 0.1.2",
  "getrandom 0.3.4",
+ "hmac 0.12.1",
+ "num-derive",
+ "num-traits",
  "opentelemetry 0.31.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "payment-channels-client",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
  "sha2 0.10.9",
+ "solana-account-info 3.1.1",
  "solana-address 2.5.0",
+ "solana-client 4.0.0",
+ "solana-commitment-config",
+ "solana-cpi 3.1.0",
  "solana-hash 3.1.0",
  "solana-instruction 3.2.0",
  "solana-keychain",
+ "solana-keypair",
  "solana-message 3.1.0",
+ "solana-program-error 3.0.1",
  "solana-pubkey 3.0.0",
  "solana-rpc-client 4.0.0",
  "solana-signature",
+ "solana-signer",
+ "solana-system-interface 2.0.0",
  "solana-transaction",
+ "solana-transaction-status-client-types 4.0.0",
+ "solana-zero-copy",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk 7.0.1",
+ "solana-zk-sdk-pod",
+ "spl-associated-token-account",
+ "spl-record",
+ "spl-token-2022",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation 0.6.1",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.32.1",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "solana-pay-kit"
-version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
-dependencies = [
- "serde_json",
- "solana-mpp",
- "solana-x402",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -13145,36 +13094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-x402"
-version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bs58",
- "getrandom 0.3.4",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "solana-address 1.1.0",
- "solana-commitment-config",
- "solana-hash 3.1.0",
- "solana-instruction 3.2.0",
- "solana-keychain",
- "solana-message 3.1.0",
- "solana-pay-core",
- "solana-pubkey 3.0.0",
- "solana-rpc-client 4.0.0",
- "solana-signature",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "solana-transaction-status-client-types 4.0.0",
- "thiserror 2.0.18",
- "tokio",
- "url 2.5.8",
-]
-
-[[package]]
 name = "solana-zero-copy"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13863,22 +13782,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "subscriptions-client"
-version = "0.1.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=e3d4d933a1fca84ff9c3a1eb2c1292f1113228be#e3d4d933a1fca84ff9c3a1eb2c1292f1113228be"
-dependencies = [
- "borsh 1.7.0",
- "num-derive",
- "num-traits",
- "solana-account-info 3.1.1",
- "solana-address 2.5.0",
- "solana-cpi 3.1.0",
- "solana-instruction 3.2.0",
- "solana-program-error 3.0.1",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,8 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pull pay-kit from the settlement preflight fix branch. Cargo.lock pins the exact resolved commit.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "fix/settlement-worker-skip-preflight", default-features = false, features = [
+# Pull pay-kit from main. Cargo.lock pins the exact resolved commit.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.20.0"
+version = "0.21.0"
 license = "MIT"
 
 [workspace.dependencies]
@@ -108,8 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pull pay-kit from main. Cargo.lock pins the exact resolved commit.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
+# Pinned to the latest reviewed pay-kit main commit for reproducible CI builds.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "b8b2fd467ec363dd715a0523cf95e679a7169a69", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,13 +111,12 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # Pinned to a rev, NOT `branch = "main"`: a moving branch lets the lock drift
 # (and split the pay-kit packages across two revs, which breaks the build), and
 # is not reproducible across machines/CI. Bump this rev deliberately.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "feat/blockhash-cache-main", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "7a215519414c4d0f6bea30376113640c905a0bc5", default-features = false, features = [
     "mpp",
     "x402",
     "client",
     "server",
     "confidential",
-    "settlement",
     "otel",
     "testkit",
 ] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # Pinned to a rev, NOT `branch = "main"`: a moving branch lets the lock drift
 # (and split the pay-kit packages across two revs, which breaks the build), and
 # is not reproducible across machines/CI. Bump this rev deliberately.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "e3d4d933a1fca84ff9c3a1eb2c1292f1113228be", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "feat/blockhash-cache-main", default-features = false, features = [
     "mpp",
     "x402",
     "client",
@@ -121,11 +121,6 @@ pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundat
     "otel",
     "testkit",
 ] }
-
-# Shared pay-kit base crate — canonical stablecoin mint registry lives here
-# (re-exported by solana-mpp / solana-x402). pay-types reads it directly. Pinned
-# to the SAME rev as pay-kit so all pay-kit packages resolve to one rev.
-solana-pay-core = { git = "https://github.com/solana-foundation/pay-kit", rev = "e3d4d933a1fca84ff9c3a1eb2c1292f1113228be", default-features = false }
 
 # Solana primitives (pinned to versions used by solana-mpp)
 bincode = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # Pinned to a rev, NOT `branch = "main"`: a moving branch lets the lock drift
 # (and split the pay-kit packages across two revs, which breaks the build), and
 # is not reproducible across machines/CI. Bump this rev deliberately.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "7a215519414c4d0f6bea30376113640c905a0bc5", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "2d23880f7e8026ea636b9a000c4698be8dbb38cb", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,8 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pull pay-kit from its main branch. Cargo.lock pins the exact resolved commit.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
+# Pull pay-kit from the active blockhash-cache branch. Cargo.lock pins the exact resolved commit.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "feat/blockhash-cache-main", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,8 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pull pay-kit from the active blockhash-cache branch. Cargo.lock pins the exact resolved commit.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "feat/blockhash-cache-main", default-features = false, features = [
+# Pull pay-kit from main. Cargo.lock pins the exact resolved commit.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,8 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pull pay-kit from main. Cargo.lock pins the exact resolved commit.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
+# Pull pay-kit from the settlement preflight fix branch. Cargo.lock pins the exact resolved commit.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "fix/settlement-worker-skip-preflight", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,10 +108,8 @@ mime_guess = { version = "2.0", default-features = false, features = ["rev-mappi
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-# Pinned to a rev, NOT `branch = "main"`: a moving branch lets the lock drift
-# (and split the pay-kit packages across two revs, which breaks the build), and
-# is not reproducible across machines/CI. Bump this rev deliberately.
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "2d23880f7e8026ea636b9a000c4698be8dbb38cb", default-features = false, features = [
+# Pull pay-kit from its main branch. Cargo.lock pins the exact resolved commit.
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", branch = "main", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -171,6 +171,30 @@ fn x402_upto_payout_for_recipient(
     }
 }
 
+fn x402_currency_configs(
+    currency_configs: &[(String, String, u8)],
+    network: &str,
+) -> Vec<pay_kit::x402::server::CurrencyConfig> {
+    let mut configs: Vec<_> = currency_configs
+        .iter()
+        .map(
+            |(_symbol, mint, decimals)| pay_kit::x402::server::CurrencyConfig {
+                currency: mint.clone(),
+                decimals: *decimals,
+                token_program: None,
+            },
+        )
+        .collect();
+    if configs.is_empty() {
+        configs.push(pay_kit::x402::server::CurrencyConfig {
+            currency: Stablecoin::Usdc.mint(Some(network)).to_string(),
+            decimals: 6,
+            token_program: None,
+        });
+    }
+    configs
+}
+
 fn resolve_session_splits(
     api: &ApiSpec,
     session: &pay_types::metering::SessionSpec,
@@ -1155,29 +1179,11 @@ impl StartCommand {
                 })
             });
             // x402 currency descriptors — one per configured operator currency.
-            // pay-kit resolves each currency's mint + token program from the
-            // SYMBOL (token program is independent of the mint), advertises one
-            // `accepts[]` entry per currency, and on verify binds the
-            // channel/transfer to the client's chosen one. `currencies[0]` is the
-            // primary/default. Shared by the exact + upto backends.
-            let x402_currencies: Vec<pay_kit::x402::server::CurrencyConfig> = {
-                let mut cs: Vec<_> = currency_configs
-                    .iter()
-                    .map(|(symbol, _mint, decimals)| pay_kit::x402::server::CurrencyConfig {
-                        currency: symbol.clone(),
-                        decimals: *decimals,
-                        token_program: None,
-                    })
-                    .collect();
-                if cs.is_empty() {
-                    cs.push(pay_kit::x402::server::CurrencyConfig {
-                        currency: "USDC".to_string(),
-                        decimals: 6,
-                        token_program: None,
-                    });
-                }
-                cs
-            };
+            // `CurrencyConfig.currency` is serialized as x402 `asset`, so it
+            // must be the resolved mint (or native SOL marker), not the display
+            // symbol. Passing "USDC" leaks into client RPC calls as an invalid
+            // pubkey.
+            let x402_currencies = x402_currency_configs(&currency_configs, network.slug());
             let x402 = if wants_x402 {
                 let cfg = pay_kit::x402::server::Config {
                     recipient: recipient.clone(),
@@ -2738,7 +2744,7 @@ fn gateway_charge_challenges(
 mod tests {
     use super::{
         build_pdb_config, resolve_currency, resolve_operator_currencies,
-        should_use_auto_fee_payer_signer, validate_browser_rpc_request,
+        should_use_auto_fee_payer_signer, validate_browser_rpc_request, x402_currency_configs,
         x402_upto_payout_for_recipient,
     };
     use crate::network::SolanaNetwork;
@@ -2789,6 +2795,36 @@ currencies:
             resolve_currency("USDG", "mainnet").0,
             pay_types::stablecoin_mints::USDG_MAINNET
         );
+    }
+
+    #[test]
+    fn x402_currency_configs_use_resolved_mints_not_symbols() {
+        let currency_configs = vec![(
+            "USDC".to_string(),
+            pay_types::stablecoin_mints::USDC_DEVNET.to_string(),
+            6,
+        )];
+
+        let configs = x402_currency_configs(&currency_configs, "devnet");
+
+        assert_eq!(configs.len(), 1);
+        assert_eq!(
+            configs[0].currency,
+            pay_types::stablecoin_mints::USDC_DEVNET
+        );
+        assert_eq!(configs[0].decimals, 6);
+    }
+
+    #[test]
+    fn x402_currency_configs_default_to_network_usdc_mint() {
+        let configs = x402_currency_configs(&[], "devnet");
+
+        assert_eq!(configs.len(), 1);
+        assert_eq!(
+            configs[0].currency,
+            pay_types::stablecoin_mints::USDC_DEVNET
+        );
+        assert_eq!(configs[0].decimals, 6);
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -327,6 +327,7 @@ struct StableTokenAccountRequirement {
 struct SurfpoolFundingTarget {
     label: &'static str,
     address: String,
+    requires_sol: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -344,12 +345,14 @@ fn surfpool_funding_targets(
         targets.push(SurfpoolFundingTarget {
             label: "operator signer",
             address: operator_pubkey.to_string(),
+            requires_sol: true,
         });
     }
     if !targets.iter().any(|target| target.address == recipient) {
         targets.push(SurfpoolFundingTarget {
             label: "payment recipient",
             address: recipient.to_string(),
+            requires_sol: false,
         });
     }
     targets
@@ -408,13 +411,25 @@ async fn validate_funding_target_balances(
     for target in targets {
         let lamports = fetch_lamports(&client, rpc_url, &target.address).await?;
         if lamports == 0 {
-            return Err(pay_core::Error::Config(format!(
-                "{} wallet has 0 SOL\n{}\non `{network}` via {rpc_url}\n\n\
-                 Startup aborted because payment configuration is not usable \
-                 until this wallet exists on chain. Fund this address and \
-                 restart the server.",
-                target.label, target.address
-            )));
+            if target.requires_sol {
+                return Err(pay_core::Error::Config(format!(
+                    "{} wallet has 0 SOL\n{}\non `{network}` via {rpc_url}\n\n\
+                     Startup aborted because payment configuration is not usable \
+                     until this wallet exists on chain. Fund this address and \
+                     restart the server.",
+                    target.label, target.address
+                )));
+            }
+            crate::components::print_notice(
+                crate::components::NoticeLevel::Warning,
+                "Payment recipient has 0 SOL",
+                &format!(
+                    "{}\non `{network}` via {rpc_url}\n\n\
+                     Startup will continue because recipients do not sign or pay \
+                     rent for stable token account creation.",
+                    target.address
+                ),
+            );
         }
         balances.push(FundingTargetBalance {
             address: target.address.clone(),
@@ -3246,8 +3261,10 @@ currencies:
         assert_eq!(targets.len(), 2);
         assert_eq!(targets[0].label, "operator signer");
         assert_eq!(targets[0].address, operator);
+        assert!(targets[0].requires_sol);
         assert_eq!(targets[1].label, "payment recipient");
         assert_eq!(targets[1].address, recipient);
+        assert!(!targets[1].requires_sol);
     }
 
     #[test]
@@ -3258,6 +3275,7 @@ currencies:
         assert_eq!(targets.len(), 1);
         assert_eq!(targets[0].label, "operator signer");
         assert_eq!(targets[0].address, VALID_TEST_KEYPAIR_PUBKEY);
+        assert!(targets[0].requires_sol);
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -293,6 +293,28 @@ impl StartCommand {
         // silently regressing to charge-only.
         api.apply_scheme_defaults();
 
+        // Validate the resolved spec once at boot — after `apply_scheme_defaults`
+        // — so configuration errors (unknown or duplicate split recipients,
+        // splits exceeding the price, malformed tiers, …) abort startup instead
+        // of surfacing as a runtime `challenge_generation_failed` 500 (charge) or
+        // an on-chain channel `open` rejection (session) on the first paid
+        // request. Aborting via `Error::Config` reuses the single notice the CLI
+        // already renders for every config check (`main::print_command_error`),
+        // consolidating these checks behind one boot-time gate.
+        let spec_issues = pay_types::metering::validate_api_spec(&api);
+        if !spec_issues.is_empty() {
+            let detail = spec_issues
+                .iter()
+                .map(|issue| format!("  • {issue}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Err(pay_core::Error::Config(format!(
+                "{} configuration error(s) in spec `{}`:\n{detail}",
+                spec_issues.len(),
+                self.spec,
+            )));
+        }
+
         // Optional OpenAPI / Discovery doc — loaded once, filtered to the
         // YAML's `endpoints[]` allow-list, and exposed at `GET /openapi.json`
         // with `rootUrl` / `servers[].url` rewritten per-request from the

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -1140,40 +1140,39 @@ impl StartCommand {
                     })
                 })
             });
-            // Primary currency = the operator's first configured currency,
-            // resolved (symbol → MINT + decimals) exactly like the MPP path
-            // (`currency_configs`). The x402 settle path feeds `currency`
-            // straight into RPC calls, so it must be the mint, not "USDC".
-            // Shared by the `exact` and `upto` backends.
-            let (x402_mint, x402_decimals) = currency_configs
-                .first()
-                .map(|(_, mint, decimals)| (mint.clone(), *decimals))
-                .unwrap_or_else(|| {
-                    (
-                        pay_types::Stablecoin::Usdc
-                            .mint(Some(network.slug()))
-                            .to_string(),
-                        6,
-                    )
-                });
+            // x402 currency descriptors — one per configured operator currency.
+            // pay-kit resolves each currency's mint + token program from the
+            // SYMBOL (token program is independent of the mint), advertises one
+            // `accepts[]` entry per currency, and on verify binds the
+            // channel/transfer to the client's chosen one. `currencies[0]` is the
+            // primary/default. Shared by the exact + upto backends.
+            let x402_currencies: Vec<pay_kit::x402::server::CurrencyConfig> = {
+                let mut cs: Vec<_> = currency_configs
+                    .iter()
+                    .map(|(symbol, _mint, decimals)| pay_kit::x402::server::CurrencyConfig {
+                        currency: symbol.clone(),
+                        decimals: *decimals,
+                        token_program: None,
+                    })
+                    .collect();
+                if cs.is_empty() {
+                    cs.push(pay_kit::x402::server::CurrencyConfig {
+                        currency: "USDC".to_string(),
+                        decimals: 6,
+                        token_program: None,
+                    });
+                }
+                cs
+            };
             let x402 = if wants_x402 {
-                // Advertise every configured currency when more than one.
-                let accepted_currencies = if currencies.len() > 1 {
-                    Some(currencies.clone())
-                } else {
-                    None
-                };
                 let cfg = pay_kit::x402::server::Config {
                     recipient: recipient.clone(),
-                    currency: x402_mint.clone(),
-                    decimals: x402_decimals,
+                    currencies: x402_currencies.clone(),
                     network: network.slug().to_string(),
                     rpc_url: Some(rpc_url.clone()),
                     resource: api.subdomain.clone(),
                     description: None,
                     max_age: Some(300),
-                    token_program: None,
-                    accepted_currencies,
                     // The operator co-signs fees only when configured to.
                     fee_payer_key: if fee_payer {
                         fee_payer_signer.as_ref().map(|s| s.pubkey().to_string())
@@ -1199,14 +1198,12 @@ impl StartCommand {
                 (true, Some(signer)) => {
                     let cfg = pay_kit::x402::server::UptoConfig {
                         recipient: recipient.clone(),
-                        currency: x402_mint.clone(),
-                        decimals: x402_decimals,
+                        currencies: x402_currencies.clone(),
                         cluster: network.slug().to_string(),
                         rpc_url: Some(rpc_url.clone()),
                         resource: api.subdomain.clone(),
                         description: None,
                         max_timeout_seconds: 300,
-                        token_program: None,
                         program_id: None,
                         operator_signer: signer,
                     };

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -657,6 +657,39 @@ impl StartCommand {
                     (currency.clone(), mpp_currency, decimals)
                 })
                 .collect();
+            // Shared recent-blockhash cache, refreshed by a background thread.
+            // Issuing a 402 embeds a `recentBlockhash` per advertised currency
+            // and scheme; fetching it inline turned one 402 into N blocking RPC
+            // round-trips (the dominant challenge latency). The handlers read
+            // this cache and only fall back to a direct fetch when it's empty or
+            // stale, so it's purely a latency optimization — the wire payload is
+            // unchanged.
+            let blockhash_cache = pay_kit::mpp::blockhash::BlockhashCache::new();
+            {
+                use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
+                let cache = blockhash_cache.clone();
+                let worker_rpc_url = rpc_url.clone();
+                let refresh = move || {
+                    let rpc = RpcClient::new(worker_rpc_url.clone());
+                    match rpc.get_latest_blockhash_with_commitment(rpc.commitment()) {
+                        Ok((blockhash, last_valid_block_height)) => {
+                            cache.set(blockhash.to_string(), last_valid_block_height);
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "blockhash cache refresh failed");
+                        }
+                    }
+                };
+                // Prime once so the first 402 is already fast, then refresh on a
+                // 10s interval — far inside the ~60-90s blockhash validity window
+                // and the cache's 45s staleness cap.
+                refresh();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_secs(10));
+                    refresh();
+                });
+            }
+
             let mpps: Vec<Mpp> = currency_configs
                 .iter()
                 .map(|(_, mpp_currency, decimals)| {
@@ -672,6 +705,7 @@ impl StartCommand {
                         html: true,
                         ..Default::default()
                     })
+                    .map(|m| m.with_blockhash_cache(blockhash_cache.clone()))
                 })
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| pay_core::Error::Config(format!("Failed to create MPP server: {e}")))?;
@@ -1148,7 +1182,7 @@ impl StartCommand {
                     },
                 };
                 match pay_kit::x402::server::X402::new(cfg) {
-                    Ok(x) => Some(x),
+                    Ok(x) => Some(x.with_blockhash_cache(blockhash_cache.clone())),
                     Err(e) => {
                         eprintln!("x402 backend disabled ({e}); x402 schemes won't be offered");
                         None
@@ -1177,7 +1211,7 @@ impl StartCommand {
                         operator_signer: signer,
                     };
                     match pay_kit::x402::server::X402Upto::new(cfg) {
-                        Ok(u) => Some(u),
+                        Ok(u) => Some(u.with_blockhash_cache(blockhash_cache.clone())),
                         Err(e) => {
                             eprintln!("x402 upto backend disabled ({e})");
                             None

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -366,12 +366,18 @@ fn surfpool_prep_notice_body(
     auto_fund: bool,
 ) -> String {
     let mut lines = vec![format!("rpc: {rpc_url}")];
-    let wallet_action = if auto_fund { "funding" } else { "checking" };
     for target in targets {
-        lines.push(format!(
-            "{wallet_action} {}: {}",
-            target.label, target.address
-        ));
+        let wallet_action = if auto_fund && target.requires_sol {
+            "funding"
+        } else {
+            "checking"
+        };
+        let label = if target.requires_sol {
+            target.label.to_string()
+        } else {
+            format!("{} (SOL optional)", target.label)
+        };
+        lines.push(format!("{wallet_action} {}: {}", label, target.address));
     }
     if !payout_recipients.is_empty() && !stable_requirements.is_empty() {
         let ata_action = if auto_fund {
@@ -1068,6 +1074,7 @@ impl StartCommand {
             let operator_pubkey = fee_payer_signer
                 .as_ref()
                 .map(|signer| signer.pubkey().to_string());
+            let operator_balance_address = operator_pubkey.as_deref().unwrap_or(&recipient);
             let x402_upto_beneficiary =
                 x402_upto_beneficiary_pubkey(&api, &recipient, operator_pubkey.as_deref())?;
             let payout_recipient_targets =
@@ -1108,7 +1115,7 @@ impl StartCommand {
                         true,
                     ),
                 );
-                for target in &surfpool_targets {
+                for target in surfpool_targets.iter().filter(|target| target.requires_sol) {
                     if let Err(e) =
                         pay_core::client::sandbox::fund_via_surfpool(&rpc_url, &target.address)
                             .await
@@ -1148,11 +1155,11 @@ impl StartCommand {
                 validate_funding_target_balances(&rpc_url, &network, &surfpool_targets).await?;
             let operator_sol = funding_balances
                 .iter()
-                .find(|balance| balance.address == recipient)
+                .find(|balance| balance.address == operator_balance_address)
                 .map(|balance| lamports_to_sol(balance.lamports))
                 .ok_or_else(|| {
                     pay_core::Error::Config(
-                        "internal error: payment recipient was not validated".to_string(),
+                        "internal error: operator signer was not validated".to_string(),
                     )
                 })?;
 
@@ -1430,18 +1437,23 @@ impl StartCommand {
             let network_link = crate::components::link::link_with_arrow(network_label, &network_url);
 
             // Operator link (explorer token page).
-            let short_recipient = if recipient.len() > 8 {
-                format!("{}...{}", &recipient[..4], &recipient[recipient.len() - 4..])
+            let operator_display = operator_balance_address;
+            let short_operator = if operator_display.len() > 8 {
+                format!(
+                    "{}...{}",
+                    &operator_display[..4],
+                    &operator_display[operator_display.len() - 4..]
+                )
             } else {
-                recipient.clone()
+                operator_display.to_string()
             };
             let explorer_cluster = network.explorer_cluster(&rpc_url);
             let cluster_query = solana_explorer_cluster_query(&explorer_cluster);
             let operator_url = format!(
                 "https://explorer.solana.com/address/{}/tokens{}",
-                recipient, cluster_query
+                operator_display, cluster_query
             );
-            let operator_link = crate::components::link::link_with_arrow(&short_recipient, &operator_url);
+            let operator_link = crate::components::link::link_with_arrow(&short_operator, &operator_url);
 
             // Pad labels to a fixed visible width — tabs land on
             // terminal-dependent stops, so a 7-char label followed by
@@ -3322,7 +3334,7 @@ currencies:
         );
 
         assert!(body.contains("rpc: https://402.surfnet.dev:8899"));
-        assert!(body.contains("funding payment recipient"));
+        assert!(body.contains("checking payment recipient (SOL optional)"));
         assert!(body.contains(
             "creating missing ATAs for all configured stable tokens (USDC, PYUSD) across 2 payout recipient(s)"
         ));

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -316,6 +316,372 @@ async fn ensure_surfpool_session_distribution_accounts(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct StableTokenAccountRequirement {
+    label: String,
+    mint: String,
+    token_program: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SurfpoolFundingTarget {
+    label: &'static str,
+    address: String,
+}
+
+fn surfpool_funding_targets(
+    recipient: &str,
+    operator_pubkey: Option<&str>,
+) -> Vec<SurfpoolFundingTarget> {
+    let mut targets = Vec::new();
+    if let Some(operator_pubkey) = operator_pubkey {
+        targets.push(SurfpoolFundingTarget {
+            label: "operator signer",
+            address: operator_pubkey.to_string(),
+        });
+    }
+    if !targets.iter().any(|target| target.address == recipient) {
+        targets.push(SurfpoolFundingTarget {
+            label: "payment recipient",
+            address: recipient.to_string(),
+        });
+    }
+    targets
+}
+
+fn surfpool_prep_notice_body(
+    rpc_url: &str,
+    targets: &[SurfpoolFundingTarget],
+    payout_recipient_count: usize,
+    stable_requirements: &[StableTokenAccountRequirement],
+    auto_fund: bool,
+) -> String {
+    let mut lines = vec![format!("rpc: {rpc_url}")];
+    let wallet_action = if auto_fund { "funding" } else { "checking" };
+    for target in targets {
+        lines.push(format!(
+            "{wallet_action} {}: {}",
+            target.label, target.address
+        ));
+    }
+    if payout_recipient_count > 0 && !stable_requirements.is_empty() {
+        let ata_action = if auto_fund {
+            "creating missing"
+        } else {
+            "checking"
+        };
+        let tokens = stable_requirements
+            .iter()
+            .map(|requirement| requirement.label.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!(
+            "{ata_action} ATAs for all configured stable tokens ({tokens}) across {payout_recipient_count} payout recipient(s)"
+        ));
+    }
+    lines.join("\n")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FundingTargetBalance {
+    address: String,
+    lamports: u64,
+}
+
+async fn validate_funding_target_balances(
+    rpc_url: &str,
+    network: &SolanaNetwork,
+    targets: &[SurfpoolFundingTarget],
+) -> pay_core::Result<Vec<FundingTargetBalance>> {
+    let client = reqwest::Client::new();
+    let mut balances = Vec::with_capacity(targets.len());
+    for target in targets {
+        let lamports = fetch_lamports(&client, rpc_url, &target.address).await?;
+        if lamports == 0 {
+            return Err(pay_core::Error::Config(format!(
+                "{} wallet has 0 SOL\n{}\non `{network}` via {rpc_url}\n\n\
+                 Startup aborted because payment configuration is not usable \
+                 until this wallet exists on chain. Fund this address and \
+                 restart the server.",
+                target.label, target.address
+            )));
+        }
+        balances.push(FundingTargetBalance {
+            address: target.address.clone(),
+            lamports,
+        });
+    }
+    Ok(balances)
+}
+
+fn lamports_to_sol(lamports: u64) -> f64 {
+    lamports as f64 / 1_000_000_000.0
+}
+
+async fn ensure_payout_recipient_token_accounts(
+    recipients: &[solana_pubkey::Pubkey],
+    stable_requirements: &[StableTokenAccountRequirement],
+    network: &str,
+    rpc_url: &str,
+    allow_startup_creation: bool,
+    fee_payer_signer: Option<Arc<dyn SolanaSigner>>,
+) -> pay_core::Result<()> {
+    if recipients.is_empty() || stable_requirements.is_empty() {
+        return Ok(());
+    }
+
+    let signer = if allow_startup_creation {
+        Some(fee_payer_signer.ok_or_else(|| {
+            pay_core::Error::Config(
+                "stable payout recipient ATA setup requires an operator signer".to_string(),
+            )
+        })?)
+    } else {
+        None
+    };
+    let payer = signer.as_ref().map(|signer| signer.pubkey());
+    let rpc = pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient::new(rpc_url.to_string());
+    for recipient in recipients {
+        for requirement in stable_requirements {
+            let mint = solana_pubkey::Pubkey::from_str(&requirement.mint).map_err(|e| {
+                pay_core::Error::Config(format!(
+                    "stable mint `{}` is not a valid Solana pubkey: {e}",
+                    requirement.mint
+                ))
+            })?;
+            let token_program = solana_pubkey::Pubkey::from_str(&requirement.token_program)
+                .map_err(|e| {
+                    pay_core::Error::Config(format!(
+                        "token program `{}` is not a valid Solana pubkey: {e}",
+                        requirement.token_program
+                    ))
+                })?;
+            let (ata, _) = pay_kit::mpp::program::payment_channels::find_associated_token_address(
+                recipient,
+                &mint,
+                &token_program,
+            );
+            if rpc.get_account(&ata).is_ok() {
+                continue;
+            }
+
+            if !allow_startup_creation {
+                // TODO(mainnet): add an operator-funded creation command for
+                // production clusters. Startup still aborts so no traffic is
+                // served before payment config is fully usable.
+                return Err(pay_core::Error::Config(format!(
+                    "Missing stable token account for payout recipient\n\
+                     recipient: {recipient}\n\
+                     mint: {}\n\
+                     ata: {ata}\n\
+                     network: {network}\n\
+                     rpc: {rpc_url}\n\n\
+                     Create this associated token account, or use the Surfpool \
+                     localnet sandbox where pay can create it automatically.",
+                    requirement.mint
+                )));
+            }
+
+            let signer = signer
+                .as_ref()
+                .expect("signer is present when startup creation is enabled");
+            let payer = payer.expect("payer is present when startup creation is enabled");
+            let ix = create_associated_token_account_idempotent_ix(
+                &payer,
+                recipient,
+                &mint,
+                &token_program,
+            );
+            sign_and_broadcast_gateway(signer.clone(), vec![ix], rpc_url).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn create_associated_token_account_idempotent_ix(
+    payer: &solana_pubkey::Pubkey,
+    owner: &solana_pubkey::Pubkey,
+    mint: &solana_pubkey::Pubkey,
+    token_program: &solana_pubkey::Pubkey,
+) -> solana_instruction::Instruction {
+    pay_kit::mpp::program::payment_channels::build_create_associated_token_account_instruction(
+        payer,
+        owner,
+        mint,
+        token_program,
+    )
+}
+
+async fn sign_and_broadcast_gateway(
+    signer: Arc<dyn SolanaSigner>,
+    instructions: Vec<solana_instruction::Instruction>,
+    rpc_url: &str,
+) -> pay_core::Result<String> {
+    use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
+    use solana_message::Message;
+    use solana_signature::Signature;
+    use solana_transaction::Transaction;
+
+    let url = rpc_url.to_string();
+    let signer_pubkey = signer.pubkey();
+    let blockhash = tokio::task::spawn_blocking({
+        let url = url.clone();
+        move || {
+            let rpc = RpcClient::new(url);
+            rpc.get_latest_blockhash()
+                .map_err(|e| pay_core::Error::Mpp(format!("Failed to fetch blockhash: {e}")))
+        }
+    })
+    .await
+    .map_err(|e| pay_core::Error::Mpp(format!("RPC task join: {e}")))??;
+
+    let message = Message::new_with_blockhash(&instructions, Some(&signer_pubkey), &blockhash);
+    let mut tx = Transaction::new_unsigned(message);
+    let msg_bytes = tx.message_data();
+    let sig_bytes = signer
+        .sign_message(&msg_bytes)
+        .await
+        .map_err(|e| pay_core::Error::Mpp(format!("Operator signing failed: {e}")))?;
+    let signature = Signature::from(<[u8; 64]>::from(sig_bytes));
+
+    let signer_index = tx
+        .message
+        .account_keys
+        .iter()
+        .position(|key| *key == signer_pubkey)
+        .ok_or_else(|| pay_core::Error::Mpp("Operator pubkey absent from account_keys".into()))?;
+    if tx.signatures.len() <= signer_index {
+        return Err(pay_core::Error::Mpp(
+            "Transaction signatures vec is shorter than account_keys".into(),
+        ));
+    }
+    tx.signatures[signer_index] = signature;
+
+    let serialized = bincode::serialize(&tx)
+        .map_err(|e| pay_core::Error::Mpp(format!("Failed to serialise tx: {e}")))?;
+    let confirmed_sig = tokio::task::spawn_blocking(move || {
+        let rpc = RpcClient::new(url);
+        let tx: Transaction = bincode::deserialize(&serialized)
+            .map_err(|e| pay_core::Error::Mpp(format!("tx round-trip: {e}")))?;
+        rpc.send_and_confirm_transaction(&tx)
+            .map_err(|e| pay_core::Error::Mpp(format!("Broadcast failed: {e}")))
+    })
+    .await
+    .map_err(|e| pay_core::Error::Mpp(format!("RPC task join: {e}")))??;
+
+    Ok(confirmed_sig.to_string())
+}
+
+fn stable_token_account_requirements(
+    currency_configs: &[(String, String, u8)],
+    network: &str,
+) -> pay_core::Result<Vec<StableTokenAccountRequirement>> {
+    let mut requirements = Vec::new();
+    for (label, mint, _decimals) in currency_configs {
+        if Stablecoin::parse_symbol(label).is_none() && Stablecoin::from_mint(mint).is_none() {
+            continue;
+        }
+
+        solana_pubkey::Pubkey::from_str(mint).map_err(|e| {
+            pay_core::Error::Config(format!(
+                "stable currency `{label}` resolved to invalid mint `{mint}`: {e}"
+            ))
+        })?;
+        let token_program = pay_kit::mpp::protocol::solana::default_token_program_for_currency(
+            label,
+            Some(network),
+        )
+        .to_string();
+        let requirement = StableTokenAccountRequirement {
+            label: label.clone(),
+            mint: mint.clone(),
+            token_program,
+        };
+        if !requirements.contains(&requirement) {
+            requirements.push(requirement);
+        }
+    }
+    Ok(requirements)
+}
+
+fn payout_recipient_pubkeys(
+    api: &ApiSpec,
+    x402_upto_beneficiary: Option<solana_pubkey::Pubkey>,
+) -> pay_core::Result<Vec<solana_pubkey::Pubkey>> {
+    let mut recipients = charge_split_recipient_pubkeys(api)?;
+    if let Some(beneficiary) = x402_upto_beneficiary {
+        recipients.push(beneficiary);
+    }
+    recipients.sort();
+    recipients.dedup();
+    Ok(recipients)
+}
+
+fn charge_split_recipient_pubkeys(api: &ApiSpec) -> pay_core::Result<Vec<solana_pubkey::Pubkey>> {
+    let mut recipients = std::collections::BTreeSet::new();
+    for ep in &api.endpoints {
+        let Some(meter) = ep.metering.as_ref() else {
+            continue;
+        };
+        if !meter
+            .accepted_schemes()
+            .contains(&pay_types::metering::Scheme::MppCharge)
+        {
+            continue;
+        }
+
+        for rule in pay_core::server::metering::resolve_split_rules(meter) {
+            let Some(alias) = api.recipients.get(&rule.recipient) else {
+                return Err(pay_core::Error::Config(format!(
+                    "{}: split recipient '{}' not declared",
+                    ep.path, rule.recipient
+                )));
+            };
+            let account = resolve_static_account(&alias.account)?;
+            let recipient = solana_pubkey::Pubkey::from_str(&account).map_err(|e| {
+                pay_core::Error::Config(format!(
+                    "{}: split recipient '{}' account is not a valid Solana pubkey: {e}",
+                    ep.path, rule.recipient
+                ))
+            })?;
+            recipients.insert(recipient);
+        }
+    }
+    Ok(recipients.into_iter().collect())
+}
+
+fn api_accepts_x402_upto(api: &ApiSpec) -> bool {
+    api.endpoints.iter().any(|ep| {
+        ep.metering.as_ref().is_some_and(|meter| {
+            meter
+                .accepted_schemes()
+                .contains(&pay_types::metering::Scheme::X402Upto)
+        })
+    })
+}
+
+fn x402_upto_beneficiary_pubkey(
+    api: &ApiSpec,
+    recipient: &str,
+    operator: Option<&str>,
+) -> pay_core::Result<Option<solana_pubkey::Pubkey>> {
+    let Some(operator) = operator else {
+        return Ok(None);
+    };
+    if !api_accepts_x402_upto(api) || recipient == operator {
+        return Ok(None);
+    }
+
+    solana_pubkey::Pubkey::from_str(recipient)
+        .map(Some)
+        .map_err(|e| {
+            pay_core::Error::Config(format!(
+                "x402 upto recipient `{recipient}` is not a valid Solana pubkey: {e}"
+            ))
+        })
+}
+
 impl StartCommand {
     pub fn run(self, active_account_name: Option<&str>, sandbox: bool) -> pay_core::Result<()> {
         let debugger = self.debugger || sandbox;
@@ -641,7 +1007,23 @@ impl StartCommand {
                 }
             };
 
-            // ── Auto-fund the operator wallet on Surfpool ──
+            let currency_configs: Vec<_> = currencies
+                .iter()
+                .map(|currency| {
+                    let (mpp_currency, decimals) = resolve_currency(currency, network.slug());
+                    (currency.clone(), mpp_currency, decimals)
+                })
+                .collect();
+            let operator_pubkey = fee_payer_signer
+                .as_ref()
+                .map(|signer| signer.pubkey().to_string());
+            let x402_upto_beneficiary =
+                x402_upto_beneficiary_pubkey(&api, &recipient, operator_pubkey.as_deref())?;
+            let payout_recipients = payout_recipient_pubkeys(&api, x402_upto_beneficiary)?;
+            let stable_requirements =
+                stable_token_account_requirements(&currency_configs, network.slug())?;
+
+            // ── Auto-fund local Surfpool wallets ──
             //
             // Trigger when EITHER:
             //   - the user passed `--sandbox` (explicit opt-in), or
@@ -659,18 +1041,67 @@ impl StartCommand {
             let looks_like_surfpool =
                 rpc_url.contains("surfnet") || rpc_url.contains("surfpool");
             let should_fund = sandbox || looks_like_surfpool;
-            if should_fund && let Some(ref signer) = fee_payer_signer {
-                let pubkey = signer.pubkey().to_string();
-                if let Err(e) =
-                    pay_core::client::sandbox::fund_via_surfpool(&rpc_url, &pubkey).await
-                {
-                    eprintln!(
-                        "  {} {}",
-                        "Sandbox funding failed:".red(),
-                        e.to_string().dimmed()
-                    );
+            let surfpool_targets =
+                surfpool_funding_targets(&recipient, operator_pubkey.as_deref());
+            if should_fund {
+                crate::components::print_notice(
+                    crate::components::NoticeLevel::Info,
+                    "Preparing sandbox wallets",
+                    &surfpool_prep_notice_body(
+                        &rpc_url,
+                        &surfpool_targets,
+                        payout_recipients.len(),
+                        &stable_requirements,
+                        true,
+                    ),
+                );
+                for target in &surfpool_targets {
+                    if let Err(e) =
+                        pay_core::client::sandbox::fund_via_surfpool(&rpc_url, &target.address)
+                            .await
+                    {
+                        if looks_like_surfpool {
+                            return Err(pay_core::Error::Config(format!(
+                                "Sandbox funding failed\n{} {}\n{}\n\n\
+                                 Startup aborted before accepting traffic.",
+                                target.label, target.address, e
+                            )));
+                        }
+                        crate::components::print_notice(
+                            crate::components::NoticeLevel::Warning,
+                            "Sandbox funding unavailable",
+                            &format!(
+                                "{} {}\n{}\n\nValidating existing balances instead.",
+                                target.label, target.address, e
+                            ),
+                        );
+                    }
                 }
+            } else {
+                crate::components::print_notice(
+                    crate::components::NoticeLevel::Info,
+                    "Validating payment configuration",
+                    &surfpool_prep_notice_body(
+                        &rpc_url,
+                        &surfpool_targets,
+                        payout_recipients.len(),
+                        &stable_requirements,
+                        false,
+                    ),
+                );
             }
+
+            let funding_balances =
+                validate_funding_target_balances(&rpc_url, &network, &surfpool_targets).await?;
+            let operator_sol = funding_balances
+                .iter()
+                .find(|balance| balance.address == recipient)
+                .map(|balance| lamports_to_sol(balance.lamports))
+                .ok_or_else(|| {
+                    pay_core::Error::Config(
+                        "internal error: payment recipient was not validated".to_string(),
+                    )
+                })?;
 
             // ── Create MPP servers ──
             let challenge_binding_secret = std::env::var("PAY_MPP_CHALLENGE_SECRET")
@@ -688,13 +1119,15 @@ impl StartCommand {
                 std::env::set_var("MPP_CHALLENGE_BINDING_SECRET", &challenge_binding_secret);
             }
 
-            let currency_configs: Vec<_> = currencies
-                .iter()
-                .map(|currency| {
-                    let (mpp_currency, decimals) = resolve_currency(currency, network.slug());
-                    (currency.clone(), mpp_currency, decimals)
-                })
-                .collect();
+            ensure_payout_recipient_token_accounts(
+                &payout_recipients,
+                &stable_requirements,
+                network.slug(),
+                &rpc_url,
+                should_fund,
+                fee_payer_signer.clone(),
+            )
+            .await?;
             // Shared recent-blockhash cache, refreshed by a background thread.
             // Issuing a 402 embeds a `recentBlockhash` per advertised currency
             // and scheme; fetching it inline turned one 402 into N blocking RPC
@@ -968,18 +1401,10 @@ impl StartCommand {
                 currencies.join(", ").green()
             );
 
-            // Fetch the operator wallet's SOL balance for the banner.
-            // We do this in BOTH sandbox and mainnet modes — in sandbox
-            // it confirms the auto-fund worked; on mainnet it's a quick
-            // sanity check that the wallet actually exists on chain so
-            // the user doesn't waste time hitting the gateway with a
-            // wallet that has zero SOL.
-            //
             // Color thresholds (covers all networks):
             //   ≥ 0.10 SOL  → green   (comfortable runway)
             //   ≥ 0.05 SOL  → yellow  (top up soon)
             //    < 0.05 SOL → red     (next tx may fail)
-            let operator_sol = fetch_sol_balance(&rpc_url, &recipient).await;
             let balance_text = format!(" ({} SOL)", format_price(operator_sol));
             let balance_colored = if operator_sol >= 0.10 {
                 balance_text.green().to_string()
@@ -995,26 +1420,6 @@ impl StartCommand {
                 balance_colored
             );
             eprintln!();
-
-            // Loud warning when the wallet is empty. The most common
-            // first-run failure mode on mainnet is "Attempt to debit an
-            // account but found no record of a prior credit" — a Solana
-            // runtime error that means the wallet has zero SOL on the
-            // configured cluster. Tell the user upfront instead of
-            // letting every payment fail at simulation time.
-            if operator_sol == 0.0 {
-                crate::components::print_notice(
-                    crate::components::NoticeLevel::Warning,
-                    "Operator wallet has 0 SOL",
-                    &format!(
-                        "{recipient}\non `{network}` via {rpc_url}\n\n\
-                         Even with operator.fee_payer = true, the wallet must \
-                         exist on chain (any prior credit) for SPL token \
-                         transfers to derive an ATA. Send a small amount of \
-                         SOL to the address above and restart the server."
-                    ),
-                );
-            }
 
             let fee_payer_wallet = if fee_payer {
                 fee_payer_signer.as_ref().map(|signer| {
@@ -2262,9 +2667,12 @@ async fn resolve_signer_with_store(
     }
 }
 
-/// Fetch a wallet's lamport balance via JSON-RPC. Returns 0 on any error
-/// — used by the banner only, where a missing balance is harmless.
-async fn fetch_lamports(client: &reqwest::Client, rpc_url: &str, pubkey: &str) -> u64 {
+/// Fetch a wallet's lamport balance via JSON-RPC.
+async fn fetch_lamports(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    pubkey: &str,
+) -> pay_core::Result<u64> {
     let resp = client
         .post(rpc_url)
         .json(&serde_json::json!({
@@ -2274,21 +2682,33 @@ async fn fetch_lamports(client: &reqwest::Client, rpc_url: &str, pubkey: &str) -
             "params": [pubkey]
         }))
         .send()
-        .await;
-    match resp {
-        Ok(r) => r
-            .json::<serde_json::Value>()
-            .await
-            .ok()
-            .and_then(|v| v["result"]["value"].as_u64())
-            .unwrap_or(0),
-        Err(_) => 0,
+        .await
+        .map_err(|e| {
+            pay_core::Error::Config(format!(
+                "Failed to fetch SOL balance for `{pubkey}` via {rpc_url}: {e}"
+            ))
+        })?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(pay_core::Error::Config(format!(
+            "Failed to fetch SOL balance for `{pubkey}` via {rpc_url}: HTTP {status}"
+        )));
     }
-}
-
-async fn fetch_sol_balance(rpc_url: &str, pubkey: &str) -> f64 {
-    let client = reqwest::Client::new();
-    fetch_lamports(&client, rpc_url, pubkey).await as f64 / 1_000_000_000.0
+    let value = resp.json::<serde_json::Value>().await.map_err(|e| {
+        pay_core::Error::Config(format!(
+            "Invalid getBalance response for `{pubkey}` via {rpc_url}: {e}"
+        ))
+    })?;
+    if let Some(err) = value.get("error") {
+        return Err(pay_core::Error::Config(format!(
+            "getBalance failed for `{pubkey}` via {rpc_url}: {err}"
+        )));
+    }
+    value["result"]["value"].as_u64().ok_or_else(|| {
+        pay_core::Error::Config(format!(
+            "getBalance response for `{pubkey}` via {rpc_url} did not include result.value"
+        ))
+    })
 }
 
 /// Build a concrete, clickable example path for an endpoint whose `path`
@@ -2743,11 +3163,15 @@ fn gateway_charge_challenges(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pdb_config, resolve_currency, resolve_operator_currencies,
-        should_use_auto_fee_payer_signer, validate_browser_rpc_request, x402_currency_configs,
+        build_pdb_config, create_associated_token_account_idempotent_ix, payout_recipient_pubkeys,
+        resolve_currency, resolve_operator_currencies, should_use_auto_fee_payer_signer,
+        stable_token_account_requirements, surfpool_funding_targets, surfpool_prep_notice_body,
+        validate_browser_rpc_request, x402_currency_configs, x402_upto_beneficiary_pubkey,
         x402_upto_payout_for_recipient,
     };
     use crate::network::SolanaNetwork;
+    use solana_pubkey::Pubkey;
+    use std::str::FromStr;
 
     #[test]
     fn resolve_operator_currencies_prefers_usd_group() {
@@ -2771,6 +3195,262 @@ currencies:
             serde_yml::from_str(r#"network: "devnet""#).unwrap();
 
         assert_eq!(resolve_operator_currencies(Some(&op), "USDC"), ["USDC"]);
+    }
+
+    #[test]
+    fn surfpool_funding_targets_include_distinct_operator_and_recipient() {
+        let operator = VALID_TEST_KEYPAIR_PUBKEY;
+        let recipient = "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY";
+
+        let targets = surfpool_funding_targets(recipient, Some(operator));
+
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].label, "operator signer");
+        assert_eq!(targets[0].address, operator);
+        assert_eq!(targets[1].label, "payment recipient");
+        assert_eq!(targets[1].address, recipient);
+    }
+
+    #[test]
+    fn surfpool_funding_targets_dedupes_operator_recipient() {
+        let targets =
+            surfpool_funding_targets(VALID_TEST_KEYPAIR_PUBKEY, Some(VALID_TEST_KEYPAIR_PUBKEY));
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].label, "operator signer");
+        assert_eq!(targets[0].address, VALID_TEST_KEYPAIR_PUBKEY);
+    }
+
+    #[test]
+    fn surfpool_prep_notice_body_names_wallet_and_ata_work() {
+        let targets =
+            surfpool_funding_targets("CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY", None);
+        let stable_requirements = stable_token_account_requirements(
+            &[
+                (
+                    "USDC".to_string(),
+                    pay_types::Stablecoin::Usdc
+                        .mint(Some("localnet"))
+                        .to_string(),
+                    6,
+                ),
+                (
+                    "PYUSD".to_string(),
+                    pay_types::Stablecoin::Pyusd
+                        .mint(Some("localnet"))
+                        .to_string(),
+                    6,
+                ),
+            ],
+            "localnet",
+        )
+        .unwrap();
+
+        let body = surfpool_prep_notice_body(
+            "https://402.surfnet.dev:8899",
+            &targets,
+            2,
+            &stable_requirements,
+            true,
+        );
+
+        assert!(body.contains("rpc: https://402.surfnet.dev:8899"));
+        assert!(body.contains("funding payment recipient"));
+        assert!(body.contains(
+            "creating missing ATAs for all configured stable tokens (USDC, PYUSD) across 2 payout recipient(s)"
+        ));
+    }
+
+    #[test]
+    fn stable_token_account_requirements_resolve_stable_mints_and_programs() {
+        let configs = vec![
+            resolve_currency("USDC", "localnet"),
+            resolve_currency("PYUSD", "localnet"),
+            resolve_currency("SOL", "localnet"),
+        ]
+        .into_iter()
+        .zip(["USDC", "PYUSD", "SOL"])
+        .map(|((mint, decimals), label)| (label.to_string(), mint, decimals))
+        .collect::<Vec<_>>();
+
+        let requirements = stable_token_account_requirements(&configs, "localnet").unwrap();
+
+        assert_eq!(requirements.len(), 2);
+        assert!(requirements.iter().any(|req| {
+            req.label == "USDC"
+                && req.mint == pay_types::Stablecoin::Usdc.mint(Some("localnet"))
+                && req.token_program == pay_kit::mpp::protocol::solana::programs::TOKEN_PROGRAM
+        }));
+        assert!(requirements.iter().any(|req| {
+            req.label == "PYUSD"
+                && req.mint == pay_types::Stablecoin::Pyusd.mint(Some("localnet"))
+                && req.token_program == pay_kit::mpp::protocol::solana::programs::TOKEN_2022_PROGRAM
+        }));
+    }
+
+    #[test]
+    fn payout_recipient_pubkeys_collects_mpp_charge_splits() {
+        let api: pay_types::metering::ApiSpec = serde_yml::from_str(
+            r#"
+name: splits-demo
+subdomain: splits-demo
+title: Splits Demo
+description: Splits Demo
+category: finance
+version: v1
+routing:
+  type: respond
+recipients:
+  partner:
+    account: mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp
+endpoints:
+  - method: POST
+    path: v1/report
+    metering:
+      schemes: [mpp-charge]
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.10
+      splits:
+        - recipient: partner
+          percent: 20
+  - method: POST
+    path: v1/exact
+    metering:
+      schemes: [x402-exact]
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.10
+      splits:
+        - recipient: partner
+          percent: 20
+"#,
+        )
+        .unwrap();
+
+        let recipients = payout_recipient_pubkeys(&api, None).unwrap();
+
+        assert_eq!(recipients.len(), 1);
+        assert_eq!(
+            recipients[0].to_string(),
+            "mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp"
+        );
+    }
+
+    #[test]
+    fn payout_recipient_pubkeys_includes_x402_upto_beneficiary() {
+        let api: pay_types::metering::ApiSpec = serde_yml::from_str(
+            r#"
+name: upto-demo
+subdomain: upto-demo
+title: Upto Demo
+description: Upto Demo
+category: finance
+version: v1
+routing:
+  type: respond
+recipients:
+  partner:
+    account: mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp
+endpoints:
+  - method: POST
+    path: v1/report
+    metering:
+      schemes: [mpp-charge, x402-upto]
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.10
+      splits:
+        - recipient: partner
+          percent: 20
+"#,
+        )
+        .unwrap();
+        let x402_recipient =
+            Pubkey::from_str("CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY").unwrap();
+
+        let recipients = payout_recipient_pubkeys(&api, Some(x402_recipient)).unwrap();
+
+        assert_eq!(recipients.len(), 2);
+        assert!(recipients.contains(&x402_recipient));
+        assert!(recipients.iter().any(
+            |recipient| recipient.to_string() == "mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp"
+        ));
+    }
+
+    #[test]
+    fn x402_upto_beneficiary_pubkey_only_for_distinct_recipient() {
+        let api: pay_types::metering::ApiSpec = serde_yml::from_str(
+            r#"
+name: upto-demo
+subdomain: upto-demo
+title: Upto Demo
+description: Upto Demo
+category: finance
+version: v1
+routing:
+  type: respond
+endpoints:
+  - method: POST
+    path: v1/report
+    metering:
+      schemes: [x402-upto]
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.10
+"#,
+        )
+        .unwrap();
+        let recipient = "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY";
+        let operator = VALID_TEST_KEYPAIR_PUBKEY;
+
+        let beneficiary = x402_upto_beneficiary_pubkey(&api, recipient, Some(operator)).unwrap();
+        let same_as_operator =
+            x402_upto_beneficiary_pubkey(&api, operator, Some(operator)).unwrap();
+
+        assert_eq!(beneficiary.unwrap().to_string(), recipient);
+        assert_eq!(same_as_operator, None);
+    }
+
+    #[test]
+    fn create_associated_token_account_ix_is_idempotent_shape() {
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::from_str(pay_types::Stablecoin::Usdc.mint(Some("localnet"))).unwrap();
+        let token_program =
+            Pubkey::from_str(pay_kit::mpp::protocol::solana::programs::TOKEN_PROGRAM).unwrap();
+        let (ata, _) = pay_kit::mpp::program::payment_channels::find_associated_token_address(
+            &owner,
+            &mint,
+            &token_program,
+        );
+
+        let ix =
+            create_associated_token_account_idempotent_ix(&payer, &owner, &mint, &token_program);
+
+        assert_eq!(
+            ix.program_id.to_string(),
+            pay_kit::mpp::protocol::solana::programs::ASSOCIATED_TOKEN_PROGRAM
+        );
+        assert_eq!(ix.data, vec![1]);
+        assert_eq!(ix.accounts[0].pubkey, payer);
+        assert!(ix.accounts[0].is_signer);
+        assert_eq!(ix.accounts[1].pubkey, ata);
+        assert_eq!(ix.accounts[2].pubkey, owner);
+        assert_eq!(ix.accounts[3].pubkey, mint);
+        assert_eq!(ix.accounts[5].pubkey, token_program);
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -157,6 +157,20 @@ fn should_use_auto_fee_payer_signer(
     sandbox || (signer_cfg.is_none() && network.is_throwaway())
 }
 
+fn x402_upto_payout_for_recipient(
+    recipient: &str,
+    operator: &str,
+) -> pay_kit::x402::server::UptoPayout {
+    if recipient == operator {
+        pay_kit::x402::server::UptoPayout::OperatorKeepsAll
+    } else {
+        pay_kit::x402::server::UptoPayout::Beneficiary {
+            address: recipient.to_string(),
+            operator_fee_bps: 0,
+        }
+    }
+}
+
 fn resolve_session_splits(
     api: &ApiSpec,
     session: &pay_types::metering::SessionSpec,
@@ -1196,8 +1210,12 @@ impl StartCommand {
             // settlement vouchers), so it's only available with a fee-payer signer.
             let x402_upto = match (wants_x402, fee_payer_signer.clone()) {
                 (true, Some(signer)) => {
+                    let operator = signer.pubkey().to_string();
                     let cfg = pay_kit::x402::server::UptoConfig {
-                        recipient: recipient.clone(),
+                        // If the YAML recipient differs from the operator signer,
+                        // pay the recipient through a bound 100% distribution
+                        // split; otherwise the operator keeps the channel payout.
+                        payout: x402_upto_payout_for_recipient(&recipient, &operator),
                         currencies: x402_currencies.clone(),
                         cluster: network.slug().to_string(),
                         rpc_url: Some(rpc_url.clone()),
@@ -2721,6 +2739,7 @@ mod tests {
     use super::{
         build_pdb_config, resolve_currency, resolve_operator_currencies,
         should_use_auto_fee_payer_signer, validate_browser_rpc_request,
+        x402_upto_payout_for_recipient,
     };
     use crate::network::SolanaNetwork;
 
@@ -2770,6 +2789,36 @@ currencies:
             resolve_currency("USDG", "mainnet").0,
             pay_types::stablecoin_mints::USDG_MAINNET
         );
+    }
+
+    #[test]
+    fn x402_upto_payout_keeps_all_when_recipient_is_operator() {
+        let payout =
+            x402_upto_payout_for_recipient(VALID_TEST_KEYPAIR_PUBKEY, VALID_TEST_KEYPAIR_PUBKEY);
+
+        assert!(matches!(
+            payout,
+            pay_kit::x402::server::UptoPayout::OperatorKeepsAll
+        ));
+    }
+
+    #[test]
+    fn x402_upto_payout_splits_100_percent_to_distinct_recipient() {
+        let recipient = "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY";
+        let payout = x402_upto_payout_for_recipient(recipient, VALID_TEST_KEYPAIR_PUBKEY);
+
+        match payout {
+            pay_kit::x402::server::UptoPayout::Beneficiary {
+                address,
+                operator_fee_bps,
+            } => {
+                assert_eq!(address, recipient);
+                assert_eq!(operator_fee_bps, 0);
+            }
+            pay_kit::x402::server::UptoPayout::OperatorKeepsAll => {
+                panic!("distinct recipient should be configured as beneficiary")
+            }
+        }
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -329,6 +329,12 @@ struct SurfpoolFundingTarget {
     address: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PayoutRecipientTarget {
+    label: String,
+    pubkey: solana_pubkey::Pubkey,
+}
+
 fn surfpool_funding_targets(
     recipient: &str,
     operator_pubkey: Option<&str>,
@@ -352,7 +358,7 @@ fn surfpool_funding_targets(
 fn surfpool_prep_notice_body(
     rpc_url: &str,
     targets: &[SurfpoolFundingTarget],
-    payout_recipient_count: usize,
+    payout_recipients: &[PayoutRecipientTarget],
     stable_requirements: &[StableTokenAccountRequirement],
     auto_fund: bool,
 ) -> String {
@@ -364,7 +370,7 @@ fn surfpool_prep_notice_body(
             target.label, target.address
         ));
     }
-    if payout_recipient_count > 0 && !stable_requirements.is_empty() {
+    if !payout_recipients.is_empty() && !stable_requirements.is_empty() {
         let ata_action = if auto_fund {
             "creating missing"
         } else {
@@ -376,8 +382,12 @@ fn surfpool_prep_notice_body(
             .collect::<Vec<_>>()
             .join(", ");
         lines.push(format!(
-            "{ata_action} ATAs for all configured stable tokens ({tokens}) across {payout_recipient_count} payout recipient(s)"
+            "{ata_action} ATAs for all configured stable tokens ({tokens}) across {} payout recipient(s):",
+            payout_recipients.len()
         ));
+        for recipient in payout_recipients {
+            lines.push(format!("  {}: {}", recipient.label, recipient.pubkey));
+        }
     }
     lines.join("\n")
 }
@@ -605,21 +615,42 @@ fn stable_token_account_requirements(
     Ok(requirements)
 }
 
-fn payout_recipient_pubkeys(
+fn add_payout_recipient_target(
+    targets: &mut Vec<PayoutRecipientTarget>,
+    label: impl Into<String>,
+    pubkey: solana_pubkey::Pubkey,
+) {
+    let label = label.into();
+    if let Some(existing) = targets.iter_mut().find(|target| target.pubkey == pubkey) {
+        if !existing.label.split(" + ").any(|part| part == label) {
+            existing.label.push_str(" + ");
+            existing.label.push_str(&label);
+        }
+    } else {
+        targets.push(PayoutRecipientTarget { label, pubkey });
+    }
+}
+
+fn payout_recipient_targets(
     api: &ApiSpec,
     x402_upto_beneficiary: Option<solana_pubkey::Pubkey>,
-) -> pay_core::Result<Vec<solana_pubkey::Pubkey>> {
-    let mut recipients = charge_split_recipient_pubkeys(api)?;
+) -> pay_core::Result<Vec<PayoutRecipientTarget>> {
+    let mut recipients = Vec::new();
     if let Some(beneficiary) = x402_upto_beneficiary {
-        recipients.push(beneficiary);
+        add_payout_recipient_target(&mut recipients, "x402-upto beneficiary", beneficiary);
     }
-    recipients.sort();
-    recipients.dedup();
+    for target in charge_split_recipient_targets(api)? {
+        add_payout_recipient_target(&mut recipients, target.label, target.pubkey);
+    }
     Ok(recipients)
 }
 
-fn charge_split_recipient_pubkeys(api: &ApiSpec) -> pay_core::Result<Vec<solana_pubkey::Pubkey>> {
-    let mut recipients = std::collections::BTreeSet::new();
+fn payout_recipient_pubkeys(targets: &[PayoutRecipientTarget]) -> Vec<solana_pubkey::Pubkey> {
+    targets.iter().map(|target| target.pubkey).collect()
+}
+
+fn charge_split_recipient_targets(api: &ApiSpec) -> pay_core::Result<Vec<PayoutRecipientTarget>> {
+    let mut recipients = Vec::new();
     for ep in &api.endpoints {
         let Some(meter) = ep.metering.as_ref() else {
             continue;
@@ -645,10 +676,15 @@ fn charge_split_recipient_pubkeys(api: &ApiSpec) -> pay_core::Result<Vec<solana_
                     ep.path, rule.recipient
                 ))
             })?;
-            recipients.insert(recipient);
+            let label = alias
+                .label
+                .as_ref()
+                .map(|display| format!("split recipient {} ({display})", rule.recipient))
+                .unwrap_or_else(|| format!("split recipient {}", rule.recipient));
+            add_payout_recipient_target(&mut recipients, label, recipient);
         }
     }
-    Ok(recipients.into_iter().collect())
+    Ok(recipients)
 }
 
 fn api_accepts_x402_upto(api: &ApiSpec) -> bool {
@@ -1019,7 +1055,9 @@ impl StartCommand {
                 .map(|signer| signer.pubkey().to_string());
             let x402_upto_beneficiary =
                 x402_upto_beneficiary_pubkey(&api, &recipient, operator_pubkey.as_deref())?;
-            let payout_recipients = payout_recipient_pubkeys(&api, x402_upto_beneficiary)?;
+            let payout_recipient_targets =
+                payout_recipient_targets(&api, x402_upto_beneficiary)?;
+            let payout_recipients = payout_recipient_pubkeys(&payout_recipient_targets);
             let stable_requirements =
                 stable_token_account_requirements(&currency_configs, network.slug())?;
 
@@ -1050,7 +1088,7 @@ impl StartCommand {
                     &surfpool_prep_notice_body(
                         &rpc_url,
                         &surfpool_targets,
-                        payout_recipients.len(),
+                        &payout_recipient_targets,
                         &stable_requirements,
                         true,
                     ),
@@ -1084,7 +1122,7 @@ impl StartCommand {
                     &surfpool_prep_notice_body(
                         &rpc_url,
                         &surfpool_targets,
-                        payout_recipients.len(),
+                        &payout_recipient_targets,
                         &stable_requirements,
                         false,
                     ),
@@ -3163,8 +3201,9 @@ fn gateway_charge_challenges(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pdb_config, create_associated_token_account_idempotent_ix, payout_recipient_pubkeys,
-        resolve_currency, resolve_operator_currencies, should_use_auto_fee_payer_signer,
+        PayoutRecipientTarget, build_pdb_config, create_associated_token_account_idempotent_ix,
+        payout_recipient_pubkeys, payout_recipient_targets, resolve_currency,
+        resolve_operator_currencies, should_use_auto_fee_payer_signer,
         stable_token_account_requirements, surfpool_funding_targets, surfpool_prep_notice_body,
         validate_browser_rpc_request, x402_currency_configs, x402_upto_beneficiary_pubkey,
         x402_upto_payout_for_recipient,
@@ -3225,6 +3264,16 @@ currencies:
     fn surfpool_prep_notice_body_names_wallet_and_ata_work() {
         let targets =
             surfpool_funding_targets("CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY", None);
+        let payout_recipients = vec![
+            PayoutRecipientTarget {
+                label: "x402-upto beneficiary".to_string(),
+                pubkey: Pubkey::from_str("CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY").unwrap(),
+            },
+            PayoutRecipientTarget {
+                label: "split recipient partner (Partner)".to_string(),
+                pubkey: Pubkey::from_str("mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp").unwrap(),
+            },
+        ];
         let stable_requirements = stable_token_account_requirements(
             &[
                 (
@@ -3249,7 +3298,7 @@ currencies:
         let body = surfpool_prep_notice_body(
             "https://402.surfnet.dev:8899",
             &targets,
-            2,
+            &payout_recipients,
             &stable_requirements,
             true,
         );
@@ -3258,6 +3307,12 @@ currencies:
         assert!(body.contains("funding payment recipient"));
         assert!(body.contains(
             "creating missing ATAs for all configured stable tokens (USDC, PYUSD) across 2 payout recipient(s)"
+        ));
+        assert!(
+            body.contains("x402-upto beneficiary: CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY")
+        );
+        assert!(body.contains(
+            "split recipient partner (Partner): mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp"
         ));
     }
 
@@ -3334,13 +3389,15 @@ endpoints:
         )
         .unwrap();
 
-        let recipients = payout_recipient_pubkeys(&api, None).unwrap();
+        let targets = payout_recipient_targets(&api, None).unwrap();
+        let recipients = payout_recipient_pubkeys(&targets);
 
         assert_eq!(recipients.len(), 1);
         assert_eq!(
             recipients[0].to_string(),
             "mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp"
         );
+        assert_eq!(targets[0].label, "split recipient partner");
     }
 
     #[test]
@@ -3378,13 +3435,16 @@ endpoints:
         let x402_recipient =
             Pubkey::from_str("CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY").unwrap();
 
-        let recipients = payout_recipient_pubkeys(&api, Some(x402_recipient)).unwrap();
+        let targets = payout_recipient_targets(&api, Some(x402_recipient)).unwrap();
+        let recipients = payout_recipient_pubkeys(&targets);
 
         assert_eq!(recipients.len(), 2);
         assert!(recipients.contains(&x402_recipient));
         assert!(recipients.iter().any(
             |recipient| recipient.to_string() == "mandyRKj8mvxhuk9Np7pJEXd7BjoEZZNRFxUTpDFeAp"
         ));
+        assert_eq!(targets[0].label, "x402-upto beneficiary");
+        assert_eq!(targets[1].label, "split recipient partner");
     }
 
     #[test]

--- a/rust/crates/cli/src/components/banner.rs
+++ b/rust/crates/cli/src/components/banner.rs
@@ -8,7 +8,7 @@ pub const PAY_SH_BANNER: &[&str] = &[
     "██║     ██║  ██║   ██║   ██╗███████║██║  ██║",
     "╚═╝     ╚═╝  ╚═╝   ╚═╝   ╚═╝╚══════╝╚═╝  ╚═╝",
 ];
-pub const PAY_SH_TAGLINE: &str = "Toolchain for Programmable Money";
+pub const PAY_SH_TAGLINE: &str = "Toolchain for agentic payments";
 
 /// Render the banner used at the top of human help output.
 pub fn help_banner() -> String {
@@ -34,7 +34,7 @@ fn render_banner_art(tagline: impl std::fmt::Display) -> String {
             .collect::<Vec<_>>()
             .join("\n"),
     );
-    output.push_str(&format!("\n  {tagline}"));
+    output.push_str(&format!("\n{tagline}"));
     output
 }
 
@@ -87,5 +87,7 @@ mod tests {
 
         assert!(banner.starts_with("\n\x1b["));
         assert!(!banner.starts_with("\n "));
+        assert!(banner.ends_with(&format!("\n{PAY_SH_TAGLINE}")));
+        assert!(!banner.ends_with(&format!("\n  {PAY_SH_TAGLINE}")));
     }
 }

--- a/rust/crates/core/src/client/mpp.rs
+++ b/rust/crates/core/src/client/mpp.rs
@@ -269,7 +269,7 @@ pub enum ChosenPayment {
 pub fn choose_payment(
     mpp_challenges: &[Challenge],
     x402_alternative: Option<&crate::client::x402::Challenge>,
-    x402_upto_alternative: Option<&crate::client::x402::UptoChallenge>,
+    x402_upto_accepts: &[pay_kit::x402::upto::UptoRequirements],
     store: &dyn AccountsStore,
     network_override: Option<&str>,
     account_override: Option<&str>,
@@ -277,13 +277,19 @@ pub fn choose_payment(
     let candidates = decoded_charge_candidates(mpp_challenges, network_override)?;
 
     // Network/RPC come from the first decodable MPP charge. With no decodable
-    // MPP candidate, honor an x402 alternative (exact preferred, else upto).
+    // MPP candidate, honor an x402 alternative (exact preferred, else the first
+    // advertised upto — balance-aware ranking needs an MPP network to fetch
+    // against, so this degenerate path settles the first offered upto).
     let Some(first) = candidates.first() else {
         if let Some(c) = x402_alternative.cloned() {
             return Ok(ChosenPayment::X402(Box::new(c)));
         }
-        if let Some(c) = x402_upto_alternative.cloned() {
-            return Ok(ChosenPayment::X402Upto(Box::new(c)));
+        if let Some(requirements) = x402_upto_accepts.first() {
+            return Ok(ChosenPayment::X402Upto(Box::new(
+                crate::client::x402::UptoChallenge {
+                    requirements: requirements.clone(),
+                },
+            )));
         }
         return Err(Error::Mpp("No usable payment challenge".to_string()));
     };
@@ -336,17 +342,12 @@ pub fn choose_payment(
         .map(|c| c.requirements.clone())
         .into_iter()
         .collect();
-    let upto_accepts: Vec<pay_kit::x402::upto::UptoRequirements> = x402_upto_alternative
-        .map(|c| c.requirements.clone())
-        .into_iter()
-        .collect();
-
     // Cost-first across all three schemes; `CheapestPayable` ties break to MPP
     // (native one-shot), then upto, then exact — see `select`'s `Source::rank`.
     match pay_kit::select_payment_parsed_all(
         mpp_challenges,
         &x402_accepts,
-        &upto_accepts,
+        x402_upto_accepts,
         &funded,
         &pay_kit::OrderingStrategy::CheapestPayable,
     ) {
@@ -357,10 +358,12 @@ pub fn choose_payment(
             .cloned()
             .map(|c| ChosenPayment::X402(Box::new(c)))
             .ok_or_else(|| Error::Mpp("x402 exact selected but no challenge available".into())),
-        Ok(pay_kit::SelectedPayment::X402Upto { .. }) => x402_upto_alternative
-            .cloned()
-            .map(|c| ChosenPayment::X402Upto(Box::new(c)))
-            .ok_or_else(|| Error::Mpp("x402 upto selected but no challenge available".into())),
+        // The router picks the specific upto currency; build that one.
+        Ok(pay_kit::SelectedPayment::X402Upto { requirement, .. }) => Ok(ChosenPayment::X402Upto(
+            Box::new(crate::client::x402::UptoChallenge {
+                requirements: *requirement,
+            }),
+        )),
         Err(e) => Err(Error::PaymentRejected(e.to_string())),
     }
 }

--- a/rust/crates/core/src/client/mpp.rs
+++ b/rust/crates/core/src/client/mpp.rs
@@ -247,8 +247,10 @@ pub fn select_challenge_by_balance<'a>(
 pub enum ChosenPayment {
     /// Settle via an MPP charge challenge.
     Mpp(Box<Challenge>),
-    /// Settle via the x402 alternative advertised on the same 402.
+    /// Settle via the x402 `exact` alternative advertised on the same 402.
     X402(Box<crate::client::x402::Challenge>),
+    /// Settle via the x402 `upto` alternative advertised on the same 402.
+    X402Upto(Box<crate::client::x402::UptoChallenge>),
 }
 
 /// Choose how to pay a 402, across *both* MPP charge challenges and an x402
@@ -267,6 +269,7 @@ pub enum ChosenPayment {
 pub fn choose_payment(
     mpp_challenges: &[Challenge],
     x402_alternative: Option<&crate::client::x402::Challenge>,
+    x402_upto_alternative: Option<&crate::client::x402::UptoChallenge>,
     store: &dyn AccountsStore,
     network_override: Option<&str>,
     account_override: Option<&str>,
@@ -274,12 +277,15 @@ pub fn choose_payment(
     let candidates = decoded_charge_candidates(mpp_challenges, network_override)?;
 
     // Network/RPC come from the first decodable MPP charge. With no decodable
-    // MPP candidate, the only thing left to honor is the x402 alternative.
+    // MPP candidate, honor an x402 alternative (exact preferred, else upto).
     let Some(first) = candidates.first() else {
-        return x402_alternative
-            .cloned()
-            .map(|c| ChosenPayment::X402(Box::new(c)))
-            .ok_or_else(|| Error::Mpp("No usable payment challenge".to_string()));
+        if let Some(c) = x402_alternative.cloned() {
+            return Ok(ChosenPayment::X402(Box::new(c)));
+        }
+        if let Some(c) = x402_upto_alternative.cloned() {
+            return Ok(ChosenPayment::X402Upto(Box::new(c)));
+        }
+        return Err(Error::Mpp("No usable payment challenge".to_string()));
     };
 
     let legacy_first_mpp =
@@ -330,18 +336,31 @@ pub fn choose_payment(
         .map(|c| c.requirements.clone())
         .into_iter()
         .collect();
+    let upto_accepts: Vec<pay_kit::x402::upto::UptoRequirements> = x402_upto_alternative
+        .map(|c| c.requirements.clone())
+        .into_iter()
+        .collect();
 
-    match pay_kit::select_payment_parsed(
+    // Cost-first across all three schemes; `CheapestPayable` ties break to MPP
+    // (native one-shot), then upto, then exact — see `select`'s `Source::rank`.
+    match pay_kit::select_payment_parsed_all(
         mpp_challenges,
         &x402_accepts,
+        &upto_accepts,
         &funded,
-        &pay_kit::OrderingStrategy::HighestBalance,
+        &pay_kit::OrderingStrategy::CheapestPayable,
     ) {
-        Ok(pay_kit::SelectedPayment::Mpp { challenge, .. }) => Ok(ChosenPayment::Mpp(challenge)),
-        Ok(pay_kit::SelectedPayment::X402 { .. }) => x402_alternative
+        Ok(pay_kit::SelectedPayment::MppCharge { challenge, .. }) => {
+            Ok(ChosenPayment::Mpp(challenge))
+        }
+        Ok(pay_kit::SelectedPayment::X402Exact { .. }) => x402_alternative
             .cloned()
             .map(|c| ChosenPayment::X402(Box::new(c)))
-            .ok_or_else(|| Error::Mpp("x402 selected but no challenge available".to_string())),
+            .ok_or_else(|| Error::Mpp("x402 exact selected but no challenge available".into())),
+        Ok(pay_kit::SelectedPayment::X402Upto { .. }) => x402_upto_alternative
+            .cloned()
+            .map(|c| ChosenPayment::X402Upto(Box::new(c)))
+            .ok_or_else(|| Error::Mpp("x402 upto selected but no challenge available".into())),
         Err(e) => Err(Error::PaymentRejected(e.to_string())),
     }
 }

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -22,10 +22,10 @@ pub enum RunOutcome {
         challenge: Box<mpp::Challenge>,
         alternatives: Vec<mpp::Challenge>,
         x402_alternative: Option<Box<x402::Challenge>>,
-        /// x402 `upto` advertised on the same 402, carried so the balance- and
-        /// cost-aware selector can settle it when it's the cheaper (or only
-        /// fundable) option. See [`mpp::choose_payment`].
-        x402_upto_alternative: Option<Box<x402::UptoChallenge>>,
+        /// Every x402 `upto` currency advertised on the same 402, carried so the
+        /// balance- and cost-aware selector can settle whichever is cheapest (or
+        /// the only fundable one) — not just the first. See [`mpp::choose_payment`].
+        x402_upto_accepts: Vec<pay_kit::x402::upto::UptoRequirements>,
         resource_url: String,
     },
     /// The server returned 402 with an MPP session challenge (intent="session").
@@ -591,11 +591,11 @@ pub(crate) fn classify_402_with_preference(
         // real `upto` is present prefer that reading and drop the (bogus) exact
         // alternative — otherwise the selector could pick an `exact` the server
         // never advertised and the payment would be rejected.
-        let upto_alternative = x402::parse_upto(headers, body).map(Box::new);
-        let x402_alternative = if upto_alternative.is_some() {
-            None
-        } else {
+        let x402_upto_accepts = x402::parse_upto_accepts(headers, body);
+        let x402_alternative = if x402_upto_accepts.is_empty() {
             x402_challenge.clone().map(Box::new)
+        } else {
+            None
         };
         return RunOutcome::MppChallenge {
             challenge: Box::new(challenge),
@@ -604,7 +604,7 @@ pub(crate) fn classify_402_with_preference(
             // cost-aware selector can settle it when it's cheaper or the only
             // fundable option.
             x402_alternative,
-            x402_upto_alternative: upto_alternative,
+            x402_upto_accepts,
             resource_url: resource_url.to_string(),
         };
     }

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -22,6 +22,10 @@ pub enum RunOutcome {
         challenge: Box<mpp::Challenge>,
         alternatives: Vec<mpp::Challenge>,
         x402_alternative: Option<Box<x402::Challenge>>,
+        /// x402 `upto` advertised on the same 402, carried so the balance- and
+        /// cost-aware selector can settle it when it's the cheaper (or only
+        /// fundable) option. See [`mpp::choose_payment`].
+        x402_upto_alternative: Option<Box<x402::UptoChallenge>>,
         resource_url: String,
     },
     /// The server returned 402 with an MPP session challenge (intent="session").
@@ -583,12 +587,24 @@ pub(crate) fn classify_402_with_preference(
     if !charge_challenges.is_empty() && preference != ProtocolPreference::OnlyX402 {
         let challenge = charge_challenges.remove(0);
         info!(resource = resource_url, "Detected MPP challenge (Solana)");
+        // An `upto`-only x402 offer also parses leniently as `exact`, so when a
+        // real `upto` is present prefer that reading and drop the (bogus) exact
+        // alternative — otherwise the selector could pick an `exact` the server
+        // never advertised and the payment would be rejected.
+        let upto_alternative = x402::parse_upto(headers, body).map(Box::new);
+        let x402_alternative = if upto_alternative.is_some() {
+            None
+        } else {
+            x402_challenge.clone().map(Box::new)
+        };
         return RunOutcome::MppChallenge {
             challenge: Box::new(challenge),
             alternatives: charge_challenges,
-            // Carry any x402 charge from the same 402 so a balance-aware
-            // selector can fall back to it when no MPP challenge is fundable.
-            x402_alternative: x402_challenge.clone().map(Box::new),
+            // Carry any x402 charge from the same 402 so the balance- and
+            // cost-aware selector can settle it when it's cheaper or the only
+            // fundable option.
+            x402_alternative,
+            x402_upto_alternative: upto_alternative,
             resource_url: resource_url.to_string(),
         };
     }

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -162,13 +162,14 @@ pub fn build_payment_with_override(
         cluster_raw
     };
 
-    // x402 may carry a recent blockhash, but the current pay-side guard only
-    // compares the selected account network against the challenge network.
-    crate::client::mpp::check_client_network_intent(network_override, &cluster, None)?;
+    crate::client::mpp::check_client_network_intent(
+        network_override,
+        &cluster,
+        embedded_blockhash,
+    )?;
 
-    // Auto-fund when the user opted into sandbox or the challenge
-    // advertises localnet (likely a sandbox gateway without --sandbox).
-    let user_opted_into_sandbox = network_override.is_some() || cluster == "localnet";
+    let should_auto_fund_surfpool =
+        should_auto_fund_surfpool_for_x402(network_override, embedded_blockhash);
     let network = network_override.map(str::to_string).unwrap_or(cluster);
 
     let (signer, ephemeral_notice) =
@@ -211,7 +212,7 @@ pub fn build_payment_with_override(
         .build()
         .map_err(|e| Error::Mpp(format!("Failed to create runtime: {e}")))?;
 
-    if user_opted_into_sandbox {
+    if should_auto_fund_surfpool {
         let pubkey = signer.pubkey().to_string();
         let fund_url = rpc_url.clone();
         if let Err(e) = rt.block_on(crate::client::sandbox::fund_via_surfpool(
@@ -310,9 +311,14 @@ pub fn build_upto_payment(
     } else {
         cluster_raw
     };
-    crate::client::mpp::check_client_network_intent(network_override, &cluster, None)?;
+    crate::client::mpp::check_client_network_intent(
+        network_override,
+        &cluster,
+        embedded_blockhash,
+    )?;
 
-    let user_opted_into_sandbox = network_override.is_some() || cluster == "localnet";
+    let should_auto_fund_surfpool =
+        should_auto_fund_surfpool_for_x402(network_override, embedded_blockhash);
     let network = network_override.map(str::to_string).unwrap_or(cluster);
 
     let (signer, ephemeral_notice) =
@@ -347,7 +353,7 @@ pub fn build_upto_payment(
         .build()
         .map_err(|e| Error::Mpp(format!("Failed to create runtime: {e}")))?;
 
-    if user_opted_into_sandbox {
+    if should_auto_fund_surfpool {
         let pubkey = signer.pubkey().to_string();
         let fund_url = rpc_url.clone();
         if let Err(e) = rt.block_on(crate::client::sandbox::fund_via_surfpool(
@@ -622,6 +628,13 @@ fn detect_x402_version(headers: &[(String, String)], body: Option<&str>) -> u64 
     X402_VERSION_V2
 }
 
+fn should_auto_fund_surfpool_for_x402(
+    network_override: Option<&str>,
+    embedded_blockhash: Option<&str>,
+) -> bool {
+    crate::client::mpp::should_auto_fund_surfpool(network_override, embedded_blockhash)
+}
+
 fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
     headers
         .iter()
@@ -661,6 +674,37 @@ mod tests {
             accepted: None,
             resource_info: None,
         }
+    }
+
+    fn surfpool_hash() -> &'static str {
+        "SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxx18b8dc98"
+    }
+
+    #[test]
+    fn x402_auto_fund_skips_mainnet_override() {
+        assert!(!should_auto_fund_surfpool_for_x402(Some("mainnet"), None));
+        assert!(!should_auto_fund_surfpool_for_x402(
+            Some("mainnet"),
+            Some("9zrUHnA1nCByPksy3aL8tQ47vqdaG2vnFs4HrxgcZj4F")
+        ));
+    }
+
+    #[test]
+    fn x402_auto_fund_runs_for_sandbox_override_or_surfpool_blockhash() {
+        assert!(should_auto_fund_surfpool_for_x402(Some("localnet"), None));
+        assert!(should_auto_fund_surfpool_for_x402(Some("sandbox"), None));
+        assert!(should_auto_fund_surfpool_for_x402(
+            None,
+            Some(surfpool_hash())
+        ));
+    }
+
+    #[test]
+    fn x402_auto_fund_skips_plain_localnet_without_override_or_surfpool_hash() {
+        assert!(!should_auto_fund_surfpool_for_x402(
+            None,
+            Some("9zrUHnA1nCByPksy3aL8tQ47vqdaG2vnFs4HrxgcZj4F")
+        ));
     }
 
     #[test]

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -254,10 +254,20 @@ pub fn build_payment_with_override(
     })
 }
 
-/// Try to parse an x402 `upto` challenge from headers and/or body.
+/// Try to parse an x402 `upto` challenge from headers and/or body — the first
+/// advertised `upto` currency, used to build the channel open.
 pub fn parse_upto(headers: &[(String, String)], body: Option<&str>) -> Option<UptoChallenge> {
     pay_kit::x402::client::upto::parse_upto_challenge(headers, body)
         .map(|requirements| UptoChallenge { requirements })
+}
+
+/// Every advertised x402 `upto` requirement, so the balance- and cost-aware
+/// selector can choose among the offered currencies (not just the first).
+pub fn parse_upto_accepts(
+    headers: &[(String, String)],
+    body: Option<&str>,
+) -> Vec<pay_kit::x402::upto::UptoRequirements> {
+    pay_kit::x402::client::upto::parse_upto_accepts(headers, body)
 }
 
 /// Build a signed x402 `upto` payment: a payment-channel `open` authorization

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -145,7 +145,7 @@ pub enum GateDecision {
     Forward {
         session: Option<SessionForward>,
         receipt: Option<ReceiptAnnotation>,
-        upto: Option<UptoForward>,
+        upto: Option<Box<UptoForward>>,
     },
     /// Not gated (discovery / free / unknown) — let normal routing handle it
     /// (forward to the default upstream, or serve a control-plane route).
@@ -696,11 +696,11 @@ impl<S: PaymentState> PaymentGate<S> {
                 GateDecision::Forward {
                     session: None,
                     receipt: None,
-                    upto: Some(UptoForward {
+                    upto: Some(Box::new(UptoForward {
                         open: Box::new(open),
                         settle_amount,
                         settlement,
-                    }),
+                    })),
                 }
             }
             Err(e) => {

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -116,10 +116,9 @@ pub struct SessionForward {
 /// An x402 `upto` channel opened (and confirmed on-chain) before the resource
 /// is served, carried to the adapter's post-response hook for settlement.
 ///
-/// `upto` is settle-after-serve: the adapter forwards, then settles the metered
-/// amount on success (`open.max_amount`) or refunds (`0`) on failure. The
-/// settlement runs `state.x402_upto().settle_actual(&open, amount)`. Holds the
-/// `!Clone` [`VerifiedUptoOpen`] (with its in-flight guard) until settled.
+/// `upto` is settle-after-serve: the adapter forwards, then settles the actual
+/// amount on success or refunds (`0`) on failure. Holds the `!Clone`
+/// [`VerifiedUptoOpen`] (with its in-flight guard) until settled.
 pub struct UptoForward {
     /// Boxed — `VerifiedUptoOpen` is large, and boxing keeps the common
     /// `GateDecision` variants small (clippy `large_enum_variant`).
@@ -128,6 +127,9 @@ pub struct UptoForward {
     /// configured `min` (clamped to the ceiling), or the full ceiling when no
     /// `min` is set. Failures always settle `0` (full refund).
     pub settle_amount: u64,
+    /// Response-metered settlement plan. `None` preserves the legacy fixed
+    /// success amount above.
+    pub settlement: Option<metering::UptoSettlementPlan>,
 }
 
 /// The outcome of gating a request.
@@ -493,10 +495,11 @@ impl<S: PaymentState> PaymentGate<S> {
         if accepted.contains(&Scheme::X402Upto)
             && let Some(upto) = self.state.x402_upto()
         {
-            // The advertised ceiling: the metered charge for this request. The
-            // client funds a channel with this as the deposit; settlement debits
-            // the actual (== ceiling on success, 0 → full refund on failure).
-            let amount = crate::server::payment::charge_amount_from_price(price.as_ref());
+            // The advertised ceiling: `metering.upto.max_usd` for usage-metered
+            // configs, or the legacy metered charge for older configs. The
+            // client funds a channel with this as the deposit; settlement later
+            // debits actual usage and refunds the rest.
+            let amount = format!("{}", metering::upto_max_usd(meter, price.as_ref()));
             match upto.payment_required_header(&amount) {
                 Ok((name, value)) => {
                     if let (Ok(n), Ok(v)) = (
@@ -676,19 +679,27 @@ impl<S: PaymentState> PaymentGate<S> {
             ..Default::default()
         };
         let variant = variant_hint_from_path(path);
-        let amount = crate::server::payment::charge_amount_from_price(
-            metering::resolve_price(meter, &props, variant.as_deref(), None).as_ref(),
-        );
+        let price = metering::resolve_price(meter, &props, variant.as_deref(), None);
+        let amount = format!("{}", metering::upto_max_usd(meter, price.as_ref()));
         match upto.verify_open(pay_header, &amount).await {
             Ok(open) => {
                 let ceiling_usd: f64 = amount.parse().unwrap_or(0.0);
-                let settle_amount = upto_settle_amount(meter.min_usd, ceiling_usd, open.max_amount);
+                let settle_amount =
+                    upto_settle_amount(metering::upto_min_usd(meter), ceiling_usd, open.max_amount);
+                let settlement = metering::upto_uses_response_usage(meter, variant.as_deref())
+                    .then(|| metering::UptoSettlementPlan {
+                        metering: meter.clone(),
+                        variant_hint: variant.clone(),
+                        request_properties: props,
+                        ceiling_usd,
+                    });
                 GateDecision::Forward {
                     session: None,
                     receipt: None,
                     upto: Some(UptoForward {
                         open: Box::new(open),
                         settle_amount,
+                        settlement,
                     }),
                 }
             }
@@ -1183,6 +1194,39 @@ pub async fn settle_upto<S: PaymentState>(
             None
         }
     }
+}
+
+/// Settle an x402 `upto` channel using post-response usage extraction.
+///
+/// When the response did not successfully serve, this always settles `0`
+/// (refund). When usage extraction fails under `missing_usage: error`, it also
+/// refunds so funds are not stranded.
+pub async fn settle_upto_metered<S: PaymentState>(
+    state: &S,
+    open: VerifiedUptoOpen,
+    plan: metering::UptoSettlementPlan,
+    served_ok: bool,
+    response_headers: &http::HeaderMap,
+    response_body: Option<&[u8]>,
+) -> Option<(HeaderName, HeaderValue)> {
+    if !served_ok {
+        return settle_upto(state, open, 0, false).await;
+    }
+
+    let amount = match metering::upto_actual_amount_from_response(
+        &plan,
+        open.max_amount,
+        response_headers,
+        response_body,
+    ) {
+        Ok(actual) => actual.base_units,
+        Err(e) => {
+            tracing::warn!(error = %e, "x402 upto response-metered settlement failed; refunding");
+            0
+        }
+    };
+
+    settle_upto(state, open, amount, true).await
 }
 
 /// Reconstruct a minimal URI from path + query for split-rule resolution.

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -1139,11 +1139,17 @@ fn upto_settle_amount(min_usd: Option<f64>, ceiling_usd: f64, max_amount: u64) -
 /// Settle an x402 `upto` channel after the resource was served (the adapter's
 /// post-response hook). Debits `settle_amount` (the configured `min`, or the
 /// full ceiling when unset — clamped to `open.max_amount`) on a successful
-/// serve, refunds the full deposit (settle `0`) on failure, and finalizes the
-/// channel on-chain. Returns the `PAYMENT-RESPONSE` receipt header
-/// to set on the response. Settlement errors are logged, not surfaced — the
-/// resource was already served, so a failed settle is an operator/on-chain retry
-/// concern (the channel store sweeps it), not a client error.
+/// serve, refunds the full deposit (settle `0`) on failure, and returns the
+/// `PAYMENT-RESPONSE` receipt header to set on the response.
+///
+/// Routes through the shared batched-settlement worker (`settle_actual_deferred`):
+/// concurrent settlements pack into one operator-signed tx that is **sent
+/// without waiting for confirmation**, with the background worker confirming +
+/// retrying. This takes the multi-second confirm poll off the response path —
+/// the client's funds are locked by the confirmed `open`, so a late or failed
+/// background confirm is an operator-retry concern (the channel store sweeps
+/// it), not a client error. Settlement errors are logged, not surfaced (the
+/// resource was already served).
 pub async fn settle_upto<S: PaymentState>(
     state: &S,
     open: VerifiedUptoOpen,
@@ -1158,7 +1164,7 @@ pub async fn settle_upto<S: PaymentState>(
     } else {
         0
     };
-    match upto.settle_actual(&open, amount).await {
+    match upto.settle_actual_deferred(&open, amount).await {
         Ok(settlement) => {
             tracing::Span::current().record("tx_sig", settlement.transaction.as_str());
             match upto.settlement_header(&settlement) {
@@ -1173,7 +1179,7 @@ pub async fn settle_upto<S: PaymentState>(
             }
         }
         Err(e) => {
-            tracing::error!(error = %e, "x402 upto settle_actual failed; channel left for sweep");
+            tracing::error!(error = %e, "x402 upto settlement failed; channel left for sweep");
             None
         }
     }

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -1,7 +1,9 @@
 use crate::server::accounting::{AccountingKey, AccountingStore};
+use http::HeaderMap;
 use pay_types::metering::{
-    AccountingMode, ApiSpec, CompareOp, Endpoint, MeterCondition, MeterDimension, MeterVariant,
-    Metering, PriceTier,
+    AccountingMode, ApiSpec, BillingUnit, CompareOp, Endpoint, MeterCondition, MeterDimension,
+    MeterDirection, MeterVariant, Metering, MissingUsagePolicy, PriceTier, UsageMeter,
+    UsageMeterSource,
 };
 use serde::{Deserialize, Serialize};
 
@@ -30,6 +32,45 @@ pub struct ResolvedDimension {
     pub scale: u64,
     pub price_usd: f64,
 }
+
+/// Settlement plan carried from x402-upto open verification to the post-response
+/// settlement hook.
+#[derive(Debug, Clone)]
+pub struct UptoSettlementPlan {
+    pub metering: Metering,
+    pub variant_hint: Option<String>,
+    pub request_properties: RequestProperties,
+    pub ceiling_usd: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UptoActualAmount {
+    pub usd: f64,
+    pub base_units: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UptoUsageError {
+    MissingUsage(String),
+    InvalidUsage(String),
+    InvalidJson(String),
+    MissingUsagePolicyError,
+}
+
+impl std::fmt::Display for UptoUsageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingUsage(msg) => write!(f, "missing usage: {msg}"),
+            Self::InvalidUsage(msg) => write!(f, "invalid usage: {msg}"),
+            Self::InvalidJson(msg) => write!(f, "invalid response JSON: {msg}"),
+            Self::MissingUsagePolicyError => {
+                write!(f, "usage missing and missing_usage is set to error")
+            }
+        }
+    }
+}
+
+impl std::error::Error for UptoUsageError {}
 
 /// Find the matching endpoint for a request path and method.
 pub fn find_endpoint<'a>(api: &'a ApiSpec, method: &str, path: &str) -> Option<&'a Endpoint> {
@@ -135,6 +176,299 @@ pub fn resolve_price(
     }
 
     None
+}
+
+pub fn effective_dimensions<'a>(
+    metering: &'a Metering,
+    variant_hint: Option<&str>,
+) -> &'a [MeterDimension] {
+    if !metering.variants.is_empty() {
+        if let Some(variant) = resolve_variant(&metering.variants, variant_hint) {
+            return &variant.dimensions;
+        }
+        if let Some(first) = metering.variants.first() {
+            return &first.dimensions;
+        }
+    }
+
+    &metering.dimensions
+}
+
+pub fn upto_max_usd(metering: &Metering, resolved_price: Option<&ResolvedPrice>) -> f64 {
+    metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.max_usd)
+        .or_else(|| {
+            resolved_price
+                .and_then(|p| p.dimensions.first())
+                .map(|d| d.price_usd / d.scale.max(1) as f64)
+        })
+        .unwrap_or(0.01)
+}
+
+pub fn upto_min_usd(metering: &Metering) -> Option<f64> {
+    metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.min_usd)
+        .or(metering.min_usd)
+}
+
+pub fn upto_missing_usage_policy(metering: &Metering) -> MissingUsagePolicy {
+    metering
+        .upto
+        .as_ref()
+        .map(|upto| upto.missing_usage)
+        .unwrap_or_default()
+}
+
+pub fn upto_uses_response_usage(metering: &Metering, variant_hint: Option<&str>) -> bool {
+    metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.usage_preset.as_deref())
+        .is_some()
+        || effective_dimensions(metering, variant_hint)
+            .iter()
+            .any(|dim| dim.meter.is_some())
+}
+
+pub fn upto_requires_response_body(metering: &Metering, variant_hint: Option<&str>) -> bool {
+    metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.usage_preset.as_deref())
+        .is_some()
+        || effective_dimensions(metering, variant_hint)
+            .iter()
+            .any(|dim| {
+                dim.meter
+                    .as_ref()
+                    .is_some_and(|meter| matches!(meter.source, UsageMeterSource::ResponseJson))
+            })
+}
+
+pub fn upto_response_body_limit(metering: &Metering) -> usize {
+    const DEFAULT_LIMIT: usize = 1024 * 1024;
+    metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.response_body.as_ref())
+        .and_then(|body| body.max_bytes)
+        .unwrap_or(DEFAULT_LIMIT)
+}
+
+pub fn upto_actual_amount_from_response(
+    plan: &UptoSettlementPlan,
+    max_amount: u64,
+    headers: &HeaderMap,
+    body: Option<&[u8]>,
+) -> Result<UptoActualAmount, UptoUsageError> {
+    if plan.ceiling_usd <= 0.0 || max_amount == 0 {
+        return Ok(UptoActualAmount {
+            usd: 0.0,
+            base_units: 0,
+        });
+    }
+
+    let result = extract_and_price_usage(
+        &plan.metering,
+        plan.variant_hint.as_deref(),
+        &plan.request_properties,
+        headers,
+        body,
+    )
+    .map(|actual_usd| clamp_actual_usd(&plan.metering, actual_usd, plan.ceiling_usd));
+
+    let usd = match result {
+        Ok(usd) => usd,
+        Err(err) => match upto_missing_usage_policy(&plan.metering) {
+            MissingUsagePolicy::Refund => 0.0,
+            MissingUsagePolicy::Min => upto_min_usd(&plan.metering)
+                .unwrap_or(0.0)
+                .min(plan.ceiling_usd),
+            MissingUsagePolicy::Ceiling => plan.ceiling_usd,
+            MissingUsagePolicy::Error => {
+                tracing::warn!(error = %err, "x402 upto response usage extraction failed");
+                return Err(UptoUsageError::MissingUsagePolicyError);
+            }
+        },
+    };
+
+    let units_per_usd = max_amount as f64 / plan.ceiling_usd;
+    Ok(UptoActualAmount {
+        usd,
+        base_units: ((usd * units_per_usd).round() as u64).min(max_amount),
+    })
+}
+
+fn clamp_actual_usd(metering: &Metering, actual_usd: f64, ceiling_usd: f64) -> f64 {
+    let with_min = match upto_min_usd(metering) {
+        Some(min_usd) if min_usd >= 0.0 => actual_usd.max(min_usd),
+        _ => actual_usd,
+    };
+    with_min.clamp(0.0, ceiling_usd)
+}
+
+fn extract_and_price_usage(
+    metering: &Metering,
+    variant_hint: Option<&str>,
+    props: &RequestProperties,
+    headers: &HeaderMap,
+    body: Option<&[u8]>,
+) -> Result<f64, UptoUsageError> {
+    let dimensions = effective_dimensions(metering, variant_hint);
+    if dimensions.is_empty() {
+        return Err(UptoUsageError::MissingUsage(
+            "no metering dimensions configured".to_string(),
+        ));
+    }
+
+    let prices = resolve_price(metering, props, variant_hint, None)
+        .ok_or_else(|| UptoUsageError::MissingUsage("no resolved price".to_string()))?;
+    let json = if upto_requires_response_body(metering, variant_hint) {
+        let body =
+            body.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+        Some(
+            serde_json::from_slice::<serde_json::Value>(body)
+                .map_err(|e| UptoUsageError::InvalidJson(e.to_string()))?,
+        )
+    } else {
+        None
+    };
+
+    let preset = metering
+        .upto
+        .as_ref()
+        .and_then(|upto| upto.usage_preset.as_deref());
+    let mut total = 0.0;
+    for (idx, dim) in dimensions.iter().enumerate() {
+        let price = prices
+            .dimensions
+            .get(idx)
+            .map(|d| d.price_usd)
+            .unwrap_or(0.0);
+        let quantity = extract_dimension_quantity(dim, preset, headers, json.as_ref())?;
+        total += quantity as f64 / dim.scale.max(1) as f64 * price;
+    }
+    Ok(total)
+}
+
+fn extract_dimension_quantity(
+    dim: &MeterDimension,
+    preset: Option<&str>,
+    headers: &HeaderMap,
+    json: Option<&serde_json::Value>,
+) -> Result<u64, UptoUsageError> {
+    if let Some(meter) = &dim.meter {
+        return extract_from_meter(meter, headers, json);
+    }
+
+    if let Some(path) = preset_json_path(preset, dim) {
+        let json =
+            json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+        return extract_from_json_pointer(json, path);
+    }
+
+    if matches!(dim.direction, MeterDirection::Usage) && matches!(dim.unit, BillingUnit::Requests) {
+        return Ok(1);
+    }
+
+    Err(UptoUsageError::MissingUsage(format!(
+        "no usage meter for {:?} {:?}",
+        dim.direction, dim.unit
+    )))
+}
+
+fn extract_from_meter(
+    meter: &UsageMeter,
+    headers: &HeaderMap,
+    json: Option<&serde_json::Value>,
+) -> Result<u64, UptoUsageError> {
+    match meter.source {
+        UsageMeterSource::ResponseJson => {
+            let json = json
+                .ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+            let path = meter.path.as_deref().ok_or_else(|| {
+                UptoUsageError::MissingUsage("response_json meter missing path".into())
+            })?;
+            extract_from_json_pointer(json, path)
+        }
+        UsageMeterSource::ResponseHeader => {
+            let name = meter.header.as_deref().ok_or_else(|| {
+                UptoUsageError::MissingUsage("response_header meter missing header".into())
+            })?;
+            let value = headers
+                .get(name)
+                .ok_or_else(|| UptoUsageError::MissingUsage(format!("header `{name}`")))?;
+            let value = value
+                .to_str()
+                .map_err(|e| UptoUsageError::InvalidUsage(e.to_string()))?;
+            parse_usage_quantity(value)
+        }
+    }
+}
+
+fn preset_json_path(preset: Option<&str>, dim: &MeterDimension) -> Option<&'static str> {
+    let preset = preset?;
+    if !preset.eq_ignore_ascii_case("google-generativelanguage") {
+        return None;
+    }
+    match (dim.direction, dim.unit) {
+        (MeterDirection::Input, BillingUnit::Tokens) => Some("/usageMetadata/promptTokenCount"),
+        (MeterDirection::Output, BillingUnit::Tokens) => {
+            Some("/usageMetadata/candidatesTokenCount")
+        }
+        (MeterDirection::Usage, BillingUnit::Tokens) => Some("/usageMetadata/totalTokenCount"),
+        _ => None,
+    }
+}
+
+fn extract_from_json_pointer(json: &serde_json::Value, path: &str) -> Result<u64, UptoUsageError> {
+    let value = json
+        .pointer(path)
+        .ok_or_else(|| UptoUsageError::MissingUsage(format!("json path `{path}`")))?;
+    match value {
+        serde_json::Value::Number(n) => {
+            if let Some(v) = n.as_u64() {
+                Ok(v)
+            } else if let Some(v) = n.as_f64() {
+                if v.is_finite() && v >= 0.0 {
+                    Ok(v.round() as u64)
+                } else {
+                    Err(UptoUsageError::InvalidUsage(format!(
+                        "json path `{path}` is negative or non-finite"
+                    )))
+                }
+            } else {
+                Err(UptoUsageError::InvalidUsage(format!(
+                    "json path `{path}` is not a supported number"
+                )))
+            }
+        }
+        serde_json::Value::String(s) => parse_usage_quantity(s),
+        _ => Err(UptoUsageError::InvalidUsage(format!(
+            "json path `{path}` is not numeric"
+        ))),
+    }
+}
+
+fn parse_usage_quantity(value: &str) -> Result<u64, UptoUsageError> {
+    let trimmed = value.trim();
+    if let Ok(v) = trimmed.parse::<u64>() {
+        return Ok(v);
+    }
+    let v = trimmed
+        .parse::<f64>()
+        .map_err(|e| UptoUsageError::InvalidUsage(e.to_string()))?;
+    if v.is_finite() && v >= 0.0 {
+        Ok(v.round() as u64)
+    } else {
+        Err(UptoUsageError::InvalidUsage(
+            "usage value is negative or non-finite".to_string(),
+        ))
+    }
 }
 
 /// Resolve the effective split rules for a metering config.
@@ -307,6 +641,7 @@ pub(crate) fn evaluate_condition(condition: &MeterCondition, props: &RequestProp
 #[cfg(test)]
 mod tests {
     use super::*;
+    use http::HeaderValue;
 
     #[test]
     fn test_path_matches_exact() {
@@ -630,6 +965,7 @@ mod tests {
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         assert!(resolve_price(&metering, &RequestProperties::default(), None, None).is_none());
     }
@@ -649,12 +985,14 @@ mod tests {
                     notes: None,
                     splits: vec![],
                 }],
+                meter: None,
             }],
             variants: vec![],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         let price = resolve_price(&metering, &RequestProperties::default(), None, None);
         assert!(price.is_some());
@@ -675,6 +1013,7 @@ mod tests {
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         let price = resolve_price(&metering, &RequestProperties::default(), None, None);
         assert!(price.is_some());
@@ -701,6 +1040,7 @@ mod tests {
                             notes: None,
                             splits: vec![],
                         }],
+                        meter: None,
                     }],
                 },
                 MeterVariant {
@@ -718,6 +1058,7 @@ mod tests {
                             notes: None,
                             splits: vec![],
                         }],
+                        meter: None,
                     }],
                 },
             ],
@@ -725,6 +1066,7 @@ mod tests {
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         // Match second variant
         let price = resolve_price(
@@ -756,12 +1098,14 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
             }],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         // No variant hint match → uses first variant as default
         let price = resolve_price(
@@ -801,12 +1145,14 @@ mod tests {
                         splits: vec![],
                     },
                 ],
+                meter: None,
             }],
             variants: vec![],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
 
         // Within condition
@@ -853,12 +1199,14 @@ mod tests {
                         splits: vec![],
                     },
                 ],
+                meter: None,
             }],
             variants: vec![],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
 
         let ctx = MeteringContext {
@@ -878,5 +1226,547 @@ mod tests {
         let price = record_usage(&metering, &RequestProperties::default(), None, &ctx, 60);
         assert!(price.is_some());
         assert_eq!(price.unwrap().dimensions[0].price_usd, 0.01);
+    }
+
+    fn price_tier(price_usd: f64) -> PriceTier {
+        PriceTier {
+            up_to: None,
+            price_usd,
+            condition: None,
+            notes: None,
+            splits: vec![],
+        }
+    }
+
+    fn usage_dim(
+        direction: MeterDirection,
+        unit: BillingUnit,
+        scale: u64,
+        price_usd: f64,
+        meter: Option<UsageMeter>,
+    ) -> MeterDimension {
+        MeterDimension {
+            direction,
+            unit,
+            scale,
+            period: None,
+            tiers: vec![price_tier(price_usd)],
+            meter,
+        }
+    }
+
+    fn upto_metering(
+        dimensions: Vec<MeterDimension>,
+        upto: Option<pay_types::metering::UptoMetering>,
+    ) -> Metering {
+        Metering {
+            dimensions,
+            variants: vec![],
+            sku_tiers: vec![],
+            splits: vec![],
+            schemes: None,
+            min_usd: None,
+            upto,
+        }
+    }
+
+    fn response_json(path: &str) -> UsageMeter {
+        UsageMeter {
+            source: UsageMeterSource::ResponseJson,
+            path: Some(path.to_string()),
+            header: None,
+        }
+    }
+
+    fn response_header(header: &str) -> UsageMeter {
+        UsageMeter {
+            source: UsageMeterSource::ResponseHeader,
+            path: None,
+            header: Some(header.to_string()),
+        }
+    }
+
+    fn settlement_plan(metering: Metering, ceiling_usd: f64) -> UptoSettlementPlan {
+        UptoSettlementPlan {
+            metering,
+            variant_hint: None,
+            request_properties: RequestProperties::default(),
+            ceiling_usd,
+        }
+    }
+
+    #[test]
+    fn upto_max_usd_prefers_explicit_ceiling() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Requests,
+                1,
+                0.01,
+                None,
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+        let price = resolve_price(&metering, &RequestProperties::default(), None, None);
+
+        assert_eq!(upto_max_usd(&metering, price.as_ref()), 0.10);
+    }
+
+    #[test]
+    fn upto_max_usd_keeps_legacy_first_dimension_fallback() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Input,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                None,
+            )],
+            None,
+        );
+        let price = resolve_price(&metering, &RequestProperties::default(), None, None);
+
+        assert_eq!(upto_max_usd(&metering, price.as_ref()), 0.00002);
+    }
+
+    #[test]
+    fn upto_actual_amount_prices_response_json_dimensions() {
+        let metering = upto_metering(
+            vec![
+                usage_dim(
+                    MeterDirection::Input,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.01,
+                    Some(response_json("/usage/input_tokens")),
+                ),
+                usage_dim(
+                    MeterDirection::Output,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.03,
+                    Some(response_json("/usage/output_tokens")),
+                ),
+            ],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                response_body: Some(pay_types::metering::UptoResponseBody {
+                    mode: pay_types::metering::UptoResponseBodyMode::Buffer,
+                    max_bytes: Some(4096),
+                }),
+                ..Default::default()
+            }),
+        );
+        let body = br#"{"usage":{"input_tokens":1000,"output_tokens":500}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.025);
+        assert_eq!(actual.base_units, 25_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_supports_google_generativelanguage_preset() {
+        let metering = upto_metering(
+            vec![
+                usage_dim(
+                    MeterDirection::Input,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.01,
+                    None,
+                ),
+                usage_dim(
+                    MeterDirection::Output,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.03,
+                    None,
+                ),
+            ],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                usage_preset: Some("google-generativelanguage".to_string()),
+                ..Default::default()
+            }),
+        );
+        let body = br#"{"usageMetadata":{"promptTokenCount":2000,"candidatesTokenCount":1000}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_prices_response_header_meter() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_header("x-usage-tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-usage-tokens", HeaderValue::from_static("2500"));
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &headers,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_applies_minimum_and_ceiling_clamps() {
+        let low = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.001,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                min_usd: Some(0.01),
+                ..Default::default()
+            }),
+        );
+        let low_actual = upto_actual_amount_from_response(
+            &settlement_plan(low, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{"tokens":100}}"#),
+        )
+        .unwrap();
+        assert_eq!(low_actual.usd, 0.01);
+        assert_eq!(low_actual.base_units, 10_000);
+
+        let high = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                1.0,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+        let high_actual = upto_actual_amount_from_response(
+            &settlement_plan(high, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{"tokens":1000}}"#),
+        )
+        .unwrap();
+        assert_eq!(high_actual.usd, 0.10);
+        assert_eq!(high_actual.base_units, 100_000);
+    }
+
+    #[test]
+    fn upto_missing_usage_policy_refunds_by_default() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.0);
+        assert_eq!(actual.base_units, 0);
+    }
+
+    #[test]
+    fn upto_missing_usage_policy_can_use_min_or_ceiling_or_error() {
+        let base = vec![usage_dim(
+            MeterDirection::Usage,
+            BillingUnit::Tokens,
+            1_000,
+            0.02,
+            Some(response_json("/usage/tokens")),
+        )];
+
+        let min = upto_metering(
+            base.clone(),
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                min_usd: Some(0.01),
+                missing_usage: MissingUsagePolicy::Min,
+                ..Default::default()
+            }),
+        );
+        let min_actual = upto_actual_amount_from_response(
+            &settlement_plan(min, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{}}"#),
+        )
+        .unwrap();
+        assert_eq!(min_actual.usd, 0.01);
+        assert_eq!(min_actual.base_units, 10_000);
+
+        let ceiling = upto_metering(
+            base.clone(),
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                missing_usage: MissingUsagePolicy::Ceiling,
+                ..Default::default()
+            }),
+        );
+        let ceiling_actual = upto_actual_amount_from_response(
+            &settlement_plan(ceiling, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{}}"#),
+        )
+        .unwrap();
+        assert_eq!(ceiling_actual.usd, 0.10);
+        assert_eq!(ceiling_actual.base_units, 100_000);
+
+        let error = upto_metering(
+            base,
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                missing_usage: MissingUsagePolicy::Error,
+                ..Default::default()
+            }),
+        );
+        let err = upto_actual_amount_from_response(
+            &settlement_plan(error, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{}}"#),
+        )
+        .unwrap_err();
+        assert_eq!(err, UptoUsageError::MissingUsagePolicyError);
+    }
+
+    #[test]
+    fn upto_response_usage_detection_distinguishes_body_and_header_meters() {
+        let json = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering::default()),
+        );
+        assert!(upto_uses_response_usage(&json, None));
+        assert!(upto_requires_response_body(&json, None));
+
+        let header = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_header("x-usage-tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering::default()),
+        );
+        assert!(upto_uses_response_usage(&header, None));
+        assert!(!upto_requires_response_body(&header, None));
+
+        let preset = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Input,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                None,
+            )],
+            Some(pay_types::metering::UptoMetering {
+                usage_preset: Some("google-generativelanguage".to_string()),
+                ..Default::default()
+            }),
+        );
+        assert!(upto_requires_response_body(&preset, None));
+    }
+
+    #[test]
+    fn upto_actual_amount_supports_request_units_without_meter() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Requests,
+                1,
+                0.02,
+                None,
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.02);
+        assert_eq!(actual.base_units, 20_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_accepts_numeric_strings() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{"tokens":"2500"}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_errors_on_bad_json_when_policy_is_error() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Usage,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_json("/usage/tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                missing_usage: MissingUsagePolicy::Error,
+                ..Default::default()
+            }),
+        );
+
+        let err = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":"#),
+        )
+        .unwrap_err();
+
+        assert_eq!(err, UptoUsageError::MissingUsagePolicyError);
+    }
+
+    #[test]
+    fn upto_actual_amount_uses_variant_specific_dimensions() {
+        let metering = Metering {
+            dimensions: vec![],
+            variants: vec![
+                MeterVariant {
+                    param: "model".to_string(),
+                    value: "pro".to_string(),
+                    dimensions: vec![usage_dim(
+                        MeterDirection::Usage,
+                        BillingUnit::Tokens,
+                        1_000,
+                        0.08,
+                        Some(response_json("/usage/tokens")),
+                    )],
+                },
+                MeterVariant {
+                    param: "model".to_string(),
+                    value: "flash".to_string(),
+                    dimensions: vec![usage_dim(
+                        MeterDirection::Usage,
+                        BillingUnit::Tokens,
+                        1_000,
+                        0.02,
+                        Some(response_json("/usage/tokens")),
+                    )],
+                },
+            ],
+            sku_tiers: vec![],
+            splits: vec![],
+            schemes: None,
+            min_usd: None,
+            upto: Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        };
+        let plan = UptoSettlementPlan {
+            metering,
+            variant_hint: Some("models/gemini-flash".to_string()),
+            request_properties: RequestProperties::default(),
+            ceiling_usd: 0.10,
+        };
+
+        let actual = upto_actual_amount_from_response(
+            &plan,
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{"tokens":1000}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.02);
+        assert_eq!(actual.base_units, 20_000);
     }
 }

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -5,7 +5,7 @@
 //! - Payment header → verify with solana-mpp, then forward upstream
 
 use axum::body::Body;
-use axum::http::{HeaderMap, Request, StatusCode};
+use axum::http::{HeaderMap, Request, StatusCode, header};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use pay_kit::mpp::AUTHORIZATION_HEADER;
@@ -103,9 +103,65 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
             // metered amount on success, refund on failure.
             if let Some(uf) = upto {
                 let served_ok = response.status().is_success();
-                let settle_amount = uf.settle_amount;
-                if let Some((n, v)) =
-                    crate::server::gate::settle_upto(&state, *uf.open, settle_amount, served_ok)
+                if let Some(plan) = uf.settlement {
+                    if metering::upto_requires_response_body(
+                        &plan.metering,
+                        plan.variant_hint.as_deref(),
+                    ) {
+                        let limit = metering::upto_response_body_limit(&plan.metering);
+                        let (mut parts, body) = response.into_parts();
+                        match axum::body::to_bytes(body, limit).await {
+                            Ok(bytes) => {
+                                if let Some((n, v)) = crate::server::gate::settle_upto_metered(
+                                    &state,
+                                    *uf.open,
+                                    plan,
+                                    served_ok,
+                                    &parts.headers,
+                                    Some(&bytes),
+                                )
+                                .await
+                                {
+                                    parts.headers.append(n, v);
+                                }
+                                parts.headers.remove(header::CONTENT_LENGTH);
+                                response = Response::from_parts(parts, Body::from(bytes));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "failed to buffer x402 upto response body; refunding"
+                                );
+                                let mut builder =
+                                    Response::builder().status(StatusCode::BAD_GATEWAY);
+                                if let Some((n, v)) =
+                                    crate::server::gate::settle_upto(&state, *uf.open, 0, false)
+                                        .await
+                                {
+                                    builder = builder.header(n, v);
+                                }
+                                response = builder
+                                    .header(header::CONTENT_TYPE, "application/json")
+                                    .body(Body::from(r#"{"error":"response_metering_failed"}"#))
+                                    .unwrap_or_else(|_| {
+                                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                                    });
+                            }
+                        }
+                    } else if let Some((n, v)) = crate::server::gate::settle_upto_metered(
+                        &state,
+                        *uf.open,
+                        plan,
+                        served_ok,
+                        response.headers(),
+                        None,
+                    )
+                    .await
+                    {
+                        response.headers_mut().append(n, v);
+                    }
+                } else if let Some((n, v)) =
+                    crate::server::gate::settle_upto(&state, *uf.open, uf.settle_amount, served_ok)
                         .await
                 {
                     response.headers_mut().append(n, v);

--- a/rust/crates/core/src/server/session_metering.rs
+++ b/rust/crates/core/src/server/session_metering.rs
@@ -706,6 +706,7 @@ mod tests {
                 notes: None,
                 splits: vec![],
             }],
+            meter: None,
         }
     }
 
@@ -717,6 +718,7 @@ mod tests {
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         }
     }
 
@@ -823,6 +825,7 @@ endpoints:
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
 
         let spec = spec_from_metering(
@@ -853,6 +856,7 @@ endpoints:
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
 
         let spec = spec_from_metering(
@@ -893,6 +897,7 @@ endpoints:
                     splits: vec![],
                 },
             ],
+            meter: None,
         }]);
         let props = RequestProperties {
             context_length: Some(250_000),
@@ -931,6 +936,7 @@ endpoints:
                     splits: vec![],
                 },
             ],
+            meter: None,
         }]);
 
         let spec = spec_from_metering(&metering, SessionMeteringContext::new()).unwrap();
@@ -964,6 +970,7 @@ endpoints:
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
 
         let err = spec_from_metering(&metering, SessionMeteringContext::new()).unwrap_err();

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -599,6 +599,7 @@ mod tests {
                 notes: notes.map(str::to_string),
                 splits: vec![],
             }],
+            meter: None,
         }
     }
 
@@ -610,6 +611,7 @@ mod tests {
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         }
     }
 

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -583,7 +583,7 @@ fn do_paid_fetch(
             challenge,
             alternatives,
             x402_alternative,
-            x402_upto_alternative,
+            x402_upto_accepts,
             ..
         } => {
             use pay_core::client::mpp::ChosenPayment;
@@ -592,11 +592,11 @@ fn do_paid_fetch(
             challenges.extend(alternatives);
             // Balance- and cost-aware, cross-scheme pick: settle the cheapest
             // option the wallet can fund across MPP charge, x402 exact, and
-            // x402 upto.
+            // every advertised x402 upto currency.
             let chosen = pay_core::client::mpp::choose_payment(
                 &challenges,
                 x402_alternative.as_deref(),
-                x402_upto_alternative.as_deref(),
+                &x402_upto_accepts,
                 &store,
                 network_override.as_deref(),
                 account_override.as_deref(),

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -583,17 +583,20 @@ fn do_paid_fetch(
             challenge,
             alternatives,
             x402_alternative,
+            x402_upto_alternative,
             ..
         } => {
             use pay_core::client::mpp::ChosenPayment;
             let mut challenges = Vec::with_capacity(1 + alternatives.len());
             challenges.push((*challenge).clone());
             challenges.extend(alternatives);
-            // Balance-aware, cross-protocol pick: settle the MPP charge the
-            // wallet can fund, or fall back to an x402 offer it can fund.
+            // Balance- and cost-aware, cross-scheme pick: settle the cheapest
+            // option the wallet can fund across MPP charge, x402 exact, and
+            // x402 upto.
             let chosen = pay_core::client::mpp::choose_payment(
                 &challenges,
                 x402_alternative.as_deref(),
+                x402_upto_alternative.as_deref(),
                 &store,
                 network_override.as_deref(),
                 account_override.as_deref(),
@@ -620,6 +623,21 @@ fn do_paid_fetch(
                         account_override.as_deref(),
                         Some(url),
                         make_auth_override(),
+                    )?;
+                    headers.extend(
+                        built_payment
+                            .headers
+                            .into_iter()
+                            .map(|(name, value)| (name.to_string(), value)),
+                    );
+                }
+                ChosenPayment::X402Upto(challenge) => {
+                    let built_payment = pay_core::client::x402::build_upto_payment(
+                        challenge.as_ref(),
+                        &store,
+                        network_override.as_deref(),
+                        account_override.as_deref(),
+                        Some(url),
                     )?;
                     headers.extend(
                         built_payment

--- a/rust/crates/proxy/Cargo.toml
+++ b/rust/crates/proxy/Cargo.toml
@@ -27,8 +27,10 @@ pay-core = { workspace = true, features = ["server"] }
 pay-types = { workspace = true }
 pay-kit = { workspace = true }
 axum = { workspace = true }
+reqwest = { workspace = true }
 http = "1"
 async-trait = "0.1"
 bytes = "1"
 anyhow = "1"
+futures-util = "0.3"
 tracing = { workspace = true }

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -499,10 +499,13 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                 ctx.receipt = receipt;
                 // x402 `upto`: the channel is open; hold it for post-response
                 // settlement (response_filter on success, logging on failure).
-                ctx.upto = upto.map(|u| PendingUpto {
-                    open: *u.open,
-                    settle_amount: u.settle_amount,
-                    settlement: u.settlement,
+                ctx.upto = upto.map(|u| {
+                    let u = *u;
+                    PendingUpto {
+                        open: *u.open,
+                        settle_amount: u.settle_amount,
+                        settlement: u.settlement,
+                    }
                 });
                 if ctx.upto.as_ref().is_some_and(|pending| {
                     pending.settlement.as_ref().is_some_and(|plan| {

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -891,61 +891,6 @@ async fn write_buffered_response(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{buffered_upstream_headers, filtered_response_headers};
-
-    #[test]
-    fn buffered_upstream_headers_force_identity_encoding() {
-        let headers = buffered_upstream_headers(&[
-            ("accept-encoding".to_string(), "br, gzip".to_string()),
-            ("content-type".to_string(), "application/json".to_string()),
-        ]);
-
-        assert_eq!(
-            headers
-                .iter()
-                .filter(|(name, _)| name.eq_ignore_ascii_case("accept-encoding"))
-                .count(),
-            1
-        );
-        assert!(headers.iter().any(|(name, value)| {
-            name.eq_ignore_ascii_case("accept-encoding") && value == "identity"
-        }));
-        assert!(headers.iter().any(|(name, value)| {
-            name.eq_ignore_ascii_case("content-type") && value == "application/json"
-        }));
-    }
-
-    #[test]
-    fn filtered_response_headers_preserve_content_encoding() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::CONTENT_ENCODING,
-            reqwest::header::HeaderValue::from_static("gzip"),
-        );
-        headers.insert(
-            reqwest::header::CONTENT_LENGTH,
-            reqwest::header::HeaderValue::from_static("123"),
-        );
-        headers.insert(
-            reqwest::header::TRANSFER_ENCODING,
-            reqwest::header::HeaderValue::from_static("chunked"),
-        );
-
-        let filtered = filtered_response_headers(&headers);
-
-        assert_eq!(
-            filtered
-                .get(http::header::CONTENT_ENCODING)
-                .and_then(|value| value.to_str().ok()),
-            Some("gzip")
-        );
-        assert!(!filtered.contains_key(http::header::CONTENT_LENGTH));
-        assert!(!filtered.contains_key(http::header::TRANSFER_ENCODING));
-    }
-}
-
 /// Write a gate-produced [`GateResponse`] (402 challenge, 404, receipt JSON, …)
 /// directly to the downstream and stop. Duplicate `WWW-Authenticate` lines are
 /// preserved via `append_header`.
@@ -1007,4 +952,59 @@ async fn write_axum_response(
     session.write_response_header(Box::new(out), false).await?;
     session.write_response_body(Some(body), true).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{buffered_upstream_headers, filtered_response_headers};
+
+    #[test]
+    fn buffered_upstream_headers_force_identity_encoding() {
+        let headers = buffered_upstream_headers(&[
+            ("accept-encoding".to_string(), "br, gzip".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+
+        assert_eq!(
+            headers
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case("accept-encoding"))
+                .count(),
+            1
+        );
+        assert!(headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("accept-encoding") && value == "identity"
+        }));
+        assert!(headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("content-type") && value == "application/json"
+        }));
+    }
+
+    #[test]
+    fn filtered_response_headers_preserve_content_encoding() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            reqwest::header::HeaderValue::from_static("gzip"),
+        );
+        headers.insert(
+            reqwest::header::CONTENT_LENGTH,
+            reqwest::header::HeaderValue::from_static("123"),
+        );
+        headers.insert(
+            reqwest::header::TRANSFER_ENCODING,
+            reqwest::header::HeaderValue::from_static("chunked"),
+        );
+
+        let filtered = filtered_response_headers(&headers);
+
+        assert_eq!(
+            filtered
+                .get(http::header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
+            Some("gzip")
+        );
+        assert!(!filtered.contains_key(http::header::CONTENT_LENGTH));
+        assert!(!filtered.contains_key(http::header::TRANSFER_ENCODING));
+    }
 }

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -23,12 +23,15 @@
 //!   open/voucher/close (all request-side, in the gate) work.
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
+use futures_util::StreamExt;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use pay_core::PaymentState;
 use pay_core::server::gate::{
     GateDecision, GateRequest, GateResponse, PaymentGate, ReceiptAnnotation, settle_upto,
+    settle_upto_metered,
 };
+use pay_core::server::metering::{self, UptoSettlementPlan};
 use pay_core::server::proxy::{
     STRIP_HEADERS, UpstreamPlan, prepare_upstream, routing_signs_request_body,
 };
@@ -37,6 +40,9 @@ use pay_types::metering::ApiSpec;
 use pingora::http::{RequestHeader, ResponseHeader};
 use pingora::proxy::{ProxyHttp, Session};
 use pingora::upstreams::peer::HttpPeer;
+
+const BUFFERED_REQUEST_BODY_LIMIT: usize = 16 * 1024 * 1024;
+const DEFAULT_RESPONSE_BODY_LIMIT: usize = 1024 * 1024;
 
 /// Where a non-`Respond` request should be proxied.
 enum Target {
@@ -60,13 +66,18 @@ pub struct Ctx {
     receipt: Option<ReceiptAnnotation>,
     /// An x402 `upto` channel opened pre-serve, settled in `response_filter`
     /// (debit on success) or `logging` (refund when the upstream never
-    /// responded). Taken when settled, so it's never double-settled. The `u64`
-    /// is the success voucher amount (configured `min`, or full ceiling).
-    upto: Option<(VerifiedUptoOpen, u64)>,
+    /// responded). Taken when settled, so it's never double-settled.
+    upto: Option<PendingUpto>,
     /// Captured at `request_filter` for the Payment Debugger exchange emitted
     /// in `logging` (the data plane is Pingora, so the old axum logging
     /// middleware never sees proxied traffic).
     log: Option<LogStart>,
+}
+
+struct PendingUpto {
+    open: VerifiedUptoOpen,
+    settle_amount: u64,
+    settlement: Option<UptoSettlementPlan>,
 }
 
 /// Request-side facts captured up front for the PDB exchange.
@@ -216,9 +227,22 @@ impl<S: PaymentState> Http402Gate<S> {
         ctx: &mut Ctx,
         served_ok: bool,
     ) -> Vec<(HeaderName, HeaderValue)> {
+        self.drain_payment_headers_with_response(ctx, served_ok, &HeaderMap::new(), None)
+            .await
+    }
+
+    async fn drain_payment_headers_with_response(
+        &self,
+        ctx: &mut Ctx,
+        served_ok: bool,
+        response_headers: &HeaderMap,
+        response_body: Option<&[u8]>,
+    ) -> Vec<(HeaderName, HeaderValue)> {
         let mut extra: Vec<(HeaderName, HeaderValue)> = Vec::new();
-        if let Some((open, amt)) = ctx.upto.take()
-            && let Some((n, v)) = settle_upto(&self.state, open, amt, served_ok).await
+        if let Some(pending) = ctx.upto.take()
+            && let Some((n, v)) = self
+                .settle_pending_upto(pending, served_ok, response_headers, response_body)
+                .await
         {
             extra.push((n, v));
         }
@@ -229,6 +253,179 @@ impl<S: PaymentState> Http402Gate<S> {
             }
         }
         extra
+    }
+
+    async fn settle_pending_upto(
+        &self,
+        pending: PendingUpto,
+        served_ok: bool,
+        response_headers: &HeaderMap,
+        response_body: Option<&[u8]>,
+    ) -> Option<(HeaderName, HeaderValue)> {
+        match pending.settlement {
+            Some(plan) => {
+                settle_upto_metered(
+                    &self.state,
+                    pending.open,
+                    plan,
+                    served_ok,
+                    response_headers,
+                    response_body,
+                )
+                .await
+            }
+            None => settle_upto(&self.state, pending.open, pending.settle_amount, served_ok).await,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn forward_upto_buffered(
+        &self,
+        session: &mut Session,
+        ctx: &mut Ctx,
+        path: &str,
+        host: Option<&str>,
+        method: &http::Method,
+        uri: &Uri,
+        headers: &http::HeaderMap,
+    ) -> pingora::Result<bool> {
+        let Some(api) = self.resolve_api(host.unwrap_or("")) else {
+            let extra = self.drain_payment_headers(ctx, false).await;
+            write_buffered_response(
+                session,
+                StatusCode::NOT_FOUND,
+                HeaderMap::new(),
+                Bytes::from_static(b"{\"error\":\"not_found\"}"),
+                extra,
+            )
+            .await?;
+            return Ok(true);
+        };
+
+        let body = match read_downstream_body(session, BUFFERED_REQUEST_BODY_LIMIT).await {
+            Ok(body) => body,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to buffer request body for x402 upto");
+                let extra = self.drain_payment_headers(ctx, false).await;
+                write_buffered_response(
+                    session,
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    HeaderMap::new(),
+                    Bytes::from_static(b"{\"error\":\"request_body_too_large\"}"),
+                    extra,
+                )
+                .await?;
+                return Ok(true);
+            }
+        };
+
+        let prepared = match prepare_upstream(api, method, uri, headers, body.as_ref()).await {
+            Ok(UpstreamPlan::Respond(resp)) => {
+                self.finish_buffered_axum_response(session, ctx, resp)
+                    .await?;
+                return Ok(true);
+            }
+            Ok(UpstreamPlan::Forward(prepared)) => prepared,
+            Err(resp) => {
+                self.finish_buffered_axum_response(session, ctx, resp)
+                    .await?;
+                return Ok(true);
+            }
+        };
+
+        let response_limit = ctx
+            .upto
+            .as_ref()
+            .and_then(|pending| pending.settlement.as_ref())
+            .map(|plan| metering::upto_response_body_limit(&plan.metering))
+            .unwrap_or(DEFAULT_RESPONSE_BODY_LIMIT);
+
+        let client = reqwest::Client::new();
+        let mut upstream_req = client.request(
+            reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap(),
+            prepared.url.clone(),
+        );
+        for (name, value) in &prepared.headers {
+            upstream_req = upstream_req.header(name.as_str(), value);
+        }
+        if !body.is_empty() {
+            upstream_req = upstream_req.body(body.to_vec());
+        } else if matches!(method.as_str(), "POST" | "PUT" | "PATCH") {
+            upstream_req = upstream_req.header("content-length", "0");
+        }
+
+        let upstream = match upstream_req.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                tracing::error!(error = %e, upstream = %prepared.url, "buffered upstream request failed");
+                let extra = self.drain_payment_headers(ctx, false).await;
+                write_buffered_response(
+                    session,
+                    StatusCode::BAD_GATEWAY,
+                    HeaderMap::new(),
+                    Bytes::from_static(b"{\"error\":\"upstream_unavailable\"}"),
+                    extra,
+                )
+                .await?;
+                return Ok(true);
+            }
+        };
+
+        let status = StatusCode::from_u16(upstream.status().as_u16())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let response_headers = filtered_response_headers(upstream.headers());
+        let body = match collect_reqwest_body(upstream, response_limit).await {
+            Ok(body) => body,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to buffer response body for x402 upto");
+                let extra = self.drain_payment_headers(ctx, false).await;
+                write_buffered_response(
+                    session,
+                    StatusCode::BAD_GATEWAY,
+                    HeaderMap::new(),
+                    Bytes::from_static(b"{\"error\":\"response_metering_failed\"}"),
+                    extra,
+                )
+                .await?;
+                return Ok(true);
+            }
+        };
+
+        let extra = self
+            .drain_payment_headers_with_response(
+                ctx,
+                status.is_success(),
+                &response_headers,
+                Some(&body),
+            )
+            .await;
+        write_buffered_response(session, status, response_headers, body, extra).await?;
+        tracing::debug!(
+            path,
+            "served x402 upto via buffered response-metered proxy path"
+        );
+        Ok(true)
+    }
+
+    async fn finish_buffered_axum_response(
+        &self,
+        session: &mut Session,
+        ctx: &mut Ctx,
+        resp: axum::response::Response,
+    ) -> pingora::Result<()> {
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let body = match axum::body::to_bytes(resp.into_body(), DEFAULT_RESPONSE_BODY_LIMIT).await {
+            Ok(body) => body,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to buffer inline response for x402 upto");
+                Bytes::new()
+            }
+        };
+        let extra = self
+            .drain_payment_headers_with_response(ctx, status.is_success(), &headers, Some(&body))
+            .await;
+        write_buffered_response(session, status, headers, body, extra).await
     }
 }
 
@@ -302,7 +499,31 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                 ctx.receipt = receipt;
                 // x402 `upto`: the channel is open; hold it for post-response
                 // settlement (response_filter on success, logging on failure).
-                ctx.upto = upto.map(|u| (*u.open, u.settle_amount));
+                ctx.upto = upto.map(|u| PendingUpto {
+                    open: *u.open,
+                    settle_amount: u.settle_amount,
+                    settlement: u.settlement,
+                });
+                if ctx.upto.as_ref().is_some_and(|pending| {
+                    pending.settlement.as_ref().is_some_and(|plan| {
+                        metering::upto_requires_response_body(
+                            &plan.metering,
+                            plan.variant_hint.as_deref(),
+                        )
+                    })
+                }) {
+                    return self
+                        .forward_upto_buffered(
+                            session,
+                            ctx,
+                            &path,
+                            host.as_deref(),
+                            &method,
+                            &uri,
+                            &headers,
+                        )
+                        .await;
+                }
                 // A verified payment must reach the real upstream — never the
                 // control-plane axum (`control_plane_ok = false`), even for a
                 // root (`path: ""`) endpoint.
@@ -403,9 +624,12 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
         // on a 2xx, refund otherwise) and attach the PAYMENT-RESPONSE receipt
         // before the response streams downstream. `take` so `logging` won't
         // double-settle.
-        if let Some((open, amt)) = ctx.upto.take() {
+        if let Some(pending) = ctx.upto.take() {
             let served_ok = upstream_response.status.is_success();
-            if let Some((name, value)) = settle_upto(&self.state, open, amt, served_ok).await {
+            if let Some((name, value)) = self
+                .settle_pending_upto(pending, served_ok, &upstream_response.headers, None)
+                .await
+            {
                 let _ = upstream_response.insert_header(name, value);
             }
         }
@@ -423,8 +647,10 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
         // An x402 `upto` channel still held here means `response_filter` never
         // ran (the upstream connect/response failed) — refund the full deposit
         // so the client's funds aren't stranded in an open channel.
-        if let Some((open, amt)) = ctx.upto.take() {
-            let _ = settle_upto(&self.state, open, amt, false).await;
+        if let Some(pending) = ctx.upto.take() {
+            let _ = self
+                .settle_pending_upto(pending, false, &HeaderMap::new(), None)
+                .await;
         }
         let Some(log) = ctx.log.take() else {
             return;
@@ -572,6 +798,85 @@ fn target_from_prepared(prepared: pay_core::server::proxy::PreparedUpstreamReque
         path_and_query,
         headers: prepared.headers,
     }
+}
+
+async fn read_downstream_body(session: &mut Session, limit: usize) -> pingora::Result<Bytes> {
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = session.read_request_body().await? {
+        if buf.len().saturating_add(chunk.len()) > limit {
+            return Err(pingora::Error::explain(
+                pingora::ErrorType::HTTPStatus(413),
+                "buffered request body too large",
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}
+
+async fn collect_reqwest_body(response: reqwest::Response, limit: usize) -> anyhow::Result<Bytes> {
+    if let Some(content_length) = response.content_length()
+        && content_length as usize > limit
+    {
+        anyhow::bail!("response body exceeds configured limit");
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut buf = BytesMut::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if buf.len().saturating_add(chunk.len()) > limit {
+            anyhow::bail!("response body exceeds configured limit");
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}
+
+fn filtered_response_headers(headers: &reqwest::header::HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::new();
+    for (name, value) in headers {
+        let name_lower = name.as_str();
+        if matches!(
+            name_lower,
+            "content-encoding" | "content-length" | "transfer-encoding"
+        ) {
+            continue;
+        }
+        if let (Ok(n), Ok(v)) = (
+            HeaderName::from_bytes(name.as_str().as_bytes()),
+            HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            out.insert(n, v);
+        }
+    }
+    out
+}
+
+async fn write_buffered_response(
+    session: &mut Session,
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Bytes,
+    extra: Vec<(HeaderName, HeaderValue)>,
+) -> pingora::Result<()> {
+    let mut out = ResponseHeader::build(status.as_u16(), None)?;
+    for (n, v) in headers {
+        let Some(n) = n else {
+            continue;
+        };
+        if n.as_str().eq_ignore_ascii_case("content-length") {
+            continue;
+        }
+        out.append_header(n, v)?;
+    }
+    for (n, v) in extra {
+        let _ = out.append_header(n, v);
+    }
+    out.insert_header("content-length", body.len().to_string())?;
+    session.write_response_header(Box::new(out), false).await?;
+    session.write_response_body(Some(body), true).await?;
+    Ok(())
 }
 
 /// Write a gate-produced [`GateResponse`] (402 challenge, 404, receipt JSON, …)

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -345,7 +345,7 @@ impl<S: PaymentState> Http402Gate<S> {
             reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap(),
             prepared.url.clone(),
         );
-        for (name, value) in &prepared.headers {
+        for (name, value) in buffered_upstream_headers(&prepared.headers) {
             upstream_req = upstream_req.header(name.as_str(), value);
         }
         if !body.is_empty() {
@@ -803,6 +803,18 @@ fn target_from_prepared(prepared: pay_core::server::proxy::PreparedUpstreamReque
     }
 }
 
+fn buffered_upstream_headers(headers: &[(String, String)]) -> Vec<(String, String)> {
+    let mut out = Vec::with_capacity(headers.len() + 1);
+    for (name, value) in headers {
+        if name.eq_ignore_ascii_case("accept-encoding") {
+            continue;
+        }
+        out.push((name.clone(), value.clone()));
+    }
+    out.push(("accept-encoding".to_string(), "identity".to_string()));
+    out
+}
+
 async fn read_downstream_body(session: &mut Session, limit: usize) -> pingora::Result<Bytes> {
     let mut buf = BytesMut::new();
     while let Some(chunk) = session.read_request_body().await? {
@@ -840,10 +852,7 @@ fn filtered_response_headers(headers: &reqwest::header::HeaderMap) -> HeaderMap 
     let mut out = HeaderMap::new();
     for (name, value) in headers {
         let name_lower = name.as_str();
-        if matches!(
-            name_lower,
-            "content-encoding" | "content-length" | "transfer-encoding"
-        ) {
+        if matches!(name_lower, "content-length" | "transfer-encoding") {
             continue;
         }
         if let (Ok(n), Ok(v)) = (
@@ -880,6 +889,61 @@ async fn write_buffered_response(
     session.write_response_header(Box::new(out), false).await?;
     session.write_response_body(Some(body), true).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{buffered_upstream_headers, filtered_response_headers};
+
+    #[test]
+    fn buffered_upstream_headers_force_identity_encoding() {
+        let headers = buffered_upstream_headers(&[
+            ("accept-encoding".to_string(), "br, gzip".to_string()),
+            ("content-type".to_string(), "application/json".to_string()),
+        ]);
+
+        assert_eq!(
+            headers
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case("accept-encoding"))
+                .count(),
+            1
+        );
+        assert!(headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("accept-encoding") && value == "identity"
+        }));
+        assert!(headers.iter().any(|(name, value)| {
+            name.eq_ignore_ascii_case("content-type") && value == "application/json"
+        }));
+    }
+
+    #[test]
+    fn filtered_response_headers_preserve_content_encoding() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::CONTENT_ENCODING,
+            reqwest::header::HeaderValue::from_static("gzip"),
+        );
+        headers.insert(
+            reqwest::header::CONTENT_LENGTH,
+            reqwest::header::HeaderValue::from_static("123"),
+        );
+        headers.insert(
+            reqwest::header::TRANSFER_ENCODING,
+            reqwest::header::HeaderValue::from_static("chunked"),
+        );
+
+        let filtered = filtered_response_headers(&headers);
+
+        assert_eq!(
+            filtered
+                .get(http::header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok()),
+            Some("gzip")
+        );
+        assert!(!filtered.contains_key(http::header::CONTENT_LENGTH));
+        assert!(!filtered.contains_key(http::header::TRANSFER_ENCODING));
+    }
 }
 
 /// Write a gate-produced [`GateResponse`] (402 challenge, 404, receipt JSON, …)

--- a/rust/crates/types/Cargo.toml
+++ b/rust/crates/types/Cargo.toml
@@ -9,8 +9,9 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # Single source of truth for stablecoin mint addresses — pay-types re-exports
-# pay-kit's core registry rather than maintaining its own copy.
-solana-pay-core = { workspace = true }
+# pay-kit's core registry rather than maintaining its own copy. (pay-kit
+# consolidated into one crate; the registry now lives at `pay_kit::core::mints`.)
+pay-kit = { workspace = true }
 
 [dev-dependencies]
 serde_yml = { workspace = true }

--- a/rust/crates/types/src/lib.rs
+++ b/rust/crates/types/src/lib.rs
@@ -7,12 +7,12 @@ pub mod splits;
 
 /// Well-known mint addresses for supported Solana stablecoins.
 ///
-/// Re-exported from pay-kit's shared base crate (`solana_pay_core::mints`) so
+/// Re-exported from pay-kit's shared core module (`pay_kit::core::mints`) so
 /// there is a single source of truth for mint addresses across the client and
 /// both protocol SDKs. Do not hard-code addresses here — add them upstream in
-/// pay-kit's core crate instead.
+/// pay-kit's core module instead.
 pub mod stablecoin_mints {
-    pub use solana_pay_core::mints::{
+    pub use pay_kit::core::mints::{
         CASH_MAINNET, PYUSD_DEVNET, PYUSD_MAINNET, PYUSD_TESTNET, USDC_DEVNET, USDC_MAINNET,
         USDC_TESTNET, USDG_MAINNET, USDPT_MAINNET, USDT_MAINNET,
     };

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -1366,14 +1366,16 @@ pub fn validate_api_spec(spec: &ApiSpec) -> Vec<String> {
         validate_tier_splits(metering, &spec.recipients, path, &mut errs);
         // Session-capable endpoints settle through a channel that forbids
         // duplicate split recipients; charge endpoints allow a repeated
-        // recipient only when each leg carries a distinct memo. A top-level
-        // `session:` block (or any session scheme) makes the endpoint
-        // session-capable.
-        let has_session_scheme = spec.session.is_some()
-            || metering
-                .schemes
-                .as_ref()
-                .is_some_and(|schemes| schemes.iter().any(|s| s.is_session()));
+        // recipient only when each leg carries a distinct memo. When endpoint
+        // schemes are omitted, a top-level `session:` block makes the endpoint
+        // session-capable via defaults; explicit schemes can still opt into
+        // charge-only routing.
+        let has_session_scheme = metering
+            .schemes
+            .as_ref()
+            .map_or(spec.session.is_some(), |schemes| {
+                schemes.iter().any(|s| s.is_session())
+            });
         validate_split_recipient_uniqueness(
             metering,
             &spec.recipients,
@@ -1952,13 +1954,15 @@ fn validate_session_splits(
     for rule in &session.splits {
         let ctx = format!("session split `{}`", rule.recipient);
 
-        if rule.amount.is_some() {
+        let amount_set = rule.amount.is_some();
+        if amount_set {
             errs.push(format!(
                 "{ctx}: session channel splits must use `percent`, not `amount`"
             ));
         }
         match rule.percent {
-            None => errs.push(format!("{ctx}: must set `percent`")),
+            None if !amount_set => errs.push(format!("{ctx}: must set `percent`")),
+            None => {}
             Some(p) if !p.is_finite() || p <= 0.0 => {
                 errs.push(format!(
                     "{ctx}: `percent` must be a positive, finite number"
@@ -3254,6 +3258,39 @@ mod tests {
     }
 
     #[test]
+    fn validate_charge_only_endpoint_uses_charge_rules_with_top_level_session() {
+        let mut spec = spec_with_splits(
+            Some(vec![Scheme::MppCharge]),
+            vec![
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("platform fee".into()),
+                },
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("referral".into()),
+                },
+            ],
+        );
+        spec.session = Some(SessionSpec {
+            cap_usdc: 10.0,
+            min_voucher_delta: 0,
+            modes: vec![],
+            pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
+            batch_open_interval_ms: 400,
+            close_delay_ms: 15_000,
+            splits: vec![],
+        });
+
+        let errs = validate_api_spec(&spec);
+        assert!(errs.is_empty(), "expected charge-only rules, got: {errs:?}");
+    }
+
+    #[test]
     fn validate_charge_rejects_duplicate_recipient_same_memo() {
         // Charge scheme + same recipient AND same memo → reject (indistinguishable legs).
         let spec = spec_with_splits(
@@ -3307,6 +3344,10 @@ mod tests {
         assert!(
             errs.iter().any(|e| e.contains("must use `percent`")),
             "got: {errs:?}"
+        );
+        assert!(
+            !errs.iter().any(|e| e.contains("must set `percent`")),
+            "amount-only split should not emit a redundant missing-percent error: {errs:?}"
         );
     }
 

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -1038,6 +1038,23 @@ pub enum Scheme {
     X402BatchSettlement,
 }
 
+impl Scheme {
+    /// Whether this scheme settles through an on-chain payment channel.
+    ///
+    /// Channel/session schemes commit a `distributionSplits` preimage that the
+    /// program rejects when it contains duplicate recipients
+    /// (draft-solana-session-00, § Distribution Splits), so split recipients
+    /// must be unique. Charge schemes emit one transfer leg per split and allow
+    /// a recipient to repeat, disambiguated by memo (draft-solana-charge-00,
+    /// § splits).
+    pub fn is_session(self) -> bool {
+        matches!(
+            self,
+            Self::MppSession | Self::X402Upto | Self::X402BatchSettlement
+        )
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Metering {
     /// Direct pricing dimensions (when there's a single pricing model).
@@ -1347,7 +1364,29 @@ pub fn validate_api_spec(spec: &ApiSpec) -> Vec<String> {
         validate_split_recipients(metering, &spec.recipients, path, &mut errs);
         validate_split_rules(metering, path, &mut errs);
         validate_tier_splits(metering, &spec.recipients, path, &mut errs);
+        // Session-capable endpoints settle through a channel that forbids
+        // duplicate split recipients; charge endpoints allow a repeated
+        // recipient only when each leg carries a distinct memo. A top-level
+        // `session:` block (or any session scheme) makes the endpoint
+        // session-capable.
+        let has_session_scheme = spec.session.is_some()
+            || metering
+                .schemes
+                .as_ref()
+                .is_some_and(|schemes| schemes.iter().any(|s| s.is_session()));
+        validate_split_recipient_uniqueness(
+            metering,
+            &spec.recipients,
+            has_session_scheme,
+            path,
+            &mut errs,
+        );
         validate_price_precision(metering, path, &mut errs);
+    }
+
+    // Channel distribution splits from a top-level `session:` block.
+    if let Some(session) = &spec.session {
+        validate_session_splits(session, &spec.recipients, &mut errs);
     }
 
     errs
@@ -1804,6 +1843,160 @@ fn validate_tier_splits(
                 }
             }
         }
+    }
+}
+
+/// Enforce per-method split-recipient uniqueness at load time, so a
+/// misconfigured spec fails fast with a clear message instead of a runtime
+/// `challenge_generation_failed` 500 (charge) or an on-chain channel `open`
+/// rejection (session).
+///
+/// - **Session** endpoints settle through a payment channel whose
+///   `distributionSplits` preimage rejects duplicate recipients
+///   (draft-solana-session-00). Uniqueness key: the **recipient account**.
+/// - **Charge** endpoints emit one transfer leg per split and allow a recipient
+///   to repeat, disambiguated by memo (draft-solana-charge-00). Uniqueness key:
+///   **(recipient account, memo)**.
+///
+/// Recipients are compared by their *resolved account*, not alias name, so two
+/// distinct aliases pointing at the same wallet are treated as one recipient.
+/// `${VAR}` accounts are compared by their literal template (runtime values are
+/// unknown at load time). The metering-level splits and each tier's override
+/// splits are checked independently — only one set is committed per transaction.
+fn validate_split_recipient_uniqueness(
+    metering: &Metering,
+    recipients: &std::collections::HashMap<String, RecipientAlias>,
+    has_session_scheme: bool,
+    path: &str,
+    errs: &mut Vec<String>,
+) {
+    let account_of = |alias: &str| -> String {
+        recipients
+            .get(alias)
+            .map(|a| a.account.clone())
+            .unwrap_or_else(|| alias.to_string())
+    };
+
+    let mut split_sets: Vec<(String, &[SplitRule])> =
+        vec![(String::new(), metering.splits.as_slice())];
+    for dim in &metering.dimensions {
+        let scale = dim.scale.max(1) as f64;
+        for tier in &dim.tiers {
+            if !tier.splits.is_empty() {
+                split_sets.push((
+                    format!(" (tier ${:.6}/unit)", tier.price_usd / scale),
+                    tier.splits.as_slice(),
+                ));
+            }
+        }
+    }
+
+    for (label, splits) in split_sets {
+        if has_session_scheme {
+            let mut seen: Vec<String> = Vec::new();
+            for split in splits {
+                let account = account_of(&split.recipient);
+                if seen.contains(&account) {
+                    errs.push(format!(
+                        "endpoint `{path}`{label}: session payments require unique split \
+                         recipients, but account `{account}` (recipient `{}`) appears more than \
+                         once — the on-chain payment channel rejects duplicate `distributionSplits` \
+                         recipients. Aggregate these into a single split.",
+                        split.recipient
+                    ));
+                } else {
+                    seen.push(account);
+                }
+            }
+        } else {
+            let mut seen: Vec<(String, String)> = Vec::new();
+            for split in splits {
+                let account = account_of(&split.recipient);
+                let memo = split.memo.clone().unwrap_or_default();
+                let key = (account.clone(), memo.clone());
+                if seen.contains(&key) {
+                    let memo_desc = if memo.is_empty() {
+                        "no memo".to_string()
+                    } else {
+                        format!("memo `{memo}`")
+                    };
+                    errs.push(format!(
+                        "endpoint `{path}`{label}: charge split recipient `{}` (account \
+                         `{account}`) repeats with the same {memo_desc} — each leg sharing a \
+                         recipient must have a distinct memo so it can be verified separately.",
+                        split.recipient
+                    ));
+                } else {
+                    seen.push(key);
+                }
+            }
+        }
+    }
+}
+
+/// Validate the channel distribution splits in a top-level `session:` block.
+///
+/// These commit to the on-chain channel at `open`, which requires percentage
+/// shares that leave a positive payee remainder and a set of **unique**
+/// recipients (draft-solana-session-00). Centralizing the rules here keeps
+/// [`validate_api_spec`] the single source of truth — the boot-time resolver
+/// then only has to transform already-valid splits.
+fn validate_session_splits(
+    session: &SessionSpec,
+    recipients: &std::collections::HashMap<String, RecipientAlias>,
+    errs: &mut Vec<String>,
+) {
+    let mut total_bps: u32 = 0;
+    let mut seen: Vec<String> = Vec::new();
+
+    for rule in &session.splits {
+        let ctx = format!("session split `{}`", rule.recipient);
+
+        if rule.amount.is_some() {
+            errs.push(format!(
+                "{ctx}: session channel splits must use `percent`, not `amount`"
+            ));
+        }
+        match rule.percent {
+            None => errs.push(format!("{ctx}: must set `percent`")),
+            Some(p) if !p.is_finite() || p <= 0.0 => {
+                errs.push(format!(
+                    "{ctx}: `percent` must be a positive, finite number"
+                ));
+            }
+            Some(p) => {
+                let bps = (p * 100.0).round();
+                if !(1.0..10_000.0).contains(&bps) {
+                    errs.push(format!(
+                        "{ctx}: `percent` must convert to 1..9999 basis points"
+                    ));
+                } else {
+                    total_bps += bps as u32;
+                }
+            }
+        }
+
+        match recipients.get(&rule.recipient) {
+            None => errs.push(format!("{ctx}: references unknown recipient")),
+            Some(alias) => {
+                if seen.contains(&alias.account) {
+                    errs.push(format!(
+                        "{ctx}: session payments require unique split recipients, but account \
+                         `{}` appears more than once — aggregate these into a single split.",
+                        alias.account
+                    ));
+                } else {
+                    seen.push(alias.account.clone());
+                }
+            }
+        }
+    }
+
+    if total_bps >= 10_000 {
+        errs.push(
+            "session splits must leave a positive primary recipient share (total < 100%)"
+                .to_string(),
+        );
     }
 }
 
@@ -2944,6 +3137,222 @@ mod tests {
         let errs = validate_api_spec(&spec);
         assert_eq!(errs.len(), 1);
         assert!(errs[0].contains("tier splits total"));
+    }
+
+    /// Build a single-endpoint spec with metering-level `splits` and the given
+    /// accepted `schemes`, for split-recipient-uniqueness tests.
+    fn spec_with_splits(schemes: Option<Vec<Scheme>>, splits: Vec<SplitRule>) -> ApiSpec {
+        test_spec(vec![Endpoint {
+            method: HttpMethod::Post,
+            path: "v1/gen".into(),
+            description: None,
+            resource: None,
+            routing: None,
+            metering: Some(Metering {
+                dimensions: vec![MeterDimension {
+                    direction: MeterDirection::Usage,
+                    unit: BillingUnit::Requests,
+                    scale: 1,
+                    period: None,
+                    tiers: vec![PriceTier {
+                        up_to: None,
+                        price_usd: 0.10,
+                        condition: None,
+                        notes: None,
+                        splits: vec![],
+                    }],
+                }],
+                variants: vec![],
+                sku_tiers: vec![],
+                splits,
+                schemes,
+                min_usd: None,
+            }),
+            subscription: None,
+        }])
+    }
+
+    #[test]
+    fn validate_session_rejects_duplicate_recipient_same_alias() {
+        // Session scheme + the same alias twice (even with distinct memos) → reject.
+        let spec = spec_with_splits(
+            Some(vec![Scheme::X402Upto]),
+            vec![
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("a".into()),
+                },
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("b".into()),
+                },
+            ],
+        );
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("unique split recipients")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_session_rejects_duplicate_account_via_distinct_aliases() {
+        // The real prod regression: two *distinct* aliases (operator + platform)
+        // resolve to the *same* wallet, and the endpoint advertises x402-upto.
+        let mut spec = spec_with_splits(
+            Some(vec![Scheme::MppCharge, Scheme::X402Upto]),
+            vec![
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.00025),
+                    percent: None,
+                    memo: Some("Operator fee".into()),
+                },
+                SplitRule {
+                    recipient: "platform".into(),
+                    amount: None,
+                    percent: Some(5.0),
+                    memo: Some("Platform fee".into()),
+                },
+            ],
+        );
+        let operator_account = spec.recipients["operator"].account.clone();
+        spec.recipients.get_mut("platform").unwrap().account = operator_account;
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("unique split recipients")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_charge_allows_duplicate_recipient_with_distinct_memos() {
+        // Charge scheme + same recipient, distinct memos → allowed (no errors).
+        let spec = spec_with_splits(
+            Some(vec![Scheme::MppCharge]),
+            vec![
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("platform fee".into()),
+                },
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("referral".into()),
+                },
+            ],
+        );
+        let errs = validate_api_spec(&spec);
+        assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
+    }
+
+    #[test]
+    fn validate_charge_rejects_duplicate_recipient_same_memo() {
+        // Charge scheme + same recipient AND same memo → reject (indistinguishable legs).
+        let spec = spec_with_splits(
+            Some(vec![Scheme::MppCharge]),
+            vec![
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("fee".into()),
+                },
+                SplitRule {
+                    recipient: "operator".into(),
+                    amount: Some(0.001),
+                    percent: None,
+                    memo: Some("fee".into()),
+                },
+            ],
+        );
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("distinct memo")),
+            "got: {errs:?}"
+        );
+    }
+
+    /// Build a spec whose top-level `session:` block carries the given splits.
+    fn spec_with_session_splits(splits: Vec<SplitRule>) -> ApiSpec {
+        let mut spec = test_spec(vec![]);
+        spec.session = Some(SessionSpec {
+            cap_usdc: 10.0,
+            min_voucher_delta: 0,
+            modes: vec![],
+            pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
+            batch_open_interval_ms: 400,
+            close_delay_ms: 15_000,
+            splits,
+        });
+        spec
+    }
+
+    #[test]
+    fn validate_session_splits_rejects_amount() {
+        let spec = spec_with_session_splits(vec![SplitRule {
+            recipient: "platform".into(),
+            amount: Some(0.30),
+            percent: None,
+            memo: None,
+        }]);
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("must use `percent`")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_session_splits_rejects_duplicate_recipient() {
+        let mut spec = spec_with_session_splits(vec![
+            SplitRule {
+                recipient: "operator".into(),
+                amount: None,
+                percent: Some(10.0),
+                memo: None,
+            },
+            SplitRule {
+                recipient: "platform".into(),
+                amount: None,
+                percent: Some(10.0),
+                memo: None,
+            },
+        ]);
+        let operator_account = spec.recipients["operator"].account.clone();
+        spec.recipients.get_mut("platform").unwrap().account = operator_account;
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("unique split recipients")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_session_splits_valid_passes() {
+        let spec = spec_with_session_splits(vec![
+            SplitRule {
+                recipient: "operator".into(),
+                amount: None,
+                percent: Some(10.0),
+                memo: None,
+            },
+            SplitRule {
+                recipient: "platform".into(),
+                amount: None,
+                percent: Some(5.0),
+                memo: None,
+            },
+        ]);
+        let errs = validate_api_spec(&spec);
+        assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
     }
 
     #[test]

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -1975,6 +1975,24 @@ fn validate_split_recipient_uniqueness(
             }
         }
     }
+    for variant in &metering.variants {
+        for dim in &variant.dimensions {
+            let scale = dim.scale.max(1) as f64;
+            for tier in &dim.tiers {
+                if !tier.splits.is_empty() {
+                    split_sets.push((
+                        format!(
+                            " (variant {}={}, tier ${:.6}/unit)",
+                            variant.param,
+                            variant.value,
+                            tier.price_usd / scale
+                        ),
+                        tier.splits.as_slice(),
+                    ));
+                }
+            }
+        }
+    }
 
     for (label, splits) in split_sets {
         if has_session_scheme {
@@ -3416,6 +3434,124 @@ mod tests {
         let errs = validate_api_spec(&spec);
         assert!(
             errs.iter().any(|e| e.contains("distinct memo")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_session_rejects_duplicate_variant_tier_recipients() {
+        let mut spec = test_spec(vec![Endpoint {
+            method: HttpMethod::Post,
+            path: "v1/models".into(),
+            description: None,
+            resource: None,
+            routing: None,
+            metering: Some(Metering {
+                dimensions: vec![],
+                variants: vec![MeterVariant {
+                    param: "model".into(),
+                    value: "gemini".into(),
+                    dimensions: vec![MeterDimension {
+                        direction: MeterDirection::Usage,
+                        unit: BillingUnit::Requests,
+                        scale: 1,
+                        period: None,
+                        tiers: vec![PriceTier {
+                            up_to: None,
+                            price_usd: 0.10,
+                            condition: None,
+                            notes: None,
+                            splits: vec![
+                                SplitRule {
+                                    recipient: "operator".into(),
+                                    amount: Some(0.001),
+                                    percent: None,
+                                    memo: Some("platform fee".into()),
+                                },
+                                SplitRule {
+                                    recipient: "platform".into(),
+                                    amount: Some(0.001),
+                                    percent: None,
+                                    memo: Some("referral".into()),
+                                },
+                            ],
+                        }],
+                        meter: None,
+                    }],
+                }],
+                sku_tiers: vec![],
+                splits: vec![],
+                schemes: Some(vec![Scheme::X402Upto]),
+                min_usd: None,
+                upto: None,
+            }),
+            subscription: None,
+        }]);
+        let operator_account = spec.recipients["operator"].account.clone();
+        spec.recipients.get_mut("platform").unwrap().account = operator_account;
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("variant model=gemini"))
+                && errs.iter().any(|e| e.contains("unique split recipients")),
+            "got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_charge_rejects_duplicate_variant_tier_recipient_same_memo() {
+        let spec = test_spec(vec![Endpoint {
+            method: HttpMethod::Post,
+            path: "v1/models".into(),
+            description: None,
+            resource: None,
+            routing: None,
+            metering: Some(Metering {
+                dimensions: vec![],
+                variants: vec![MeterVariant {
+                    param: "model".into(),
+                    value: "gemini".into(),
+                    dimensions: vec![MeterDimension {
+                        direction: MeterDirection::Usage,
+                        unit: BillingUnit::Requests,
+                        scale: 1,
+                        period: None,
+                        tiers: vec![PriceTier {
+                            up_to: None,
+                            price_usd: 0.10,
+                            condition: None,
+                            notes: None,
+                            splits: vec![
+                                SplitRule {
+                                    recipient: "operator".into(),
+                                    amount: Some(0.001),
+                                    percent: None,
+                                    memo: Some("fee".into()),
+                                },
+                                SplitRule {
+                                    recipient: "operator".into(),
+                                    amount: Some(0.001),
+                                    percent: None,
+                                    memo: Some("fee".into()),
+                                },
+                            ],
+                        }],
+                        meter: None,
+                    }],
+                }],
+                sku_tiers: vec![],
+                splits: vec![],
+                schemes: Some(vec![Scheme::MppCharge]),
+                min_usd: None,
+                upto: None,
+            }),
+            subscription: None,
+        }]);
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("variant model=gemini"))
+                && errs.iter().any(|e| e.contains("distinct memo")),
             "got: {errs:?}"
         );
     }

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -1079,8 +1079,70 @@ pub struct Metering {
     /// price is the *ceiling* the client authorizes; absent a real usage meter,
     /// the operator settles a voucher for this `min` (clamped to the ceiling) on
     /// a successful serve, refunding the rest. `None` settles the full ceiling.
+    ///
+    /// Deprecated for new configs: prefer `upto.min_usd`, which lives with the
+    /// rest of the `x402-upto` settlement policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_usd: Option<f64>,
+    /// Settlement policy for `x402-upto` endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upto: Option<UptoMetering>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct UptoMetering {
+    /// Authorized ceiling in USD. The client opens the channel for this amount;
+    /// settlement later debits the measured usage and refunds the remainder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_usd: Option<f64>,
+    /// Minimum amount to settle on a successful response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_usd: Option<f64>,
+    /// What to do when the upstream response succeeds but configured usage
+    /// fields cannot be extracted.
+    #[serde(default, skip_serializing_if = "is_default_missing_usage_policy")]
+    pub missing_usage: MissingUsagePolicy,
+    /// Response-body handling for usage extraction. The first supported mode is
+    /// buffered JSON, which lets the gateway compute the settlement before it
+    /// writes the final response headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_body: Option<UptoResponseBody>,
+    /// Provider preset for common usage JSON layouts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage_preset: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingUsagePolicy {
+    /// Close the channel with a zero voucher, refunding the full deposit.
+    #[default]
+    Refund,
+    /// Settle the configured minimum, or refund when no minimum is set.
+    Min,
+    /// Settle the full authorized ceiling.
+    Ceiling,
+    /// Treat missing usage as a settlement error. The gateway still refunds to
+    /// avoid stranding funds after the upstream has already responded.
+    Error,
+}
+
+fn is_default_missing_usage_policy(policy: &MissingUsagePolicy) -> bool {
+    matches!(policy, MissingUsagePolicy::Refund)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct UptoResponseBody {
+    pub mode: UptoResponseBodyMode,
+    /// Maximum response body bytes the gateway will buffer for usage extraction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UptoResponseBodyMode {
+    Buffer,
 }
 
 impl Metering {
@@ -1115,6 +1177,27 @@ pub struct MeterDimension {
     pub period: Option<BillingPeriod>,
     /// Volume tiers. Evaluated in order — first matching tier applies.
     pub tiers: Vec<PriceTier>,
+    /// Optional usage source for post-response settlement, used by `x402-upto`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meter: Option<UsageMeter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct UsageMeter {
+    pub source: UsageMeterSource,
+    /// RFC 6901 JSON pointer, e.g. `/usageMetadata/promptTokenCount`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Response header name for `response_header` meters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageMeterSource {
+    ResponseJson,
+    ResponseHeader,
 }
 
 /// A volume-based price tier. `up_to: None` means "and above" (final tier).
@@ -2412,12 +2495,14 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
             }],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
             min_usd: None,
+            upto: None,
         };
         let json = serde_json::to_string(&metering).unwrap();
         let back: Metering = serde_json::from_str(&json).unwrap();
@@ -2477,12 +2562,14 @@ mod tests {
                             notes: Some("Free tier".to_string()),
                             splits: vec![],
                         }],
+                        meter: None,
                     }],
                     variants: vec![],
                     sku_tiers: vec![],
                     splits: vec![],
                     schemes: None,
                     min_usd: None,
+                    upto: None,
                 }),
                 subscription: None,
             }],
@@ -2813,6 +2900,7 @@ mod tests {
                 splits: vec![],
                 schemes,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }
@@ -2872,6 +2960,7 @@ mod tests {
                 }],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -2901,6 +2990,7 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
@@ -2912,6 +3002,7 @@ mod tests {
                 }],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -2941,6 +3032,7 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
@@ -2952,6 +3044,7 @@ mod tests {
                 }],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -2981,6 +3074,7 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
@@ -2992,6 +3086,7 @@ mod tests {
                 }],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -3020,6 +3115,7 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
@@ -3031,6 +3127,7 @@ mod tests {
                 }],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -3062,6 +3159,7 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
@@ -3081,6 +3179,7 @@ mod tests {
                 ],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -3129,12 +3228,14 @@ mod tests {
                             memo: None,
                         }],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
                 splits: vec![],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -3165,12 +3266,14 @@ mod tests {
                         notes: None,
                         splits: vec![],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
                 splits,
                 schemes,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }])
@@ -3436,12 +3539,14 @@ mod tests {
                             },
                         ],
                     }],
+                    meter: None,
                 }],
                 variants: vec![],
                 sku_tiers: vec![],
                 splits: vec![],
                 schemes: None,
                 min_usd: None,
+                upto: None,
             }),
             subscription: None,
         }]);
@@ -4018,6 +4123,80 @@ endpoints:
             errs.iter()
                 .any(|e| e.contains("does not support nested oauth2 auth")),
             "expected nested oauth2 validation error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn parses_x402_upto_response_metering_yaml() {
+        let spec: ApiSpec = serde_yml::from_str(
+            r#"
+name: usage-demo
+subdomain: usage-demo
+title: Usage Demo
+description: Usage Demo
+category: finance
+version: v1
+routing:
+  type: respond
+operator:
+  currencies:
+    usd: ["USDC"]
+  network: localnet
+  fee_payer: true
+endpoints:
+  - method: POST
+    path: v1/generate
+    resource: generate
+    description: Usage-metered generation
+    metering:
+      schemes: [x402-upto]
+      upto:
+        max_usd: 0.10
+        min_usd: 0.001
+        missing_usage: refund
+        usage_preset: google-generativelanguage
+        response_body:
+          mode: buffer
+          max_bytes: 4096
+      dimensions:
+        - direction: input
+          unit: tokens
+          scale: 1000
+          meter:
+            source: response_json
+            path: /usageMetadata/promptTokenCount
+          tiers:
+            - price_usd: 0.000075
+        - direction: output
+          unit: tokens
+          scale: 1000
+          meter:
+            source: response_json
+            path: /usageMetadata/candidatesTokenCount
+          tiers:
+            - price_usd: 0.00030
+"#,
+        )
+        .unwrap();
+
+        let metering = spec.endpoints[0].metering.as_ref().unwrap();
+        let upto = metering.upto.as_ref().unwrap();
+        assert_eq!(upto.max_usd, Some(0.10));
+        assert_eq!(upto.min_usd, Some(0.001));
+        assert!(matches!(upto.missing_usage, MissingUsagePolicy::Refund));
+        assert_eq!(
+            upto.usage_preset.as_deref(),
+            Some("google-generativelanguage")
+        );
+        assert_eq!(upto.response_body.as_ref().unwrap().max_bytes, Some(4096));
+        assert_eq!(
+            metering.dimensions[0]
+                .meter
+                .as_ref()
+                .unwrap()
+                .path
+                .as_deref(),
+            Some("/usageMetadata/promptTokenCount")
         );
     }
 }

--- a/typescript/packages/solana-pay/core/package.json
+++ b/typescript/packages/solana-pay/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-foundation/pay",
     "license": "MIT",


### PR DESCRIPTION
## Summary

Splits with duplicate recipients started failing with a runtime `challenge_generation_failed` 500 — a regression. The two MPP method specs actually disagree on duplicates, so a blanket allow/deny is wrong:

- **charge** (`draft-solana-charge-00`): a recipient *may* repeat across split legs; each occurrence is a distinct, separately-verified payment leg → uniqueness key is **(recipient, memo)**.
- **session** (`draft-solana-session-00`): the on-chain channel `open` rejects duplicate `distributionSplits` recipients → uniqueness key is **recipient**.

This makes `validate_api_spec` the **single canonical spec validator** and enforces both rules:

- `validate_split_recipient_uniqueness` — endpoint splits, charge vs session keyed by scheme (any session scheme or a top-level `session:` block ⇒ session rule). Recipients are compared by **resolved account**, so two distinct aliases pointing at the same wallet are correctly caught.
- `validate_session_splits` — top-level `session:` block: percent-only, positive/finite, 1..9999 bps, positive payee remainder, known **and unique** recipients (previously unchecked).
- `Scheme::is_session()` to classify channel vs charge schemes.

## Boot behavior

`pay server start` now runs `validate_api_spec` once (after `apply_scheme_defaults`) and aborts via `Error::Config`, which the CLI already renders through the notice component (`NoticeLevel::Error`, "Configuration error"). Misconfigured splits fail fast at boot instead of as a runtime 500 / on-chain `open` rejection.

## Tests

7 new unit tests (74 pass total): charge allows dupe + distinct memos; charge rejects dupe + same memo; session rejects dupe (same alias, and distinct-aliases-same-account); session-block rejects `amount`, rejects dupe recipient, accepts a valid set.

## Note

`resolve_session_splits` (the transformer in `start.rs`) keeps its defensive guards; `validate_api_spec` is now the source of truth that runs first at boot. Can slim it to be fully DRY in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)