### PR TITLE
chore(deps): update PayKit

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5891,7 +5891,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7225,7 +7225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10703,8 +10703,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.2.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=66cf5a3ccf2051a937aa08ec978129b3aa004eee#66cf5a3ccf2051a937aa08ec978129b3aa004eee"
+version = "0.3.0"
+source = "git+https://github.com/solana-foundation/pay-kit?rev=75f97c2930f0382fa35732197dee4fab4b9e7259#75f97c2930f0382fa35732197dee4fab4b9e7259"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15341,7 +15341,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "66cf5a3ccf2051a937aa08ec978129b3aa004eee", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "75f97c2930f0382fa35732197dee4fab4b9e7259", default-features = false, features = [
     "mpp",
     "x402",
     "client",


### PR DESCRIPTION
## Summary

- update the git-pinned `solana-pay-kit` dependency to the merged PayKit revision `75f97c2` (v0.3.0)
- refresh the Cargo lockfile to its resolved transitive dependency graph
- no downstream source changes were required

## Test Plan

- `cargo check -p pay-core`
- `PAY_PDB_ALLOW_PLACEHOLDER=1 just rs build`

> The normal release build requires prebuilt `web-ui/dist` assets; placeholder mode validates the Rust workspace in this clean worktree without embedding local UI artifacts.