### PR TITLE
fix(catalog): probe path parameter examples

### DIFF
--- a/rust/crates/cli/src/commands/catalog/probe.rs
+++ b/rust/crates/cli/src/commands/catalog/probe.rs
@@ -163,9 +163,10 @@ fn resolved_endpoint_to_probe_endpoint(
     r: ResolvedEndpoint,
     openapi_driven: bool,
 ) -> pay_types::registry::ProbeEndpoint {
+    let probe_path = r.path_example.as_ref().unwrap_or(&r.spec.path);
     let path = match &r.query_example {
-        Some(q) => format!("{}?{}", r.spec.path, q),
-        None => r.spec.path.clone(),
+        Some(q) => format!("{}?{}", probe_path, q),
+        None => probe_path.clone(),
     };
     pay_types::registry::ProbeEndpoint {
         method: r.spec.method,

--- a/rust/crates/core/src/skills/build.rs
+++ b/rust/crates/core/src/skills/build.rs
@@ -910,9 +910,12 @@ fn build_detail_endpoints(
                 // published `spec.path` (below) stays clean. Without the query,
                 // GETs that require parameters 4xx/5xx before the paywall and
                 // get pruned.
-                path: match &r.query_example {
-                    Some(q) => format!("{}?{}", r.spec.path, q),
-                    None => r.spec.path.clone(),
+                path: {
+                    let probe_path = r.path_example.as_ref().unwrap_or(&r.spec.path);
+                    match &r.query_example {
+                        Some(q) => format!("{}?{}", probe_path, q),
+                        None => probe_path.clone(),
+                    }
                 },
                 metered: true,
                 body: r.body_example.clone(),
@@ -1057,6 +1060,7 @@ mod tests {
                 pricing,
             },
             body_example: None,
+            path_example: None,
             query_example: None,
         }
     }
@@ -1218,6 +1222,7 @@ mod tests {
                 pricing: None,
             },
             body_example: None,
+            path_example: None,
             query_example: Some("country_code=us".to_string()),
         }];
         let options = BuildOptions {
@@ -1252,6 +1257,7 @@ mod tests {
                 pricing: None,
             },
             body_example: None,
+            path_example: None,
             query_example: Some("product_id=stale".to_string()),
         }];
         let options = BuildOptions {

--- a/rust/crates/core/src/skills/openapi.rs
+++ b/rust/crates/core/src/skills/openapi.rs
@@ -40,6 +40,9 @@ pub struct ResolvedEndpoint {
     /// Serialized JSON body. `None` for GET/DELETE or when the OpenAPI doc
     /// does not declare a request body for the operation.
     pub body_example: Option<String>,
+    /// Concrete example path assembled from `in: path` parameter examples.
+    /// Used for probing only; the published `spec.path` remains templated.
+    pub path_example: Option<String>,
     /// Example query string (without a leading `?`) assembled from the
     /// operation's `in: query` parameters that carry an example value, e.g.
     /// `country_code=us&brand_name=Amazon.com`. Appended to the probe URL only
@@ -131,9 +134,12 @@ fn parse_openapi3_endpoints(doc: &Value) -> Result<Vec<ResolvedEndpoint>> {
                 .map(|s| s.to_string())
                 .unwrap_or_else(|| format!("{} {}", method.to_uppercase(), path));
 
+            let path = normalize_path(path);
+            let path_example = extract_path_example(&path, item_obj, op);
+
             let spec = EndpointSpec {
                 method: method.to_uppercase(),
-                path: normalize_path(path),
+                path,
                 description,
                 resource: op
                     .get("tags")
@@ -155,11 +161,77 @@ fn parse_openapi3_endpoints(doc: &Value) -> Result<Vec<ResolvedEndpoint>> {
             endpoints.push(ResolvedEndpoint {
                 spec,
                 body_example,
+                path_example,
                 query_example,
             });
         }
     }
     Ok(endpoints)
+}
+
+/// Substitute examples for every `{path}` placeholder so live probes exercise
+/// a concrete URL while the published endpoint keeps its OpenAPI shape.
+fn extract_path_example(path: &str, item_obj: &Map<String, Value>, op: &Value) -> Option<String> {
+    let placeholders = path_placeholders(path);
+    if placeholders.is_empty() {
+        return None;
+    }
+
+    let mut values: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let sources = [op.get("parameters"), item_obj.get("parameters")];
+    for params in sources.into_iter().flatten() {
+        let Some(arr) = params.as_array() else {
+            continue;
+        };
+        for param in arr {
+            if param.get("in").and_then(Value::as_str) != Some("path") {
+                continue;
+            }
+            let Some(name) = param.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            if values.contains_key(name) {
+                continue; // operation-level parameters win
+            }
+            if let Some(value) = param_example_value(param) {
+                values.insert(name.to_string(), value);
+            }
+        }
+    }
+
+    if !placeholders.iter().all(|name| values.contains_key(name)) {
+        return None;
+    }
+
+    const PATH_SET: &AsciiSet = &NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~');
+    let mut concrete = path.to_string();
+    for name in placeholders {
+        let value = values.get(&name)?;
+        let encoded = utf8_percent_encode(value, PATH_SET).to_string();
+        concrete = concrete.replace(&format!("{{{name}}}"), &encoded);
+    }
+    Some(concrete)
+}
+
+fn path_placeholders(path: &str) -> Vec<String> {
+    let mut placeholders = Vec::new();
+    let mut rest = path;
+    while let Some(start) = rest.find('{') {
+        let after_start = &rest[start + 1..];
+        let Some(end) = after_start.find('}') else {
+            break;
+        };
+        let name = &after_start[..end];
+        if !name.is_empty() {
+            placeholders.push(name.to_string());
+        }
+        rest = &after_start[end + 1..];
+    }
+    placeholders
 }
 
 /// Assemble an example query string from an operation's `in: query`
@@ -875,6 +947,7 @@ fn emit_discovery_methods(
                 pricing: None,
             },
             body_example,
+            path_example: None,
             // Discovery endpoints carry their query inputs in the request body
             // shape, not OpenAPI-style `in: query` parameters.
             query_example: None,
@@ -999,6 +1072,7 @@ pub fn effective_openapi_relative_to(
                 .map(|spec| ResolvedEndpoint {
                     spec,
                     body_example: None,
+                    path_example: None,
                     // Inline `endpoints:` declare a clean path; no query
                     // examples to synthesize.
                     query_example: None,
@@ -3689,6 +3763,24 @@ mod tests {
         }"#;
         let endpoints = parse_endpoints(doc).unwrap();
         assert!(endpoints[0].query_example.is_none());
+    }
+
+    #[test]
+    fn path_example_substitutes_path_param_examples() {
+        let doc = r#"{
+            "paths": {
+                "/v1/tip/{recipient}": {
+                    "get": {
+                        "parameters": [
+                            {"name": "recipient", "in": "path", "required": true, "example": "jack"}
+                        ]
+                    }
+                }
+            }
+        }"#;
+        let endpoints = parse_endpoints(doc).unwrap();
+        assert_eq!(endpoints[0].spec.path, "v1/tip/{recipient}");
+        assert_eq!(endpoints[0].path_example.as_deref(), Some("v1/tip/jack"));
     }
 
     #[test]


### PR DESCRIPTION
Substitute \`in: path\` parameter examples when probing endpoints, so parameterized endpoints hit a concrete URL instead of the literal template.

## Why

\`catalog check\` probes parameterized paths verbatim (e.g. \`/api/v1/tip/x402/{recipient}\`), which servers reject before the paywall — the probe never sees the 402 challenge. This currently blocks pay-skills CI on clustly/tipping (single parameterized endpoint provider): the templated path returns 400, so no Solana 402 challenge is observed and the provider is blocked. See https://github.com/solana-foundation/pay-skills/actions/runs/28536601434.

With this change the probe uses the spec's path examples (\`/api/v1/tip/x402/jack\`), which returns the expected x402 Solana challenge. Verified locally: \`catalog check\` on the pay-skills PR #166 file set goes from 1 blocked provider to exit 0 (warnings only).

The published endpoint spec keeps its templated OpenAPI shape; the concrete path is used for probing only.

Note: \`ghcr.io/solana-foundation/pay:latest\` (built 2026-07-01 from 3f01005) predates this fix — the docker image needs a republish after merge for pay-skills CI to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)