### PR TITLE
feat(cli): add paid agent provider routing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1205,6 +1205,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.4.1",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,7 +1928,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes 1.12.0",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -5891,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7226,7 +7239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7558,6 +7571,34 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redis"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes 1.12.0",
+ "cfg-if 1.0.4",
+ "combine 4.6.7",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint 0.4.6",
+ "percent-encoding 2.3.2",
+ "pin-project-lite",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.4",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.6.4",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util 0.7.18",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -8598,6 +8639,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -10704,8 +10751,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.3.0"
-source = "git+https://github.com/solana-foundation/pay-kit?rev=76402a5f#76402a5f882b1905e7382c8dbdc55a2d9b755a17"
+version = "0.4.0"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=7cc768372445cbc10adfcfb0250fe8a279d5cd60#7cc768372445cbc10adfcfb0250fe8a279d5cd60"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -10724,6 +10771,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.31.0",
  "opentelemetry_sdk 0.31.0",
+ "redis",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -15342,7 +15390,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6343,7 +6343,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pay"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "pay-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6456,7 +6456,7 @@ dependencies = [
 
 [[package]]
 name = "pay-integration"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64 0.22.1",
  "pay-core",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "pay-keystore"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "bs58",
  "secret-service",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "pay-mcp"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -6509,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "pay-pdb"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "pay-proxy"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "pay-types"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -7239,7 +7239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=7cc768372445cbc10adfcfb0250fe8a279d5cd60#7cc768372445cbc10adfcfb0250fe8a279d5cd60"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=cb02b5afcbba8147c4483a9d800a3eff93ed6592#cb02b5afcbba8147c4483a9d800a3eff93ed6592"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15390,7 +15390,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit", rev = "76402a5f", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "7cc768372445cbc10adfcfb0250fe8a279d5cd60", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.23.0"
+version = "0.24.0"
 license = "MIT"
 
 [workspace.dependencies]
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "7cc768372445cbc10adfcfb0250fe8a279d5cd60", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "cb02b5afcbba8147c4483a9d800a3eff93ed6592", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 ARG PAY_PDB_ALLOW_PLACEHOLDER
 ENV PAY_PDB_ALLOW_PLACEHOLDER=${PAY_PDB_ALLOW_PLACEHOLDER}
 
-RUN cargo build --release --features gcp_kms
+RUN cargo build --release --features gcp_kms,redis-session-store
 
 RUN cp target/release/pay /usr/local/bin/pay
 

--- a/rust/crates/cli/Cargo.toml
+++ b/rust/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 default = []
 gcp_kms = ["pay-kit/gcp_kms"]
 vendored-openssl = ["pay-core/vendored-openssl"]
+redis-session-store = ["pay-core/redis-session-store", "pay-kit/redis-store"]
 
 [dependencies]
 async-trait = "0.1"

--- a/rust/crates/cli/src/commands/agent_args.rs
+++ b/rust/crates/cli/src/commands/agent_args.rs
@@ -1,0 +1,72 @@
+pub(crate) fn model_arg(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if let Some(model) = arg.strip_prefix("--model=")
+            && !model.is_empty()
+        {
+            return Some(model.to_string());
+        }
+        if matches!(arg.as_str(), "--model" | "-m")
+            && let Some(model) = iter.next()
+            && !model.trim().is_empty()
+        {
+            return Some(model.to_string());
+        }
+    }
+    None
+}
+
+pub(crate) fn args_without_model(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if matches!(arg.as_str(), "--model" | "-m") {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--model=") {
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_long_short_and_equals_model_arguments() {
+        assert_eq!(
+            model_arg(&["--model".into(), "llama3.2".into()]),
+            Some("llama3.2".into())
+        );
+        assert_eq!(
+            model_arg(&["--model=qwen3.5".into()]),
+            Some("qwen3.5".into())
+        );
+        assert_eq!(
+            model_arg(&["-m".into(), "gemma4".into()]),
+            Some("gemma4".into())
+        );
+        assert_eq!(model_arg(&["--model".into()]), None);
+    }
+
+    #[test]
+    fn removes_model_arguments_without_disturbing_other_arguments() {
+        assert_eq!(
+            args_without_model(&[
+                "--debug".into(),
+                "--model".into(),
+                "qwen3.7-plus".into(),
+                "--verbose".into(),
+            ]),
+            vec!["--debug", "--verbose"]
+        );
+        assert_eq!(
+            args_without_model(&["--model=qwen3.7-plus".into(), "hello".into()]),
+            vec!["hello"]
+        );
+    }
+}

--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
+
+use super::agent_args::model_arg;
 use owo_colors::OwoColorize;
 
 use crate::commands::payer_proxy;
@@ -723,24 +725,6 @@ fn claude_metadata_requested(args: &[String]) -> bool {
         .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "--version" | "-v"))
 }
 
-fn model_arg(args: &[String]) -> Option<String> {
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        if let Some(model) = arg.strip_prefix("--model=")
-            && !model.is_empty()
-        {
-            return Some(model.to_string());
-        }
-        if matches!(arg.as_str(), "--model" | "-m")
-            && let Some(model) = iter.next()
-            && !model.trim().is_empty()
-        {
-            return Some(model.to_string());
-        }
-    }
-    None
-}
-
 fn claude_args_with_model(args: &[String], model: Option<&str>) -> Vec<String> {
     let Some(model) = model else {
         return args.to_vec();
@@ -886,23 +870,6 @@ mod tests {
         assert_eq!(launch.args, args);
         assert_eq!(launch.base_url, None);
         assert_eq!(launch.model, None);
-    }
-
-    #[test]
-    fn model_arg_reads_long_and_short_forms() {
-        assert_eq!(
-            model_arg(&["--model".into(), "llama3.2".into()]),
-            Some("llama3.2".into())
-        );
-        assert_eq!(
-            model_arg(&["--model=qwen3.5".into()]),
-            Some("qwen3.5".into())
-        );
-        assert_eq!(
-            model_arg(&["-m".into(), "gemma4".into()]),
-            Some("gemma4".into())
-        );
-        assert_eq!(model_arg(&["--model".into()]), None);
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -975,7 +975,7 @@ mod tests {
             chat_completions_path(&provider),
             "compatible-mode/v1/chat/completions"
         );
-        assert_eq!(responses_path(&provider), "compatible-mode/v1/responses");
+        assert_eq!(responses_path(&provider), "v1/responses");
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -200,13 +200,13 @@ impl AlternateClient {
         match (self, dialect) {
             (Self::Claude, Dialect::Anthropic) => supports_post_endpoint(provider, "v1/messages"),
             (Self::Claude, Dialect::OpenAiCompat) => {
-                supports_post_endpoint(provider, providers::OPENAI_CHAT_COMPLETIONS_PATH)
+                supports_post_endpoint(provider, "chat/completions")
             }
             (Self::Codex, Dialect::OpenAiCompat) => {
                 supports_post_endpoint(provider, "v1/responses")
             }
             (Self::Goose | Self::Qoder, Dialect::OpenAiCompat) => {
-                supports_post_endpoint(provider, providers::OPENAI_CHAT_COMPLETIONS_PATH)
+                supports_post_endpoint(provider, "chat/completions")
             }
             _ => false,
         }

--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
+use owo_colors::OwoColorize;
 
 use crate::commands::payer_proxy;
 use crate::commands::server::inference::{
@@ -20,6 +21,8 @@ const PROVIDER_PROBE_TIMEOUT: Duration = Duration::from_millis(400);
 const ANTHROPIC_BASE_URL_ENV: &str = "ANTHROPIC_BASE_URL";
 const ANTHROPIC_API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
 const ANTHROPIC_AUTH_TOKEN_ENV: &str = "ANTHROPIC_AUTH_TOKEN";
+const CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION_ENV: &str = "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION";
+const CLAUDE_CODE_DISABLE_TERMINAL_TITLE_ENV: &str = "CLAUDE_CODE_DISABLE_TERMINAL_TITLE";
 const OLLAMA_AUTH_TOKEN: &str = "ollama";
 /// Hosted catalog gateways are remote (TLS handshake included) — give their
 /// reachability/model probes more room than the localhost ones.
@@ -138,6 +141,266 @@ struct ClaudeLaunch {
     args: Vec<String>,
 }
 
+/// Agent harness using a provider selected by `--alt`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AlternateClient {
+    Claude,
+    Codex,
+    Goose,
+    Qoder,
+}
+
+impl AlternateClient {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Goose => "goose",
+            Self::Qoder => "qoder",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+            Self::Goose => "Goose",
+            Self::Qoder => "Qoder",
+        }
+    }
+
+    fn compatibility_label(self) -> &'static str {
+        match self {
+            Self::Claude => "Anthropic or OpenAI-compatible",
+            Self::Codex => "OpenAI Responses-compatible",
+            Self::Goose => "OpenAI Chat Completions-compatible",
+            Self::Qoder => "OpenAI Chat Completions-compatible",
+        }
+    }
+
+    fn fallback_dialect(self) -> Dialect {
+        match self {
+            Self::Claude => Dialect::Anthropic,
+            Self::Codex | Self::Goose | Self::Qoder => Dialect::OpenAiCompat,
+        }
+    }
+
+    fn supports_dialect(self, dialect: Dialect) -> bool {
+        match self {
+            Self::Claude => matches!(dialect, Dialect::Anthropic | Dialect::OpenAiCompat),
+            Self::Codex | Self::Goose | Self::Qoder => dialect == Dialect::OpenAiCompat,
+        }
+    }
+
+    fn provider_supported(self, provider: &DiscoveredProvider) -> bool {
+        let dialect = provider.provider.dialect();
+        if !self.supports_dialect(dialect) {
+            return false;
+        }
+        match (self, dialect) {
+            (Self::Claude, Dialect::Anthropic) => supports_post_endpoint(provider, "v1/messages"),
+            (Self::Claude, Dialect::OpenAiCompat) => {
+                supports_post_endpoint(provider, providers::OPENAI_CHAT_COMPLETIONS_PATH)
+            }
+            (Self::Codex, Dialect::OpenAiCompat) => {
+                supports_post_endpoint(provider, "v1/responses")
+            }
+            (Self::Goose | Self::Qoder, Dialect::OpenAiCompat) => {
+                supports_post_endpoint(provider, providers::OPENAI_CHAT_COMPLETIONS_PATH)
+            }
+            _ => false,
+        }
+    }
+
+    fn payer_base_url(self, payer_base_url: &str) -> String {
+        match self {
+            Self::Claude => payer_base_url.to_string(),
+            // Goose takes a host and a separate `OPENAI_BASE_PATH`.
+            Self::Goose => payer_base_url.to_string(),
+            // Codex and Qoder append their operation to an OpenAI `/v1` base.
+            Self::Codex | Self::Qoder => {
+                format!("{}/v1", payer_base_url.trim_end_matches('/'))
+            }
+        }
+    }
+}
+
+/// One-run provider settings backed by the local payer proxy.
+pub(crate) struct AlternateProvider {
+    pub base_url: String,
+    pub model: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum AlternateRouteKind {
+    Hosted,
+    LocalGateway,
+    Direct,
+}
+
+/// Discover, filter, select, and proxy a provider for an alternate agent
+/// harness. Compatibility is enforced before the provider picker is shown.
+pub(crate) fn prepare_alternate_provider(
+    client: AlternateClient,
+    args: &[String],
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+) -> pay_core::Result<AlternateProvider> {
+    let agent = client.name();
+    let requested_model = model_arg(args);
+    let gateway_up = gateway_listening();
+    let mut providers = discover_local_providers()?;
+    if gateway_up {
+        let gateway_providers = gateway_provider_summaries();
+        if !gateway_providers.is_empty() {
+            apply_gateway_provider_summaries(&mut providers, &gateway_providers);
+        } else {
+            apply_gateway_proxy_fallback(&mut providers);
+        }
+    }
+    providers.extend(discover_catalog_providers());
+    providers.retain(|provider| client.provider_supported(provider));
+
+    let choice = if providers.is_empty() {
+        None
+    } else {
+        Some(select_provider_choice(
+            agent,
+            providers,
+            requested_model.as_deref(),
+        )?)
+    };
+
+    let translated = client == AlternateClient::Claude
+        && choice
+            .as_ref()
+            .is_some_and(|choice| choice.provider.provider.dialect() == Dialect::OpenAiCompat);
+
+    let (upstream, model, provider_name, route_kind) = match choice {
+        Some(choice) if choice.provider.hosted() => {
+            let provider_name = choice.provider.title().to_string();
+            let upstream = payer_upstream(&choice.provider, choice.provider.base_url.clone());
+            (
+                upstream,
+                Some(choice.model),
+                provider_name,
+                AlternateRouteKind::Hosted,
+            )
+        }
+        Some(choice) if gateway_up => {
+            let provider_name = choice.provider.title().to_string();
+            let upstream = gateway_payer_upstream(&choice.provider);
+            (
+                upstream,
+                Some(choice.model),
+                provider_name,
+                AlternateRouteKind::LocalGateway,
+            )
+        }
+        Some(choice) => {
+            let provider_name = choice.provider.title().to_string();
+            let upstream = payer_upstream(&choice.provider, choice.provider.base_url.clone());
+            (
+                upstream,
+                Some(choice.model),
+                provider_name,
+                AlternateRouteKind::Direct,
+            )
+        }
+        None if gateway_up => {
+            let upstream = payer_proxy::PayerUpstream {
+                base_url: inference::LOCAL_GATEWAY_BASE_URL.to_string(),
+                host_header: None,
+                dialect: client.fallback_dialect(),
+                chat_path: providers::OPENAI_CHAT_COMPLETIONS_PATH.to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: false,
+                payment_protocol: payer_proxy::PaymentProtocol::Auto,
+            };
+            (
+                upstream,
+                requested_model,
+                "Local gateway".to_string(),
+                AlternateRouteKind::LocalGateway,
+            )
+        }
+        None => {
+            return Err(pay_core::Error::Config(format!(
+                "no {} provider found for {agent} and no gateway is listening on {}",
+                client.compatibility_label(),
+                inference::LOCAL_GATEWAY_BASE_URL
+            )));
+        }
+    };
+
+    let payer = payer_proxy::start_background(upstream, network_override, account_override)?;
+    print_alternate_route(
+        client,
+        &provider_name,
+        model.as_deref(),
+        route_kind,
+        translated,
+        payer.payer_pubkey.as_deref(),
+    );
+
+    Ok(AlternateProvider {
+        base_url: client.payer_base_url(&payer.base_url),
+        model,
+    })
+}
+
+fn print_alternate_route(
+    client: AlternateClient,
+    provider: &str,
+    model: Option<&str>,
+    route_kind: AlternateRouteKind,
+    translated: bool,
+    payer_pubkey: Option<&str>,
+) {
+    let model = model
+        .map(|model| format!(" {}", format!("· {model}").magenta()))
+        .unwrap_or_default();
+    let translation = if translated {
+        format!(" {}", "· Anthropic→OpenAI".dimmed())
+    } else {
+        String::new()
+    };
+    let route = match route_kind {
+        AlternateRouteKind::Hosted => payer_pubkey
+            .map(abbreviate_pubkey)
+            .map(|payer| format!(" {}", format!("· payer {payer}").dimmed()))
+            .unwrap_or_else(|| format!(" {}", "· paid".dimmed())),
+        AlternateRouteKind::LocalGateway => format!(" {}", "· local gateway".dimmed()),
+        AlternateRouteKind::Direct => format!(" {}", "· direct".dimmed()),
+    };
+
+    eprintln!(
+        "{} {} {} {}{}{}{}",
+        "⚡".yellow().bold(),
+        client.display_name().bold(),
+        "→".dimmed(),
+        provider.cyan().bold(),
+        model,
+        translation,
+        route,
+    );
+}
+
+fn abbreviate_pubkey(pubkey: &str) -> String {
+    if pubkey.len() <= 12 {
+        return pubkey.to_string();
+    }
+    format!("{}…{}", &pubkey[..5], &pubkey[pubkey.len() - 4..])
+}
+
+fn supports_post_endpoint(provider: &DiscoveredProvider, endpoint_path: &str) -> bool {
+    let required = endpoint_path.trim_matches('/');
+    provider.provider.paid_endpoints().iter().any(|endpoint| {
+        matches!(endpoint.method, pay_types::metering::HttpMethod::Post)
+            && endpoint.path.trim_matches('/').ends_with(required)
+    })
+}
+
 fn prepare_claude_launch(
     args: &[String],
     alternate_provider: bool,
@@ -160,7 +423,7 @@ fn prepare_claude_launch(
 ///
 /// `pay claude` never spawns a gateway itself — it routes:
 ///
-/// 1. **Hosted catalog provider selected** (Gemini, Model Studio, … from
+/// 1. **Hosted compatible provider selected** (Model Studio, … from
 ///    the pay catalog) → payer proxy targets its `service_url` directly
 ///    and settles the gateway's MPP 402 challenges per request.
 /// 2. **Gateway on 127.0.0.1:1402** (the user ran `pay serve inference`,
@@ -183,110 +446,17 @@ fn prepare_alternate_claude_launch(
         });
     }
 
-    let requested_model = model_arg(args);
-    let gateway_up = gateway_listening();
-    let mut providers = discover_local_providers()?;
-    if gateway_up {
-        let gateway_providers = gateway_provider_summaries();
-        if !gateway_providers.is_empty() {
-            apply_gateway_provider_summaries(&mut providers, &gateway_providers);
-        } else {
-            apply_gateway_proxy_fallback(&mut providers);
-        }
-    }
-    providers.extend(discover_catalog_providers());
-
-    let choice = if providers.is_empty() {
-        None
-    } else {
-        Some(select_provider_choice(
-            providers,
-            requested_model.as_deref(),
-        )?)
-    };
-
-    if let Some(choice) = &choice {
-        match choice.provider.provider.dialect() {
-            Dialect::Anthropic => {}
-            Dialect::OpenAiCompat => eprintln!(
-                "⏺ translating anthropic → openai for {}",
-                choice.provider.title()
-            ),
-            dialect => eprintln!(
-                "⚠ {} speaks {dialect}; no translator yet — expect errors from claude",
-                choice.provider.title()
-            ),
-        }
-    }
-
-    let (upstream, model) = match choice {
-        // A hosted catalog provider is its own upstream: the payer proxy
-        // pays its 402s directly; the local gateway never fronts it.
-        Some(choice) if choice.provider.hosted() => {
-            eprintln!(
-                "⏺ routing claude → {} {} (hosted, paid per request)",
-                choice.provider.slug(),
-                choice.provider.base_url
-            );
-            let upstream = payer_upstream(&choice.provider, choice.provider.base_url.clone());
-            (upstream, Some(choice.model))
-        }
-        // Direct discovery still supplies the model list for the
-        // ANTHROPIC_DEFAULT_* env vars; the gateway routes by model.
-        Some(choice) if gateway_up => {
-            let gateway_url = inference::local_gateway_provider_url(choice.provider.slug());
-            eprintln!("⏺ routing claude → gateway {gateway_url}");
-            let upstream = gateway_payer_upstream(&choice.provider);
-            (upstream, Some(choice.model))
-        }
-        Some(choice) => {
-            eprintln!(
-                "⏺ routing claude → {} {} (direct, unmetered)",
-                choice.provider.slug(),
-                choice.provider.base_url
-            );
-            let upstream = payer_upstream(&choice.provider, choice.provider.base_url.clone());
-            (upstream, Some(choice.model))
-        }
-        None if gateway_up => {
-            eprintln!(
-                "⏺ routing claude → gateway {}",
-                inference::LOCAL_GATEWAY_BASE_URL
-            );
-            let upstream = payer_proxy::PayerUpstream {
-                base_url: inference::LOCAL_GATEWAY_BASE_URL.to_string(),
-                host_header: None,
-                dialect: Dialect::Anthropic,
-                chat_path: providers::OPENAI_CHAT_COMPLETIONS_PATH.to_string(),
-            };
-            (upstream, requested_model)
-        }
-        None => {
-            return Err(pay_core::Error::Config(format!(
-                "no gateway on {} and no local inference provider detected — \
-                 start one, e.g. `ollama serve`, or run `pay serve inference`.",
-                inference::LOCAL_GATEWAY_BASE_URL
-            )));
-        }
-    };
-
-    let upstream_base = upstream.base_url.clone();
-    let payer = payer_proxy::start_background(upstream, network_override, account_override)?;
-    eprintln!(
-        "⏺ payer proxy on {} → {} (paying as {})",
-        payer.base_url,
-        upstream_base,
-        payer
-            .payer_pubkey
-            .as_deref()
-            .unwrap_or("unresolved account")
-    );
-
-    let args = claude_args_with_model(args, model.as_deref());
+    let alternate = prepare_alternate_provider(
+        AlternateClient::Claude,
+        args,
+        network_override,
+        account_override,
+    )?;
+    let args = claude_args_with_model(args, alternate.model.as_deref());
 
     Ok(ClaudeLaunch {
-        base_url: Some(payer.base_url),
-        model,
+        base_url: Some(alternate.base_url),
+        model: alternate.model,
         args,
     })
 }
@@ -299,6 +469,9 @@ fn payer_upstream(provider: &DiscoveredProvider, base_url: String) -> payer_prox
         host_header: None,
         dialect: provider.provider.dialect(),
         chat_path: chat_completions_path(provider.provider.as_ref()),
+        responses_path: responses_path(provider.provider.as_ref()),
+        require_payment: provider.hosted(),
+        payment_protocol: provider_payment_protocol(provider),
     }
 }
 
@@ -311,6 +484,19 @@ fn gateway_payer_upstream(provider: &DiscoveredProvider) -> payer_proxy::PayerUp
         host_header: Some(inference::local_gateway_provider_host(provider.slug())),
         dialect: provider.provider.dialect(),
         chat_path: chat_completions_path(provider.provider.as_ref()),
+        responses_path: responses_path(provider.provider.as_ref()),
+        require_payment: false,
+        payment_protocol: provider_payment_protocol(provider),
+    }
+}
+
+/// Alibaba Model Studio and Gemini are session-only agent routes. Keeping the
+/// requirement here makes the local payer fail closed even while a stale
+/// catalog entry still advertises the legacy x402 fallback.
+fn provider_payment_protocol(provider: &DiscoveredProvider) -> payer_proxy::PaymentProtocol {
+    match provider.slug() {
+        "modelstudio" | "generativelanguage" => payer_proxy::PaymentProtocol::MppSession,
+        _ => payer_proxy::PaymentProtocol::Auto,
     }
 }
 
@@ -327,17 +513,30 @@ fn chat_completions_path(provider: &dyn InferenceProvider) -> String {
         .unwrap_or_else(|| providers::OPENAI_CHAT_COMPLETIONS_PATH.to_string())
 }
 
+/// The provider's Responses API path. Some hosted providers expose it below
+/// the same compatibility prefix as Chat Completions.
+fn responses_path(provider: &dyn InferenceProvider) -> String {
+    provider
+        .paid_endpoints()
+        .into_iter()
+        .filter(|ep| matches!(ep.method, pay_types::metering::HttpMethod::Post))
+        .map(|ep| ep.path)
+        .find(|path| path.trim_matches('/').ends_with("/responses"))
+        .unwrap_or_else(|| "v1/responses".to_string())
+}
+
 fn select_provider_choice(
+    agent: &str,
     providers: Vec<DiscoveredProvider>,
     requested_model: Option<&str>,
 ) -> pay_core::Result<crate::tui::ProviderChoice> {
-    match select_provider("claude", providers, requested_model)
+    match select_provider(agent, providers, requested_model)
         .map_err(|e| pay_core::Error::Config(format!("Provider selection failed: {e}")))?
     {
         ProviderSelection::Selected(choice) => Ok(choice),
-        ProviderSelection::Cancelled => Err(pay_core::Error::Config(
-            "Claude provider selection cancelled".to_string(),
-        )),
+        ProviderSelection::Cancelled => Err(pay_core::Error::Config(format!(
+            "{agent} provider selection cancelled"
+        ))),
     }
 }
 
@@ -431,13 +630,18 @@ fn discover_catalog_providers() -> Vec<DiscoveredProvider> {
         return Vec::new();
     };
     rt.block_on(async {
-        let mut catalog = match load_catalog_quietly().await {
-            Ok(catalog) => catalog,
+        let mut resolved = match load_catalog_quietly().await {
+            Ok(mut catalog) => catalog_providers::resolve_catalog_providers(
+                &mut catalog,
+                catalog_providers::DEFAULT_CATALOG_FQNS,
+            )
+            .await,
             Err(e) => {
-                tracing::debug!(error = %e, "skills catalog unavailable — hosted providers skipped");
-                return Vec::new();
+                tracing::debug!(error = %e, "skills catalog unavailable — using built-in gateway providers");
+                Vec::new()
             }
         };
+        catalog_providers::append_default_fallbacks(&mut resolved);
         let Ok(client) = reqwest::Client::builder()
             .timeout(CATALOG_PROBE_TIMEOUT)
             .build()
@@ -446,11 +650,6 @@ fn discover_catalog_providers() -> Vec<DiscoveredProvider> {
         };
 
         let mut discovered = Vec::new();
-        let resolved = catalog_providers::resolve_catalog_providers(
-            &mut catalog,
-            catalog_providers::DEFAULT_CATALOG_FQNS,
-        )
-        .await;
         for provider in resolved {
             let base_url = provider.service_url().to_string();
             let provider: Arc<dyn InferenceProvider> = Arc::new(provider);
@@ -565,6 +764,14 @@ fn claude_env(base_url: &str, model: Option<&str>) -> Vec<(String, String)> {
         (
             "CLAUDE_CODE_ATTRIBUTION_HEADER".to_string(),
             "0".to_string(),
+        ),
+        (
+            CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION_ENV.to_string(),
+            "false".to_string(),
+        ),
+        (
+            CLAUDE_CODE_DISABLE_TERMINAL_TITLE_ENV.to_string(),
+            "1".to_string(),
         ),
     ];
 
@@ -731,6 +938,73 @@ mod tests {
             "CLAUDE_CODE_SUBAGENT_MODEL".to_string(),
             "llama3.2".to_string()
         )));
+        assert!(env.contains(&(
+            CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION_ENV.to_string(),
+            "false".to_string()
+        )));
+        assert!(env.contains(&(
+            CLAUDE_CODE_DISABLE_TERMINAL_TITLE_ENV.to_string(),
+            "1".to_string()
+        )));
+    }
+
+    #[test]
+    fn alternate_clients_filter_incompatible_dialects_before_selection() {
+        assert!(!AlternateClient::Claude.supports_dialect(Dialect::GeminiNative));
+        assert!(AlternateClient::Claude.supports_dialect(Dialect::Anthropic));
+        assert!(AlternateClient::Claude.supports_dialect(Dialect::OpenAiCompat));
+        assert!(!AlternateClient::Codex.supports_dialect(Dialect::Anthropic));
+        assert!(AlternateClient::Codex.supports_dialect(Dialect::OpenAiCompat));
+        assert!(AlternateClient::Goose.supports_dialect(Dialect::OpenAiCompat));
+        assert!(AlternateClient::Qoder.supports_dialect(Dialect::OpenAiCompat));
+    }
+
+    #[test]
+    fn launch_banner_abbreviates_payer_pubkeys() {
+        assert_eq!(
+            abbreviate_pubkey("CHPEgF7X1hYJf64oRx53ABUL43DXpEjTJBzAYmZWNuKR"),
+            "CHPEg…NuKR"
+        );
+        assert_eq!(abbreviate_pubkey("short"), "short");
+    }
+
+    #[test]
+    fn alibaba_chat_path_uses_the_deployed_gateway_prefix() {
+        let provider = catalog_providers::alibaba_modelstudio_fallback();
+        assert_eq!(
+            chat_completions_path(&provider),
+            "compatible-mode/v1/chat/completions"
+        );
+        assert_eq!(responses_path(&provider), "compatible-mode/v1/responses");
+    }
+
+    #[test]
+    fn hosted_fallbacks_are_filtered_by_agent_wire_api() {
+        let alibaba = catalog_providers::alibaba_modelstudio_fallback();
+        let alibaba = DiscoveredProvider {
+            models: vec!["qwen3.7-plus".to_string()],
+            base_url: alibaba.service_url().to_string(),
+            provider: Arc::new(alibaba),
+            version: None,
+            pricing: None,
+            model_pricing: Vec::new(),
+        };
+        assert!(AlternateClient::Claude.provider_supported(&alibaba));
+        assert!(AlternateClient::Codex.provider_supported(&alibaba));
+        assert!(AlternateClient::Goose.provider_supported(&alibaba));
+
+        let gemini = catalog_providers::google_gemini_fallback();
+        let gemini = DiscoveredProvider {
+            models: vec!["gemini-2.5-flash".to_string()],
+            base_url: gemini.service_url().to_string(),
+            provider: Arc::new(gemini),
+            version: None,
+            pricing: None,
+            model_pricing: Vec::new(),
+        };
+        assert!(AlternateClient::Claude.provider_supported(&gemini));
+        assert!(!AlternateClient::Codex.provider_supported(&gemini));
+        assert!(AlternateClient::Goose.provider_supported(&gemini));
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/codex.rs
+++ b/rust/crates/cli/src/commands/codex.rs
@@ -1,9 +1,13 @@
-use std::path::Path;
 #[cfg(windows)]
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use clap::Args;
+
+use super::claude::{AlternateClient, AlternateProvider, prepare_alternate_provider};
+
+const ALTERNATE_PROVIDER_ID: &str = "pay_alt";
+const ALTERNATE_BASE_INSTRUCTIONS: &str = "You are Codex, a coding agent working with the user in the current workspace. Follow the developer instructions. Use the provided tools to inspect and modify files when requested, verify your work, and report results concisely. Do not invent tool results.";
 
 pub(crate) const PAY_MCP_ENABLED_TOOLS: &[&str] = &[
     "curl",
@@ -28,12 +32,34 @@ pub struct CodexCommand {
 }
 
 impl CodexCommand {
-    pub fn run(self, pay_bin: &str, active_account_name: Option<&str>) -> pay_core::Result<i32> {
-        let instructions_file = write_instructions_file()?;
+    pub fn run(
+        self,
+        pay_bin: &str,
+        active_account_name: Option<&str>,
+        network_override: Option<&str>,
+        alternate_provider: bool,
+    ) -> pay_core::Result<i32> {
+        let alternate = if alternate_provider && !codex_metadata_requested(&self.args) {
+            Some(prepare_alternate_provider(
+                AlternateClient::Codex,
+                &self.args,
+                network_override,
+                active_account_name,
+            )?)
+        } else {
+            None
+        };
+
+        let model_catalog_file = alternate
+            .as_ref()
+            .and_then(|provider| provider.model.as_deref())
+            .map(write_model_catalog_file)
+            .transpose()?;
         let codex_args = build_codex_args(
             pay_bin,
             active_account_name,
-            instructions_file.path(),
+            alternate.as_ref(),
+            model_catalog_file.as_ref().map(|file| file.path()),
             &self.args,
         );
 
@@ -59,10 +85,16 @@ impl CodexCommand {
     }
 }
 
+fn codex_metadata_requested(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "--version" | "-V"))
+}
+
 fn build_codex_args(
     pay_bin: &str,
     active_account_name: Option<&str>,
-    instructions_path: &Path,
+    alternate: Option<&AlternateProvider>,
+    model_catalog_path: Option<&std::path::Path>,
     extra_args: &[String],
 ) -> Vec<String> {
     let mut args = vec![
@@ -76,6 +108,42 @@ fn build_codex_args(
             toml_string_array(PAY_MCP_ENABLED_TOOLS)
         ),
     ];
+
+    if let Some(alternate) = alternate {
+        args.extend([
+            "-c".to_string(),
+            config_string("model_provider", ALTERNATE_PROVIDER_ID),
+            "-c".to_string(),
+            config_string(
+                &format!("model_providers.{ALTERNATE_PROVIDER_ID}.name"),
+                "Pay alternate provider",
+            ),
+            "-c".to_string(),
+            config_string(
+                &format!("model_providers.{ALTERNATE_PROVIDER_ID}.base_url"),
+                &alternate.base_url,
+            ),
+            "-c".to_string(),
+            config_string(
+                &format!("model_providers.{ALTERNATE_PROVIDER_ID}.wire_api"),
+                "responses",
+            ),
+        ]);
+        if let Some(model) = alternate.model.as_deref() {
+            args.extend([
+                "-c".to_string(),
+                config_string("model", model),
+                "-c".to_string(),
+                config_string("model_reasoning_effort", "none"),
+            ]);
+        }
+        if let Some(path) = model_catalog_path {
+            args.extend([
+                "-c".to_string(),
+                config_string("model_catalog_json", &path.to_string_lossy()),
+            ]);
+        }
+    }
 
     // Pass config to MCP server via env.
     let mut env_parts = Vec::new();
@@ -99,25 +167,64 @@ fn build_codex_args(
         args.push(format!("mcp_servers.pay.env={{{}}}", env_parts.join(",")));
     }
 
+    // This is additive to Codex's model prompt. `model_instructions_file`
+    // replaces the model prompt and leaves alternate models without Codex's
+    // core agent instructions.
     args.push("-c".to_string());
     args.push(config_string(
-        "model_instructions_file",
-        &instructions_path.to_string_lossy(),
+        "developer_instructions",
+        pay_core::instructions::INSTRUCTIONS,
     ));
     args.extend(extra_args.iter().cloned());
     args
 }
 
-fn write_instructions_file() -> pay_core::Result<tempfile::NamedTempFile> {
+fn write_model_catalog_file(model: &str) -> pay_core::Result<tempfile::NamedTempFile> {
     use std::io::Write;
 
     let mut file = tempfile::Builder::new()
-        .prefix("pay_codex_instructions_")
-        .suffix(".md")
+        .prefix("pay_codex_model_catalog_")
+        .suffix(".json")
         .tempfile()?;
-    file.write_all(pay_core::instructions::INSTRUCTIONS.as_bytes())?;
+    let catalog = build_model_catalog(model);
+    serde_json::to_writer(&mut file, &catalog)?;
     file.flush()?;
     Ok(file)
+}
+
+fn build_model_catalog(model: &str) -> serde_json::Value {
+    serde_json::json!({
+        "models": [{
+            "slug": model,
+            "display_name": model,
+            "description": "OpenAI-compatible model routed through Pay",
+            "default_reasoning_level": null,
+            "supported_reasoning_levels": [],
+            "shell_type": "default",
+            "visibility": "list",
+            "supported_in_api": true,
+            "priority": 1,
+            "availability_nux": null,
+            "upgrade": null,
+            "base_instructions": ALTERNATE_BASE_INSTRUCTIONS,
+            "supports_reasoning_summaries": false,
+            "default_reasoning_summary": "none",
+            "support_verbosity": false,
+            "default_verbosity": null,
+            "apply_patch_tool_type": null,
+            "web_search_tool_type": "text",
+            "truncation_policy": {"mode": "bytes", "limit": 10000},
+            "supports_parallel_tool_calls": false,
+            "supports_image_detail_original": false,
+            "context_window": 1000000,
+            "max_context_window": 1000000,
+            "effective_context_window_percent": 95,
+            "experimental_supported_tools": [],
+            "input_modalities": ["text"],
+            "supports_search_tool": false,
+            "use_responses_lite": false
+        }]
+    })
 }
 
 fn config_string(key: &str, value: &str) -> String {
@@ -231,12 +338,7 @@ mod tests {
 
     #[test]
     fn build_args_escapes_windows_paths_as_toml() {
-        let args = build_codex_args(
-            r#"C:\Users\me\pay.exe"#,
-            Some("default"),
-            Path::new(r#"C:\Users\me\AppData\Local\Temp\pay instructions.md"#),
-            &[],
-        );
+        let args = build_codex_args(r#"C:\Users\me\pay.exe"#, Some("default"), None, None, &[]);
 
         assert!(args.contains(&r#"mcp_servers.pay.command="C:\\Users\\me\\pay.exe""#.to_string()));
         assert!(args.contains(
@@ -245,10 +347,53 @@ mod tests {
         assert!(
             args.contains(&r#"mcp_servers.pay.env={PAY_ACTIVE_ACCOUNT="default"}"#.to_string())
         );
+        assert!(
+            args.iter()
+                .any(|arg| arg.starts_with("developer_instructions="))
+        );
+    }
+
+    #[test]
+    fn build_args_routes_codex_through_alternate_responses_provider() {
+        let alternate = AlternateProvider {
+            base_url: "http://127.0.0.1:54321/v1".to_string(),
+            model: Some("qwen3-coder-next".to_string()),
+        };
+        let args = build_codex_args(
+            "pay",
+            None,
+            Some(&alternate),
+            Some(std::path::Path::new("/tmp/pay-model-catalog.json")),
+            &[],
+        );
+
+        assert!(args.contains(&"model_provider=\"pay_alt\"".to_string()));
         assert!(args.contains(
-            &r#"model_instructions_file="C:\\Users\\me\\AppData\\Local\\Temp\\pay instructions.md""#
-                .to_string()
+            &"model_providers.pay_alt.base_url=\"http://127.0.0.1:54321/v1\"".to_string()
         ));
+        assert!(args.contains(&"model_providers.pay_alt.wire_api=\"responses\"".to_string()));
+        assert!(args.contains(&"model=\"qwen3-coder-next\"".to_string()));
+        assert!(args.contains(&"model_reasoning_effort=\"none\"".to_string()));
+        assert!(args.contains(&"model_catalog_json=\"/tmp/pay-model-catalog.json\"".to_string()));
+    }
+
+    #[test]
+    fn alternate_model_catalog_disables_unsupported_openai_features() {
+        let catalog = build_model_catalog("qwen3.7-plus");
+        let model = &catalog["models"][0];
+
+        assert_eq!(model["slug"], "qwen3.7-plus");
+        assert_eq!(model["supported_reasoning_levels"], serde_json::json!([]));
+        assert_eq!(model["supports_reasoning_summaries"], false);
+        assert_eq!(model["supports_parallel_tool_calls"], false);
+        assert_eq!(model["input_modalities"], serde_json::json!(["text"]));
+    }
+
+    #[test]
+    fn metadata_requests_skip_alternate_provider_selection() {
+        assert!(codex_metadata_requested(&["--version".to_string()]));
+        assert!(codex_metadata_requested(&["-h".to_string()]));
+        assert!(!codex_metadata_requested(&["hello".to_string()]));
     }
 
     #[cfg(windows)]

--- a/rust/crates/cli/src/commands/goose.rs
+++ b/rust/crates/cli/src/commands/goose.rs
@@ -1,0 +1,193 @@
+//! `pay goose` — launch Goose with the pay MCP server and optional paid
+//! alternate-provider routing.
+
+use std::process::{Command, Stdio};
+
+use clap::Args;
+
+use super::claude::{AlternateClient, AlternateProvider, prepare_alternate_provider};
+
+const GOOSE_PROVIDER_ENV: &str = "GOOSE_PROVIDER";
+const GOOSE_MODEL_ENV: &str = "GOOSE_MODEL";
+const OPENAI_HOST_ENV: &str = "OPENAI_HOST";
+const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
+const OPENAI_BASE_PATH_ENV: &str = "OPENAI_BASE_PATH";
+const GOOSE_DISABLE_SESSION_NAMING_ENV: &str = "GOOSE_DISABLE_SESSION_NAMING";
+
+/// Run Goose with 402 payment support.
+#[derive(Args)]
+#[command(disable_help_flag = true)]
+pub struct GooseCommand {
+    /// Arguments forwarded to `goose session`.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
+}
+
+impl GooseCommand {
+    pub fn run(
+        self,
+        pay_bin: &str,
+        active_account_name: Option<&str>,
+        network_override: Option<&str>,
+        _alternate_provider: bool,
+    ) -> pay_core::Result<i32> {
+        if goose_version_requested(&self.args) {
+            return launch_goose(&self.args, None, active_account_name);
+        }
+        if goose_help_requested(&self.args) {
+            let mut args = vec!["session".to_string()];
+            args.extend(self.args);
+            return launch_goose(&args, None, active_account_name);
+        }
+
+        // Goose is intentionally alternate-first: both `pay goose` and
+        // `pay --alt goose` select a paid provider and use the payer proxy.
+        let alternate = prepare_alternate_provider(
+            AlternateClient::Goose,
+            &self.args,
+            network_override,
+            active_account_name,
+        )?;
+        let mut args = vec!["session".to_string(), "--with-extension".to_string()];
+        args.push(pay_mcp_command(pay_bin));
+        args.extend(args_without_model(&self.args));
+        launch_goose(&args, Some(&alternate), active_account_name)
+    }
+}
+
+fn launch_goose(
+    args: &[String],
+    alternate: Option<&AlternateProvider>,
+    active_account_name: Option<&str>,
+) -> pay_core::Result<i32> {
+    let mut command = Command::new("goose");
+    command
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    if let Some(account) = active_account_name {
+        command.env("PAY_ACTIVE_ACCOUNT", account);
+    }
+    if let Some(alternate) = alternate {
+        let model = alternate.model.as_deref().ok_or_else(|| {
+            pay_core::Error::Config(
+                "Goose alternate-provider routing requires a selected model".to_string(),
+            )
+        })?;
+        command.envs(goose_provider_env(alternate, model));
+    }
+
+    let status = command.status().map_err(|e| {
+        pay_core::Error::Config(format!(
+            "Failed to launch Goose: {e}. Install: https://block.github.io/goose/docs/getting-started/installation"
+        ))
+    })?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn goose_provider_env(alternate: &AlternateProvider, model: &str) -> Vec<(String, String)> {
+    vec![
+        (GOOSE_PROVIDER_ENV.to_string(), "openai".to_string()),
+        (GOOSE_MODEL_ENV.to_string(), model.to_string()),
+        (OPENAI_HOST_ENV.to_string(), alternate.base_url.clone()),
+        (OPENAI_API_KEY_ENV.to_string(), "pay".to_string()),
+        (
+            OPENAI_BASE_PATH_ENV.to_string(),
+            "v1/chat/completions".to_string(),
+        ),
+        // Goose otherwise makes a second, hidden model request after each of
+        // the first few turns to generate a session title. With a paid
+        // provider that request opens and settles its own payment channel.
+        (
+            GOOSE_DISABLE_SESSION_NAMING_ENV.to_string(),
+            "true".to_string(),
+        ),
+    ]
+}
+
+fn goose_version_requested(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "--version" | "-V"))
+}
+
+fn goose_help_requested(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+}
+
+fn args_without_model(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if matches!(arg.as_str(), "--model" | "-m") {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--model=") {
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
+}
+
+fn pay_mcp_command(pay_bin: &str) -> String {
+    #[cfg(windows)]
+    return format!("\"{}\" mcp", pay_bin.replace('"', "\"\""));
+
+    #[cfg(not(windows))]
+    format!("'{}' mcp", pay_bin.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alternate_provider_uses_goose_openai_environment() {
+        let provider = AlternateProvider {
+            base_url: "http://127.0.0.1:54321".to_string(),
+            model: Some("qwen3.7-plus".to_string()),
+        };
+        let env = goose_provider_env(&provider, "qwen3.7-plus");
+
+        assert!(env.contains(&(GOOSE_PROVIDER_ENV.to_string(), "openai".to_string())));
+        assert!(env.contains(&(
+            OPENAI_HOST_ENV.to_string(),
+            "http://127.0.0.1:54321".to_string()
+        )));
+        assert!(env.contains(&(
+            OPENAI_BASE_PATH_ENV.to_string(),
+            "v1/chat/completions".to_string()
+        )));
+        assert!(env.contains(&(
+            GOOSE_DISABLE_SESSION_NAMING_ENV.to_string(),
+            "true".to_string()
+        )));
+    }
+
+    #[test]
+    fn selected_model_is_not_forwarded_to_goose_session() {
+        assert_eq!(
+            args_without_model(&["--model".into(), "qwen3.7-plus".into(), "--debug".into()]),
+            vec!["--debug"]
+        );
+    }
+
+    #[test]
+    fn metadata_requests_do_not_start_alternate_routing() {
+        assert!(goose_version_requested(&["--version".into()]));
+        assert!(goose_help_requested(&["--help".into()]));
+        assert!(!goose_version_requested(&["hello".into()]));
+        assert!(!goose_help_requested(&["hello".into()]));
+    }
+
+    #[test]
+    fn mcp_command_quotes_spaces() {
+        let command = pay_mcp_command("/tmp/Pay Tools/pay");
+        assert!(command.contains("Pay Tools"));
+        assert!(command.ends_with(" mcp"));
+    }
+}

--- a/rust/crates/cli/src/commands/goose.rs
+++ b/rust/crates/cli/src/commands/goose.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 
 use clap::Args;
 
+use super::agent_args::args_without_model;
 use super::claude::{AlternateClient, AlternateProvider, prepare_alternate_provider};
 
 const GOOSE_PROVIDER_ENV: &str = "GOOSE_PROVIDER";
@@ -117,22 +118,6 @@ fn goose_help_requested(args: &[String]) -> bool {
         .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
 }
 
-fn args_without_model(args: &[String]) -> Vec<String> {
-    let mut out = Vec::with_capacity(args.len());
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        if matches!(arg.as_str(), "--model" | "-m") {
-            let _ = iter.next();
-            continue;
-        }
-        if arg.starts_with("--model=") {
-            continue;
-        }
-        out.push(arg.clone());
-    }
-    out
-}
-
 fn pay_mcp_command(pay_bin: &str) -> String {
     #[cfg(windows)]
     return format!("\"{}\" mcp", pay_bin.replace('"', "\"\""));
@@ -166,14 +151,6 @@ mod tests {
             GOOSE_DISABLE_SESSION_NAMING_ENV.to_string(),
             "true".to_string()
         )));
-    }
-
-    #[test]
-    fn selected_model_is_not_forwarded_to_goose_session() {
-        assert_eq!(
-            args_without_model(&["--model".into(), "qwen3.7-plus".into(), "--debug".into()]),
-            vec!["--debug"]
-        );
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub(crate) mod agent_args;
 pub mod catalog;
 pub mod claude;
 pub mod codex;

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod codex;
 pub mod curl;
 pub mod docs;
 pub mod fetch;
+pub mod goose;
 pub mod help;
 pub mod http;
 pub(crate) mod payer_proxy;
@@ -48,7 +49,10 @@ pub enum Command {
     Claude(claude::ClaudeCommand),
     /// Run Codex with 402 payment support.
     Codex(codex::CodexCommand),
+    /// Run Goose with 402 payment support.
+    Goose(goose::GooseCommand),
     /// Run Qoder CLI (qodercli) with 402 payment support.
+    #[command(alias = "qoder")]
     Qodercli(qodercli::QodercliCommand),
     /// Manage accounts (new, import, list, default, remove, export).
     /// With no subcommand, lists accounts and prints the available subcommands.
@@ -112,6 +116,7 @@ pub enum ToolKind {
     Fetch,
     Claude,
     Codex,
+    Goose,
     Qodercli,
     Mcp,
 }
@@ -141,6 +146,7 @@ impl Command {
             | Command::Fetch(_)
             | Command::Claude(_)
             | Command::Codex(_)
+            | Command::Goose(_)
             | Command::Qodercli(_)
             | Command::Send(_)
             | Command::Topup(_) => true,
@@ -167,6 +173,7 @@ impl Command {
             Command::Fetch(_) => ToolKind::Fetch,
             Command::Claude(_) => ToolKind::Claude,
             Command::Codex(_) => ToolKind::Codex,
+            Command::Goose(_) => ToolKind::Goose,
             Command::Qodercli(_) => ToolKind::Qodercli,
             Command::Account { .. }
             | Command::Whoami(_)
@@ -253,8 +260,24 @@ impl Command {
                 network_override,
                 alternate_provider,
             )?),
-            Command::Codex(cmd) => std::process::exit(cmd.run(&pay_bin, account_override)?),
-            Command::Qodercli(cmd) => std::process::exit(cmd.run(&pay_bin, account_override)?),
+            Command::Codex(cmd) => std::process::exit(cmd.run(
+                &pay_bin,
+                account_override,
+                network_override,
+                alternate_provider,
+            )?),
+            Command::Goose(cmd) => std::process::exit(cmd.run(
+                &pay_bin,
+                account_override,
+                network_override,
+                alternate_provider,
+            )?),
+            Command::Qodercli(cmd) => std::process::exit(cmd.run(
+                &pay_bin,
+                account_override,
+                network_override,
+                alternate_provider,
+            )?),
             Command::Docs { command } => return command.run(),
             _ => {}
         }

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -8,13 +8,11 @@
 //! 1. Every request is forwarded upstream, preserving method, path+query,
 //!    and headers (minus hop-by-hop). The request body is buffered (capped
 //!    at [`MAX_BODY_BYTES`]) so it can be replayed.
-//! 2. When the upstream answers `402 Payment Required` with an MPP
-//!    `Payment` challenge, the proxy builds a signed charge credential
-//!    with the exact client machinery that backs `pay curl` / `pay fetch`
-//!    ([`pay_core::mpp::select_challenge_by_balance`] +
-//!    [`pay_core::mpp::build_credential`]), swaps the request's
-//!    `Authorization` header for `Payment <credential>`, and retries the
-//!    buffered request exactly once.
+//! 2. When the upstream answers `402 Payment Required`, the proxy satisfies
+//!    the configured payment protocol and retries the buffered request once.
+//!    Hosted inference routes can require an MPP delegated session; the
+//!    resulting channel authorization is cached for the lifetime of the agent
+//!    process so subsequent completions do not create new on-chain payments.
 //! 3. Response bodies stream back ([`Body::from_stream`]).
 //! 4. If payment fails for any reason (mainnet challenge under
 //!    `--sandbox`, insufficient funds, signer errors, …) the original 402
@@ -35,6 +33,7 @@
 //! challenge fires on the translated request, so the retry replays the
 //! translated body. Other requests and dialects pass through untouched.
 
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use axum::Router;
@@ -58,6 +57,10 @@ use crate::commands::server::inference::providers::Dialect;
 /// buffer so a runaway client cannot exhaust memory.
 const MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
 
+/// The payer proxy is an implementation detail shared only with the child
+/// agent process. Never bind it to a LAN-reachable interface.
+const PAYER_PROXY_BIND_IP: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
 /// Handle returned by [`start_background`].
 pub struct PayerProxy {
     /// Base URL of the payer proxy, e.g. `http://127.0.0.1:52341`.
@@ -66,6 +69,15 @@ pub struct PayerProxy {
     /// startup (in sandbox mode the ephemeral localnet wallet is created
     /// eagerly so the pubkey is always known).
     pub payer_pubkey: Option<String>,
+}
+
+/// Payment contract the local payer must enforce for its upstream.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PaymentProtocol {
+    /// Preserve the generic payer behavior: MPP charge first, then x402 upto.
+    Auto,
+    /// Require a delegated MPP session and never fall back to x402.
+    MppSession,
 }
 
 /// Where the payer forwards to, and how to talk to it.
@@ -86,6 +98,15 @@ pub struct PayerUpstream {
     /// translated requests are sent to, e.g. `v1/chat/completions` or
     /// Alibaba's `compatible-mode/v1/chat/completions`.
     pub chat_path: String,
+    /// Responses API path used by Codex, e.g.
+    /// `compatible-mode/v1/responses` for Alibaba Model Studio.
+    pub responses_path: String,
+    /// Refuse successful responses that were served without a 402 handshake.
+    /// Hosted catalog providers set this so a gateway routing mistake cannot
+    /// silently bypass metering and consume upstream credentials for free.
+    pub require_payment: bool,
+    /// Payment protocol required by this route.
+    pub payment_protocol: PaymentProtocol,
 }
 
 /// Shared state for the proxy handlers.
@@ -96,6 +117,14 @@ struct PayerState {
     dialect: Dialect,
     /// Chat-completions path without a leading slash (translation target).
     chat_path: String,
+    responses_path: String,
+    require_payment: bool,
+    payment_protocol: PaymentProtocol,
+    /// Cached delegated-session authorization. Holding the mutex serializes
+    /// requests because the server reserves a session's remaining capacity
+    /// while it meters a response.
+    session_authorization: tokio::sync::Mutex<Option<String>>,
+    session_opener: SessionOpener,
     client: reqwest::Client,
     store: Arc<dyn AccountsStore>,
     /// Forced network slug (`--sandbox` → `localnet`, `--mainnet` →
@@ -134,6 +163,11 @@ impl PayerState {
             host_header,
             dialect: upstream.dialect,
             chat_path: upstream.chat_path.trim_start_matches('/').to_string(),
+            responses_path: upstream.responses_path.trim_start_matches('/').to_string(),
+            require_payment: upstream.require_payment,
+            payment_protocol: upstream.payment_protocol,
+            session_authorization: tokio::sync::Mutex::new(None),
+            session_opener: build_session_authorization,
             client,
             store,
             network_override,
@@ -141,7 +175,16 @@ impl PayerState {
             per_request_cap_base_units: None,
         })
     }
+
+    #[cfg(test)]
+    fn with_session_opener(mut self, session_opener: SessionOpener) -> Self {
+        self.session_opener = session_opener;
+        self
+    }
 }
+
+type SessionOpener =
+    fn(&PayerState, &pay_core::mpp::Challenge) -> pay_core::Result<(PaidHeaders, String)>;
 
 /// Start the payer proxy on an ephemeral 127.0.0.1 port, on a dedicated
 /// runtime in a background thread (the `pay claude` main thread stays
@@ -161,7 +204,7 @@ pub fn start_background(
     )?);
     let payer_pubkey = resolve_payer_pubkey(&state);
 
-    let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<u16, String>>();
+    let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<SocketAddr, String>>();
     let serve_state = state.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_multi_thread()
@@ -175,27 +218,27 @@ pub fn start_background(
             }
         };
         rt.block_on(async move {
-            let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            let listener = match tokio::net::TcpListener::bind((PAYER_PROXY_BIND_IP, 0)).await {
                 Ok(listener) => listener,
                 Err(e) => {
                     let _ = tx.send(Err(format!("payer proxy bind: {e}")));
                     return;
                 }
             };
-            let port = match listener.local_addr() {
-                Ok(addr) => addr.port(),
+            let addr = match listener.local_addr() {
+                Ok(addr) => addr,
                 Err(e) => {
                     let _ = tx.send(Err(format!("payer proxy local_addr: {e}")));
                     return;
                 }
             };
-            let _ = tx.send(Ok(port));
+            let _ = tx.send(Ok(addr));
             axum::serve(listener, router(serve_state)).await.ok();
         });
     });
 
-    let port = match rx.recv() {
-        Ok(Ok(port)) => port,
+    let addr = match rx.recv() {
+        Ok(Ok(addr)) => addr,
         Ok(Err(e)) => return Err(pay_core::Error::Config(e)),
         Err(_) => {
             return Err(pay_core::Error::Config(
@@ -205,7 +248,7 @@ pub fn start_background(
     };
 
     Ok(PayerProxy {
-        base_url: format!("http://127.0.0.1:{port}"),
+        base_url: format!("http://{addr}"),
         payer_pubkey,
     })
 }
@@ -283,10 +326,38 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             openai_body,
             true,
         ),
-        None => (format!("{}{}", state.upstream, path_query), body, false),
+        None => (
+            passthrough_upstream_url(&state, &method, &path, &path_query),
+            body,
+            false,
+        ),
     };
 
-    let first = match send_upstream(&state, &method, &url, &headers, body.clone(), None).await {
+    // A delegated session is shared across every request made by this agent
+    // process. Keep the guard until the gateway has accepted and metered this
+    // response so two concurrent calls cannot reserve the same channel cap.
+    let mut session_authorization = if state.payment_protocol == PaymentProtocol::MppSession {
+        Some(state.session_authorization.lock().await)
+    } else {
+        None
+    };
+    let cached_payment = session_authorization
+        .as_deref()
+        .and_then(Option::as_ref)
+        .cloned()
+        .map(PaidHeaders::mpp);
+    let used_cached_session = cached_payment.is_some();
+
+    let first = match send_upstream(
+        &state,
+        &method,
+        &url,
+        &headers,
+        body.clone(),
+        cached_payment.as_ref(),
+    )
+    .await
+    {
         Ok(resp) => resp,
         Err(e) => {
             tracing::warn!(%url, error = %e, "payer proxy: upstream request failed");
@@ -299,7 +370,22 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
     };
 
     if first.status() != StatusCode::PAYMENT_REQUIRED {
+        if state.require_payment && first.status().is_success() && !used_cached_session {
+            tracing::error!(%url, status = %first.status(), "payer proxy: hosted provider bypassed its payment gate");
+            let message = if path.trim_matches('/') == "v1/responses" {
+                "payer proxy: the hosted Responses endpoint is not payment-enabled; deploy its Agent Gateway provider spec before using Codex"
+            } else {
+                "payer proxy: hosted provider returned success without a payment challenge; refusing an ungated response"
+            };
+            return (StatusCode::BAD_GATEWAY, message).into_response();
+        }
         return deliver(first, translated).await;
+    }
+
+    // The cached channel may have expired, closed, or exhausted its cap. Drop
+    // it before consuming the fresh challenge and opening a replacement.
+    if let Some(cached) = session_authorization.as_mut() {
+        **cached = None;
     }
 
     // Buffer the 402 so it can be passed through untouched when payment
@@ -318,26 +404,45 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         }
     };
 
-    let challenges = pay_core::mpp::parse_all(
+    let mpp_challenges = pay_core::mpp::parse_all(
         resp_headers
             .get_all(header::WWW_AUTHENTICATE)
             .iter()
             .filter_map(|value| value.to_str().ok()),
     );
+    let charge_challenges: Vec<_> = mpp_challenges
+        .iter()
+        .filter(|challenge| pay_kit::mpp::client::is_solana_charge_challenge(challenge))
+        .cloned()
+        .collect();
 
-    // Scheme precedence: MPP charge first (the established path), then x402
-    // `upto` (per-token gateway). MPP wins when both are advertised — it is
-    // an exact, single-shot charge, whereas `upto` opens a spending channel
-    // for a ceiling; prefer the tighter commitment when the server offers a
-    // choice.
-    let payment = if !challenges.is_empty() {
+    let payment = if state.payment_protocol == PaymentProtocol::MppSession {
+        let Some(challenge) = mpp_challenges.into_iter().find(|challenge| {
+            challenge.method.as_str() == "solana" && challenge.intent.as_str() == "session"
+        }) else {
+            tracing::error!(%url, "payer proxy: hosted route did not advertise the required MPP session");
+            return (
+                StatusCode::BAD_GATEWAY,
+                "payer proxy: this hosted route requires MPP session, but the gateway did not advertise one",
+            )
+                .into_response();
+        };
+        let state = state.clone();
+        tokio::task::spawn_blocking(move || {
+            (state.session_opener)(&state, &challenge)
+                .map(|(payment, authorization)| (payment, Some(authorization)))
+        })
+        .await
+    } else if !charge_challenges.is_empty() {
+        // Scheme precedence in auto mode: MPP charge first, then x402 upto.
         // `select_challenge_by_balance` / `build_credential` spin their own
         // runtimes and may block on RPC + signing — keep them off the async
         // workers.
         let state = state.clone();
         let resource_url = url.clone();
         tokio::task::spawn_blocking(move || {
-            build_payment_authorization(&state, &challenges, &resource_url)
+            build_payment_authorization(&state, &charge_challenges, &resource_url)
+                .map(|payment| (payment, None))
         })
         .await
     } else if let Some(upto) = parse_upto_challenge(&resp_headers, &resp_body) {
@@ -345,14 +450,16 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         // settles the actual per-token cost after serving and refunds the rest.
         let state = state.clone();
         let resource_url = url.clone();
-        tokio::task::spawn_blocking(move || build_upto_authorization(&state, &upto, &resource_url))
-            .await
+        tokio::task::spawn_blocking(move || {
+            build_upto_authorization(&state, &upto, &resource_url).map(|payment| (payment, None))
+        })
+        .await
     } else {
         tracing::warn!(%url, "payer proxy: 402 without an MPP or x402-upto challenge — passing through");
         return buffered_response(status, &resp_headers, resp_body);
     };
 
-    let payment = match payment {
+    let (payment, new_session_authorization) = match payment {
         Ok(Ok(payment)) => payment,
         Ok(Err(e)) => {
             tracing::warn!(%url, error = %e, "payer proxy: could not pay 402 — passing it through");
@@ -363,15 +470,56 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             return buffered_response(status, &resp_headers, resp_body);
         }
     };
+    if let (Some(cache), Some(authorization)) = (
+        session_authorization.as_mut(),
+        new_session_authorization.as_ref(),
+    ) {
+        **cache = Some(authorization.clone());
+    }
 
     tracing::info!(%url, "payer proxy: 402 paid — retrying once with payment credential");
     match send_upstream(&state, &method, &url, &headers, body, Some(&payment)).await {
-        Ok(retry) => deliver(retry, translated).await,
+        Ok(retry) => {
+            if retry.status() == StatusCode::PAYMENT_REQUIRED
+                && let Some(cache) = session_authorization.as_mut()
+            {
+                **cache = None;
+            }
+            deliver(retry, translated).await
+        }
         Err(e) => {
+            if let Some(cache) = session_authorization.as_mut() {
+                **cache = None;
+            }
             tracing::warn!(%url, error = %e, "payer proxy: paid retry failed — returning the original 402");
             buffered_response(status, &resp_headers, resp_body)
         }
     }
+}
+
+/// Map standard agent API paths to the selected provider's declared paths.
+/// Hosted gateways may expose compatible APIs below a provider prefix.
+fn passthrough_upstream_url(
+    state: &PayerState,
+    method: &Method,
+    path: &str,
+    path_query: &str,
+) -> String {
+    if *method == Method::POST {
+        let incoming = path.trim_matches('/');
+        let target = match incoming {
+            "v1/chat/completions" => Some(state.chat_path.as_str()),
+            "v1/responses" => Some(state.responses_path.as_str()),
+            _ => None,
+        };
+        if let Some(target) = target
+            && target.trim_matches('/') != incoming
+        {
+            let query = path_query.strip_prefix(path).unwrap_or_default();
+            return format!("{}/{}{}", state.upstream, target.trim_matches('/'), query);
+        }
+    }
+    format!("{}{}", state.upstream, path_query)
 }
 
 /// Parse an x402 `upto` challenge off the buffered 402 response. `parse_upto`
@@ -550,6 +698,72 @@ impl PaidHeaders {
             headers: vec![(header::AUTHORIZATION.as_str().to_string(), credential)],
         }
     }
+}
+
+/// Open a delegated push session and return the authorization reused for all
+/// subsequent requests handled by this payer proxy.
+fn build_session_authorization(
+    state: &PayerState,
+    challenge: &pay_core::mpp::Challenge,
+) -> pay_core::Result<(PaidHeaders, String)> {
+    use pay_kit::mpp::{SessionMode, SessionRequest, SessionSettlementAuthority};
+
+    let request: SessionRequest = challenge
+        .request
+        .decode()
+        .map_err(|error| pay_core::Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
+    if request.settlement_authority != SessionSettlementAuthority::Delegated {
+        return Err(pay_core::Error::Mpp(
+            "agent payer requires a delegated MPP session".to_string(),
+        ));
+    }
+    if !request.modes.is_empty() && !request.modes.contains(&SessionMode::Push) {
+        return Err(pay_core::Error::Mpp(
+            "agent payer requires MPP session push mode".to_string(),
+        ));
+    }
+    if let (Some(forced), Some(offered)) = (
+        state.network_override.as_deref(),
+        request.network.as_deref(),
+    ) && forced != offered
+    {
+        return Err(pay_core::Error::Mpp(format!(
+            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{offered}`"
+        )));
+    }
+
+    let cap = request.cap.parse::<u64>().map_err(|_| {
+        pay_core::Error::Mpp(format!(
+            "MPP session challenge advertised a non-numeric cap: {}",
+            request.cap
+        ))
+    })?;
+    if cap == 0 {
+        return Err(pay_core::Error::Mpp(
+            "MPP session challenge advertised a zero cap".to_string(),
+        ));
+    }
+    let min_delta = request
+        .min_voucher_delta
+        .as_deref()
+        .unwrap_or("1")
+        .parse::<u64>()
+        .map_err(|_| {
+            pay_core::Error::Mpp("MPP session challenge has invalid minVoucherDelta".to_string())
+        })?;
+    let deposit = min_delta.saturating_mul(1_000).max(1_000_000).min(cap);
+    let sandbox = state.network_override.as_deref() == Some("localnet");
+    let (_handle, authorization) = pay_core::session::open_payment_channel_session_header(
+        challenge,
+        &request,
+        state.store.as_ref(),
+        state.network_override.as_deref(),
+        state.account_override.as_deref(),
+        deposit,
+        sandbox,
+    )?;
+
+    Ok((PaidHeaders::mpp(authorization.clone()), authorization))
 }
 
 /// Select a payable MPP challenge and build the `Authorization: Payment …`
@@ -796,6 +1010,12 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn payer_proxy_bind_address_is_loopback_only() {
+        assert!(PAYER_PROXY_BIND_IP.is_loopback());
+        assert_eq!(PAYER_PROXY_BIND_IP, Ipv4Addr::LOCALHOST);
+    }
+
     /// A canned MPP charge challenge that signs fully offline: the
     /// embedded `recentBlockhash` skips the blockhash RPC and the
     /// embedded `tokenProgram` + `decimals` skip the mint-account RPC
@@ -819,6 +1039,17 @@ mod tests {
             "solana",
             "charge",
             pay_kit::mpp::Base64UrlJson::from_value(&request).unwrap(),
+        );
+        pay_kit::mpp::format_www_authenticate(&challenge).unwrap()
+    }
+
+    fn session_challenge_header() -> String {
+        let challenge = pay_core::mpp::Challenge::new(
+            "USDC",
+            "test",
+            "solana",
+            "session",
+            pay_kit::mpp::Base64UrlJson::from_value(&serde_json::json!({})).unwrap(),
         );
         pay_kit::mpp::format_www_authenticate(&challenge).unwrap()
     }
@@ -883,6 +1114,9 @@ mod tests {
                 host_header: None,
                 dialect: Dialect::Anthropic,
                 chat_path: "v1/chat/completions".to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: false,
+                payment_protocol: PaymentProtocol::Auto,
             },
             network_override,
         )
@@ -897,10 +1131,96 @@ mod tests {
                 host_header: None,
                 dialect: Dialect::OpenAiCompat,
                 chat_path: "compatible-mode/v1/chat/completions".to_string(),
+                responses_path: "compatible-mode/v1/responses".to_string(),
+                require_payment: false,
+                payment_protocol: PaymentProtocol::Auto,
             },
             network_override,
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn direct_openai_chat_uses_declared_provider_path() {
+        let upstream = spawn_server(Router::new().route(
+            "/compatible-mode/v1/chat/completions",
+            axum::routing::post(|req: Request| async move {
+                assert_eq!(req.uri().query(), Some("trace=1"));
+                (StatusCode::OK, "provider path reached")
+            }),
+        ))
+        .await;
+        let payer = spawn_openai_payer(upstream, None).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{payer}/v1/chat/completions?trace=1"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "provider path reached");
+    }
+
+    #[tokio::test]
+    async fn direct_openai_responses_uses_declared_provider_path() {
+        let upstream = spawn_server(Router::new().route(
+            "/compatible-mode/v1/responses",
+            axum::routing::post(|req: Request| async move {
+                assert_eq!(req.uri().query(), Some("trace=1"));
+                (StatusCode::OK, "responses path reached")
+            }),
+        ))
+        .await;
+        let payer = spawn_openai_payer(upstream, None).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{payer}/v1/responses?trace=1"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "responses path reached");
+    }
+
+    #[tokio::test]
+    async fn hosted_provider_success_without_payment_challenge_is_rejected() {
+        let upstream = spawn_server(Router::new().fallback(any(|| async {
+            (StatusCode::OK, "ungated upstream response")
+        })))
+        .await;
+        let payer = spawn_payer_with(
+            PayerUpstream {
+                base_url: upstream,
+                host_header: None,
+                dialect: Dialect::Anthropic,
+                chat_path: "v1/chat/completions".to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: true,
+                payment_protocol: PaymentProtocol::Auto,
+            },
+            None,
+        )
+        .await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{payer}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            response
+                .text()
+                .await
+                .unwrap()
+                .contains("refusing an ungated response")
+        );
     }
 
     const OPENAI_COMPLETION_JSON: &str = r#"{
@@ -1091,6 +1411,144 @@ mod tests {
             seen.retry_body.as_deref(),
             Some(body.as_bytes()),
             "upto retry must replay the identical request body"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn session_challenge_does_not_mask_coexisting_x402_upto() {
+        let seen = Arc::new(Mutex::new(StubSeen::default()));
+        let record = seen.clone();
+        let app = Router::new().fallback(any(move |req: Request| {
+            let record = record.clone();
+            async move {
+                let sig = req
+                    .headers()
+                    .get("payment-signature")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let _ = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await;
+                let mut seen = record.lock().unwrap();
+                seen.calls += 1;
+                if seen.calls == 1 {
+                    return Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::WWW_AUTHENTICATE, session_challenge_header())
+                        .header("payment-required", upto_challenge_header("500000"))
+                        .body(Body::from(r#"{"error":"payment required"}"#))
+                        .unwrap();
+                }
+                seen.retry_auth = sig;
+                (StatusCode::OK, "upto paid ok").into_response()
+            }
+        }));
+        let upstream = spawn_server(app).await;
+        let payer = spawn_payer(upstream, None).await;
+
+        let resp = reqwest::Client::new()
+            .post(format!("{payer}/v1/messages"))
+            .body(r#"{"messages":[]}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.calls, 2, "x402 upto must pay and retry once");
+        assert!(
+            seen.retry_auth
+                .as_deref()
+                .is_some_and(|sig| !sig.is_empty()),
+            "session MPP must not prevent the x402 PAYMENT-SIGNATURE retry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforced_session_is_opened_once_and_reused_without_x402() {
+        fn open_test_session(
+            _state: &PayerState,
+            _challenge: &pay_core::mpp::Challenge,
+        ) -> pay_core::Result<(PaidHeaders, String)> {
+            let authorization = "Payment test-session".to_string();
+            Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::<(Option<String>, Option<String>)>::new()));
+        let record = seen.clone();
+        let app = Router::new().fallback(any(move |req: Request| {
+            let record = record.clone();
+            async move {
+                let authorization = req
+                    .headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let payment_signature = req
+                    .headers()
+                    .get("payment-signature")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let _ = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await;
+                record
+                    .lock()
+                    .unwrap()
+                    .push((authorization.clone(), payment_signature));
+                if authorization
+                    .as_deref()
+                    .is_some_and(|value| value.starts_with("Payment "))
+                {
+                    return (StatusCode::OK, "session paid").into_response();
+                }
+                Response::builder()
+                    .status(StatusCode::PAYMENT_REQUIRED)
+                    .header(header::WWW_AUTHENTICATE, session_challenge_header())
+                    .header("payment-required", upto_challenge_header("500000"))
+                    .body(Body::from(r#"{"error":"payment required"}"#))
+                    .unwrap()
+            }
+        }));
+        let upstream = spawn_server(app).await;
+        let store: Arc<dyn AccountsStore> = Arc::new(MemoryAccountsStore::new());
+        let state = PayerState::new(
+            PayerUpstream {
+                base_url: upstream,
+                host_header: None,
+                dialect: Dialect::Anthropic,
+                chat_path: "v1/chat/completions".to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: true,
+                payment_protocol: PaymentProtocol::MppSession,
+            },
+            store,
+            None,
+            None,
+        )
+        .unwrap()
+        .with_session_opener(open_test_session);
+        let payer = spawn_server(router(Arc::new(state))).await;
+
+        let client = reqwest::Client::new();
+        for prompt in ["one", "two"] {
+            let response = client
+                .post(format!("{payer}/v1/messages"))
+                .body(prompt)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            seen.len(),
+            3,
+            "only the first call should require a 402 retry"
+        );
+        let first_paid = seen[1].0.as_deref().expect("first session authorization");
+        let reused = seen[2].0.as_deref().expect("reused session authorization");
+        assert_eq!(first_paid, reused, "the same session must be reused");
+        assert!(
+            seen.iter().all(|(_, signature)| signature.is_none()),
+            "session enforcement must never fall back to x402"
         );
     }
 
@@ -1319,6 +1777,9 @@ mod tests {
                 host_header: Some("ollama.localhost:1402".to_string()),
                 dialect: Dialect::Anthropic,
                 chat_path: "v1/chat/completions".to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: false,
+                payment_protocol: PaymentProtocol::Auto,
             },
             None,
         )

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -542,10 +542,11 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             deliver(retry, translated).await
         }
         Err(e) => {
-            if let Some(cache) = session_authorization.as_mut() {
-                **cache = None;
-            }
-            tracing::warn!(%url, error = %e, "payer proxy: paid retry failed — returning the original 402");
+            // The open credential is idempotent and the channel may already
+            // have been funded even though the response was lost. Preserve it
+            // across transport failures; only a definitive 402 rejection
+            // above proves that the cached session cannot be reused.
+            tracing::warn!(%url, error = %e, "payer proxy: paid retry failed — preserving the session and returning the original 402");
             buffered_response(status, &resp_headers, resp_body)
         }
     }
@@ -1061,6 +1062,7 @@ mod tests {
     use std::time::Duration;
 
     use pay_core::accounts::MemoryAccountsStore;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
 
@@ -1603,6 +1605,72 @@ mod tests {
         assert!(
             seen.iter().all(|(_, signature)| signature.is_none()),
             "session enforcement must never fall back to x402"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn session_open_credential_survives_a_paid_retry_transport_error() {
+        fn open_test_session(
+            _state: &PayerState,
+            _challenge: &pay_core::mpp::Challenge,
+        ) -> pay_core::Result<(PaidHeaders, String)> {
+            let authorization = "Payment durable-open".to_string();
+            Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+        }
+
+        // Serve exactly the challenge response, then stop listening before the
+        // paid retry. This models a connection failure after the open may
+        // already have funded its channel.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let challenge = session_challenge_header();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            drop(listener);
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await;
+            let body = r#"{"error":"payment required"}"#;
+            let response = format!(
+                "HTTP/1.1 402 Payment Required\r\nWWW-Authenticate: {challenge}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let store: Arc<dyn AccountsStore> = Arc::new(MemoryAccountsStore::new());
+        let state = Arc::new(
+            PayerState::new(
+                PayerUpstream {
+                    base_url: format!("http://{addr}"),
+                    host_header: None,
+                    dialect: Dialect::Anthropic,
+                    chat_path: "v1/chat/completions".to_string(),
+                    responses_path: "v1/responses".to_string(),
+                    require_payment: true,
+                    payment_protocol: PaymentProtocol::MppSession,
+                },
+                store,
+                None,
+                None,
+            )
+            .unwrap()
+            .with_session_opener(open_test_session),
+        );
+        let payer = spawn_server(router(state.clone())).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{payer}/v1/messages"))
+            .body("{}")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert_eq!(
+            state.session_authorization.lock().await.as_deref(),
+            Some("Payment durable-open"),
+            "an ambiguous transport failure must retain the idempotent open credential"
         );
     }
 

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -98,8 +98,7 @@ pub struct PayerUpstream {
     /// translated requests are sent to, e.g. `v1/chat/completions` or
     /// Alibaba's `compatible-mode/v1/chat/completions`.
     pub chat_path: String,
-    /// Responses API path used by Codex, e.g.
-    /// `compatible-mode/v1/responses` for Alibaba Model Studio.
+    /// Responses API path used by Codex, e.g. `v1/responses`.
     pub responses_path: String,
     /// Refuse successful responses that were served without a 402 handshake.
     /// Hosted catalog providers set this so a gateway routing mistake cannot
@@ -1186,7 +1185,7 @@ mod tests {
                 host_header: None,
                 dialect: Dialect::OpenAiCompat,
                 chat_path: "compatible-mode/v1/chat/completions".to_string(),
-                responses_path: "compatible-mode/v1/responses".to_string(),
+                responses_path: "v1/responses".to_string(),
                 require_payment: false,
                 payment_protocol: PaymentProtocol::Auto,
             },
@@ -1221,7 +1220,7 @@ mod tests {
     #[tokio::test]
     async fn direct_openai_responses_uses_declared_provider_path() {
         let upstream = spawn_server(Router::new().route(
-            "/compatible-mode/v1/responses",
+            "/v1/responses",
             axum::routing::post(|req: Request| async move {
                 assert_eq!(req.uri().query(), Some("trace=1"));
                 (StatusCode::OK, "responses path reached")

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -122,7 +122,7 @@ struct PayerState {
     /// Cached delegated-session authorization. Holding the mutex serializes
     /// requests because the server reserves a session's remaining capacity
     /// while it meters a response.
-    session_authorization: tokio::sync::Mutex<Option<String>>,
+    session_authorization: Arc<tokio::sync::Mutex<Option<String>>>,
     session_opener: SessionOpener,
     client: reqwest::Client,
     store: Arc<dyn AccountsStore>,
@@ -165,7 +165,7 @@ impl PayerState {
             responses_path: upstream.responses_path.trim_start_matches('/').to_string(),
             require_payment: upstream.require_payment,
             payment_protocol: upstream.payment_protocol,
-            session_authorization: tokio::sync::Mutex::new(None),
+            session_authorization: Arc::new(tokio::sync::Mutex::new(None)),
             session_opener: build_session_authorization,
             client,
             store,
@@ -336,7 +336,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
     // process. Keep the guard until the gateway has accepted and metered this
     // response so two concurrent calls cannot reserve the same channel cap.
     let mut session_authorization = if state.payment_protocol == PaymentProtocol::MppSession {
-        Some(state.session_authorization.lock().await)
+        Some(state.session_authorization.clone().lock_owned().await)
     } else {
         None
     };
@@ -378,7 +378,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             };
             return (StatusCode::BAD_GATEWAY, message).into_response();
         }
-        return deliver(first, translated).await;
+        return deliver(first, translated, session_authorization.take()).await;
     }
 
     // The cached channel may have expired, closed, or exhausted its cap. Drop
@@ -440,7 +440,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
                 )
                     .into_response();
             }
-            return deliver(refreshed, translated).await;
+            return deliver(refreshed, translated, session_authorization.take()).await;
         }
 
         status = refreshed.status();
@@ -539,7 +539,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             {
                 **cache = None;
             }
-            deliver(retry, translated).await
+            deliver(retry, translated, session_authorization.take()).await
         }
         Err(e) => {
             // The open credential is idempotent and the channel may already
@@ -630,9 +630,15 @@ fn translate_request(
 /// Hand an upstream response back to Claude Code: translated (SSE or
 /// buffered JSON) when the request was translated and succeeded,
 /// streamed passthrough otherwise.
-async fn deliver(resp: reqwest::Response, translated: bool) -> Response {
+type SessionAuthorizationGuard = tokio::sync::OwnedMutexGuard<Option<String>>;
+
+async fn deliver(
+    resp: reqwest::Response,
+    translated: bool,
+    session_guard: Option<SessionAuthorizationGuard>,
+) -> Response {
     if !translated || !resp.status().is_success() {
-        return stream_response(resp);
+        return stream_response(resp, session_guard);
     }
     let is_sse = resp
         .headers()
@@ -640,7 +646,7 @@ async fn deliver(resp: reqwest::Response, translated: bool) -> Response {
         .and_then(|value| value.to_str().ok())
         .is_some_and(|ct| ct.contains("text/event-stream"));
     if is_sse {
-        translate_stream_response(resp)
+        translate_stream_response(resp, session_guard)
     } else {
         translate_json_response(resp).await
     }
@@ -693,10 +699,14 @@ async fn translate_json_response(resp: reqwest::Response) -> Response {
 /// translator — chunks flow as they arrive; a carry-over buffer inside
 /// [`translate::StreamTranslator`] reassembles SSE lines split across
 /// chunk boundaries.
-fn translate_stream_response(resp: reqwest::Response) -> Response {
+fn translate_stream_response(
+    resp: reqwest::Response,
+    session_guard: Option<SessionAuthorizationGuard>,
+) -> Response {
     let status = resp.status();
     let upstream_headers = resp.headers().clone();
     let stream_body = Body::from_stream(async_stream::stream! {
+        let _session_guard = session_guard;
         let mut resp = resp;
         let mut translator = translate::StreamTranslator::new();
         loop {
@@ -972,7 +982,10 @@ async fn send_upstream(
 
 /// Stream an upstream response back to the client without buffering —
 /// SSE completion streams must flow chunk by chunk.
-fn stream_response(resp: reqwest::Response) -> Response {
+fn stream_response(
+    resp: reqwest::Response,
+    session_guard: Option<SessionAuthorizationGuard>,
+) -> Response {
     let status = resp.status();
     let headers = resp.headers().clone();
 
@@ -980,15 +993,27 @@ fn stream_response(resp: reqwest::Response) -> Response {
     if let Some(dst) = builder.headers_mut() {
         copy_response_headers(dst, &headers);
     }
-    builder
-        .body(Body::from_stream(resp.bytes_stream()))
-        .unwrap_or_else(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "payer proxy: response build error",
-            )
-                .into_response()
-        })
+    let stream_body = Body::from_stream(async_stream::stream! {
+        let _session_guard = session_guard;
+        let mut resp = resp;
+        loop {
+            match resp.chunk().await {
+                Ok(Some(chunk)) => yield Ok::<_, std::io::Error>(chunk),
+                Ok(None) => break,
+                Err(error) => {
+                    yield Err(std::io::Error::other(error));
+                    break;
+                }
+            }
+        }
+    });
+    builder.body(stream_body).unwrap_or_else(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "payer proxy: response build error",
+        )
+            .into_response()
+    })
 }
 
 /// Rebuild a fully-buffered upstream response (the 402 passthrough path).
@@ -1672,6 +1697,118 @@ mod tests {
             Some("Payment durable-open"),
             "an ambiguous transport failure must retain the idempotent open credential"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cached_session_stays_locked_until_stream_body_finishes() {
+        fn open_test_session(
+            _state: &PayerState,
+            _challenge: &pay_core::mpp::Challenge,
+        ) -> pay_core::Result<(PaidHeaders, String)> {
+            let authorization = "Payment streaming-session".to_string();
+            Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+        }
+
+        let calls = Arc::new(Mutex::new(0_usize));
+        let release_stream = Arc::new(tokio::sync::Notify::new());
+        let record = calls.clone();
+        let release = release_stream.clone();
+        let app = Router::new().fallback(any(move |req: Request| {
+            let record = record.clone();
+            let release = release.clone();
+            async move {
+                let authorization = req
+                    .headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let _ = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await;
+                let call = {
+                    let mut calls = record.lock().unwrap();
+                    *calls += 1;
+                    *calls
+                };
+                match call {
+                    1 => Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::WWW_AUTHENTICATE, session_challenge_header())
+                        .body(Body::from(r#"{"error":"payment required"}"#))
+                        .unwrap(),
+                    2 => {
+                        assert_eq!(authorization.as_deref(), Some("Payment streaming-session"));
+                        let body = Body::from_stream(async_stream::stream! {
+                            yield Ok::<_, std::io::Error>(Bytes::from_static(b"first "));
+                            release.notified().await;
+                            yield Ok(Bytes::from_static(b"done"));
+                        });
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .body(body)
+                            .unwrap()
+                    }
+                    3 => {
+                        assert_eq!(authorization.as_deref(), Some("Payment streaming-session"));
+                        (StatusCode::OK, "second response").into_response()
+                    }
+                    call => panic!("unexpected upstream call {call}"),
+                }
+            }
+        }));
+        let upstream = spawn_server(app).await;
+        let store: Arc<dyn AccountsStore> = Arc::new(MemoryAccountsStore::new());
+        let state = Arc::new(
+            PayerState::new(
+                PayerUpstream {
+                    base_url: upstream,
+                    host_header: None,
+                    dialect: Dialect::Anthropic,
+                    chat_path: "v1/chat/completions".to_string(),
+                    responses_path: "v1/responses".to_string(),
+                    require_payment: true,
+                    payment_protocol: PaymentProtocol::MppSession,
+                },
+                store,
+                None,
+                None,
+            )
+            .unwrap()
+            .with_session_opener(open_test_session),
+        );
+        let payer = spawn_server(router(state)).await;
+        let client = reqwest::Client::new();
+
+        let first = client
+            .post(format!("{payer}/v1/messages"))
+            .body("first")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second_client = client.clone();
+        let second_url = format!("{payer}/v1/messages");
+        let second =
+            tokio::spawn(async move { second_client.post(second_url).body("second").send().await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            *calls.lock().unwrap(),
+            2,
+            "the second request must not reach upstream while the first stream is active"
+        );
+        assert!(
+            !second.is_finished(),
+            "the second request must wait for the first stream's session lock"
+        );
+
+        release_stream.notify_one();
+        assert_eq!(first.text().await.unwrap(), "first done");
+        let second = tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("second request should resume after the first stream")
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.text().await.unwrap(), "second response");
+        assert_eq!(*calls.lock().unwrap(), 3);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -390,9 +390,9 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
 
     // Buffer the 402 so it can be passed through untouched when payment
     // is impossible. 402 bodies are small (a JSON error envelope).
-    let status = first.status();
-    let resp_headers = first.headers().clone();
-    let resp_body = match first.bytes().await {
+    let mut status = first.status();
+    let mut resp_headers = first.headers().clone();
+    let mut resp_body = match first.bytes().await {
         Ok(bytes) => bytes,
         Err(e) => {
             tracing::warn!(%url, error = %e, "payer proxy: failed to read 402 body");
@@ -404,12 +404,67 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         }
     };
 
-    let mpp_challenges = pay_core::mpp::parse_all(
+    let mut mpp_challenges = pay_core::mpp::parse_all(
         resp_headers
             .get_all(header::WWW_AUTHENTICATE)
             .iter()
             .filter_map(|value| value.to_str().ok()),
     );
+
+    // A cached delegated session is represented by its idempotent `open`
+    // credential. Once the server seals that channel, the resulting 402 is a
+    // terminal-session error rather than a fresh challenge. Rediscovery must
+    // therefore happen without the stale credential before we can open a
+    // replacement channel.
+    if state.payment_protocol == PaymentProtocol::MppSession
+        && used_cached_session
+        && !mpp_challenges.iter().any(|challenge| {
+            challenge.method.as_str() == "solana" && challenge.intent.as_str() == "session"
+        })
+    {
+        tracing::info!(%url, "payer proxy: cached MPP session ended; requesting a fresh challenge");
+        let refreshed = match send_upstream(&state, &method, &url, &headers, body.clone(), None)
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(%url, %error, "payer proxy: failed to refresh MPP session challenge");
+                return buffered_response(status, &resp_headers, resp_body);
+            }
+        };
+        if refreshed.status() != StatusCode::PAYMENT_REQUIRED {
+            if state.require_payment && refreshed.status().is_success() {
+                tracing::error!(%url, status = %refreshed.status(), "payer proxy: hosted provider bypassed its payment gate while refreshing a session");
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    "payer proxy: hosted provider returned success without a payment challenge; refusing an ungated response",
+                )
+                    .into_response();
+            }
+            return deliver(refreshed, translated).await;
+        }
+
+        status = refreshed.status();
+        resp_headers = refreshed.headers().clone();
+        resp_body = match refreshed.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::warn!(%url, %error, "payer proxy: failed to read refreshed MPP session challenge");
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!("payer proxy: upstream error: {error}"),
+                )
+                    .into_response();
+            }
+        };
+        mpp_challenges = pay_core::mpp::parse_all(
+            resp_headers
+                .get_all(header::WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|value| value.to_str().ok()),
+        );
+    }
+
     let charge_challenges: Vec<_> = mpp_challenges
         .iter()
         .filter(|challenge| pay_kit::mpp::client::is_solana_charge_challenge(challenge))
@@ -1549,6 +1604,91 @@ mod tests {
         assert!(
             seen.iter().all(|(_, signature)| signature.is_none()),
             "session enforcement must never fall back to x402"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ended_cached_session_discovers_and_opens_a_replacement() {
+        fn open_test_session(
+            _state: &PayerState,
+            _challenge: &pay_core::mpp::Challenge,
+        ) -> pay_core::Result<(PaidHeaders, String)> {
+            let authorization = "Payment test-session".to_string();
+            Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+        let record = seen.clone();
+        let app = Router::new().fallback(any(move |req: Request| {
+            let record = record.clone();
+            async move {
+                let authorization = req
+                    .headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let _ = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await;
+                let mut seen = record.lock().unwrap();
+                seen.push(authorization.clone());
+                match seen.len() {
+                    1 | 4 => Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::WWW_AUTHENTICATE, session_challenge_header())
+                        .body(Body::from(r#"{"error":"payment required"}"#))
+                        .unwrap(),
+                    2 | 5 => (StatusCode::OK, "session paid").into_response(),
+                    3 => Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(
+                            r#"{"error":"session_failed","message":"channel is already sealed"}"#,
+                        ))
+                        .unwrap(),
+                    call => panic!("unexpected upstream call {call}"),
+                }
+            }
+        }));
+        let upstream = spawn_server(app).await;
+        let store: Arc<dyn AccountsStore> = Arc::new(MemoryAccountsStore::new());
+        let state = PayerState::new(
+            PayerUpstream {
+                base_url: upstream,
+                host_header: None,
+                dialect: Dialect::Anthropic,
+                chat_path: "v1/chat/completions".to_string(),
+                responses_path: "v1/responses".to_string(),
+                require_payment: true,
+                payment_protocol: PaymentProtocol::MppSession,
+            },
+            store,
+            None,
+            None,
+        )
+        .unwrap()
+        .with_session_opener(open_test_session);
+        let payer = spawn_server(router(Arc::new(state))).await;
+
+        let client = reqwest::Client::new();
+        for prompt in ["one", "two"] {
+            let response = client
+                .post(format!("{payer}/v1/messages"))
+                .body(prompt)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                None,
+                Some("Payment test-session".to_string()),
+                Some("Payment test-session".to_string()),
+                None,
+                Some("Payment test-session".to_string()),
+            ],
+            "a terminal cached session must be followed by unauthenticated challenge discovery",
         );
     }
 

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -35,6 +35,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::body::{Body, Bytes};
@@ -151,10 +152,14 @@ impl PayerState {
             .map(HeaderValue::from_str)
             .transpose()
             .map_err(|e| pay_core::Error::Config(format!("payer proxy Host header: {e}")))?;
-        // No request timeout: streamed completions stay open for minutes.
+        // Do not impose a total request timeout: streamed completions may stay
+        // open for minutes. Bound connection setup and silent read stalls so a
+        // hung provider cannot retain the session mutex forever.
         // `no_proxy` keeps env proxies from hijacking localhost traffic.
         let client = reqwest::Client::builder()
             .no_proxy()
+            .connect_timeout(Duration::from_secs(15))
+            .read_timeout(Duration::from_secs(300))
             .build()
             .map_err(|e| pay_core::Error::Config(format!("payer proxy HTTP client: {e}")))?;
         Ok(Self {

--- a/rust/crates/cli/src/commands/qodercli/mod.rs
+++ b/rust/crates/cli/src/commands/qodercli/mod.rs
@@ -12,9 +12,13 @@ use std::process::{Command, Stdio};
 
 use clap::Args;
 
+use super::claude::{AlternateClient, AlternateProvider, prepare_alternate_provider};
+
 /// Allow-list of pay MCP tools surfaced to qodercli. Must stay in sync
 /// with the tool set exposed by other pay launchers.
 const ALLOWED_TOOLS: &str = "mcp__pay__curl,mcp__pay__search_catalog,mcp__pay__list_catalog,mcp__pay__get_catalog_entry,mcp__pay__get_balance,mcp__pay__topup,mcp__pay__create_skill";
+const EXTERNAL_PROVIDER_PROBE_BASE_URL: &str = "http://127.0.0.1:9/v1";
+const EXTERNAL_PROVIDER_PROBE_MODEL: &str = "pay-qoder-access-probe";
 
 /// Run Qoder CLI (qodercli) with 402 payment support.
 ///
@@ -74,12 +78,30 @@ where
 }
 
 impl QodercliCommand {
-    pub fn run(self, pay_bin: &str, active_account_name: Option<&str>) -> pay_core::Result<i32> {
+    pub fn run(
+        self,
+        pay_bin: &str,
+        active_account_name: Option<&str>,
+        network_override: Option<&str>,
+        alternate_provider: bool,
+    ) -> pay_core::Result<i32> {
         let mcp_config =
             build_mcp_config(pay_bin, active_account_name, |var| std::env::var(var).ok());
+        let alternate = if alternate_provider && !qoder_metadata_requested(&self.args) {
+            ensure_qoder_external_provider_access()?;
+            Some(prepare_alternate_provider(
+                AlternateClient::Qoder,
+                &self.args,
+                network_override,
+                active_account_name,
+            )?)
+        } else {
+            None
+        };
+        let qoder_args = qoder_args(&self.args, alternate.as_ref())?;
 
         #[cfg(windows)]
-        return launch_windows(mcp_config, &self.args);
+        return launch_windows(mcp_config, &qoder_args);
 
         #[cfg(not(windows))]
         {
@@ -90,7 +112,7 @@ impl QodercliCommand {
                 .arg(ALLOWED_TOOLS)
                 .arg("--append-system-prompt")
                 .arg(pay_core::instructions::INSTRUCTIONS)
-                .args(&self.args)
+                .args(&qoder_args)
                 .stdin(Stdio::inherit())
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit())
@@ -104,6 +126,116 @@ impl QodercliCommand {
             Ok(status.code().unwrap_or(1))
         }
     }
+}
+
+fn qoder_metadata_requested(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "--version" | "-v"))
+}
+
+fn qoder_args(
+    extra_args: &[String],
+    alternate: Option<&AlternateProvider>,
+) -> pay_core::Result<Vec<String>> {
+    let Some(alternate) = alternate else {
+        return Ok(extra_args.to_vec());
+    };
+    let Some(model) = alternate.model.as_deref() else {
+        return Err(pay_core::Error::Config(
+            "Qoder alternate-provider routing requires a selected model; pass `--model <model>`"
+                .to_string(),
+        ));
+    };
+
+    let (settings, provider_model) = qoder_provider_settings(alternate, model);
+    let mut args = vec![
+        "--settings".to_string(),
+        settings.to_string(),
+        "--model".to_string(),
+        provider_model,
+    ];
+    args.extend(args_without_model(extra_args));
+    Ok(args)
+}
+
+// Qoder's BYOK custom-model path is forwarded by Qoder's servers, so it
+// cannot reach the payer proxy on 127.0.0.1. The external-provider path is a
+// direct client transport, but Qoder enables it only for entitled accounts.
+fn qoder_provider_settings(
+    alternate: &AlternateProvider,
+    model: &str,
+) -> (serde_json::Value, String) {
+    let provider_model = format!("pay/{model}");
+    let settings = serde_json::json!({
+        "providers": {
+            "pay": {
+                "baseUrl": alternate.base_url,
+                "apiKey": "pay",
+                "displayName": "Pay alternate provider",
+                "model": provider_model,
+                "models": [{
+                    "model": provider_model,
+                    "displayName": format!("Pay: {model}"),
+                    "capabilities": {
+                        "tools": true,
+                        "vision": false,
+                        "thinking": false
+                    }
+                }]
+            }
+        }
+    });
+    (settings, provider_model)
+}
+
+fn ensure_qoder_external_provider_access() -> pay_core::Result<()> {
+    let probe = AlternateProvider {
+        base_url: EXTERNAL_PROVIDER_PROBE_BASE_URL.to_string(),
+        model: Some(EXTERNAL_PROVIDER_PROBE_MODEL.to_string()),
+    };
+    let (settings, provider_model) = qoder_provider_settings(&probe, EXTERNAL_PROVIDER_PROBE_MODEL);
+    let output = Command::new("qodercli")
+        .arg("--list-models")
+        .arg("--settings")
+        .arg(settings.to_string())
+        .output()
+        .map_err(|e| {
+            pay_core::Error::Config(format!(
+                "Failed to query Qoder's external-provider capability: {e}"
+            ))
+        })?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if output.status.success()
+        && qoder_model_list_contains(&stdout, &provider_model, EXTERNAL_PROVIDER_PROBE_MODEL)
+    {
+        return Ok(());
+    }
+
+    Err(pay_core::Error::Config(
+        "Qoder has not enabled direct external providers for this account. Its public custom-model feature routes through Qoder's servers and does not accept the local payer proxy URL. Ask Qoder to enable direct external providers for this account, or use `pay --alt codex`, `pay --alt claude`, or `pay goose`.".to_string(),
+    ))
+}
+
+fn qoder_model_list_contains(output: &str, provider_model: &str, model: &str) -> bool {
+    output.lines().map(str::trim).any(|line| {
+        line == provider_model || line == format!("Pay: {model}") || line == format!("Pay {model}")
+    })
+}
+
+fn args_without_model(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if matches!(arg.as_str(), "--model" | "-m") {
+            let _ = iter.next();
+            continue;
+        }
+        if arg.starts_with("--model=") {
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out
 }
 
 // On Windows, cmd.exe (used to execute .cmd batch wrappers) rejects
@@ -278,5 +410,62 @@ mod tests {
         assert!(!env.contains_key("PAY_PROTOCOL_ENFORCED"));
         assert!(!env.contains_key("PAY_DEBUGGER_PROXY"));
         assert!(!env.contains_key("PAY_ACTIVE_ACCOUNT"));
+    }
+
+    #[test]
+    fn alternate_provider_is_injected_as_a_direct_qoder_provider() {
+        let alternate = AlternateProvider {
+            base_url: "http://127.0.0.1:54321/v1".to_string(),
+            model: Some("qwen3-coder-next".to_string()),
+        };
+
+        let args = qoder_args(
+            &[
+                "--model".to_string(),
+                "qwen3-coder-next".to_string(),
+                "-p".to_string(),
+                "hello".to_string(),
+            ],
+            Some(&alternate),
+        )
+        .unwrap();
+
+        assert_eq!(args[0], "--settings");
+        assert_eq!(args[2], "--model");
+        assert_eq!(args[3], "pay/qwen3-coder-next");
+        let settings: serde_json::Value = serde_json::from_str(&args[1]).unwrap();
+        let provider = &settings["providers"]["pay"];
+        assert_eq!(provider["baseUrl"], "http://127.0.0.1:54321/v1");
+        assert_eq!(provider["apiKey"], "pay");
+        assert_eq!(provider["model"], "pay/qwen3-coder-next");
+        assert_eq!(provider["models"][0]["model"], "pay/qwen3-coder-next");
+        assert_eq!(provider["models"][0]["capabilities"]["tools"], true);
+        assert_eq!(&args[4..], ["-p", "hello"]);
+    }
+
+    #[test]
+    fn metadata_requests_skip_alternate_provider_selection() {
+        assert!(qoder_metadata_requested(&["--version".to_string()]));
+        assert!(qoder_metadata_requested(&["-h".to_string()]));
+        assert!(!qoder_metadata_requested(&["hello".to_string()]));
+    }
+
+    #[test]
+    fn qoder_external_provider_must_appear_in_the_entitled_model_list() {
+        assert!(qoder_model_list_contains(
+            "MODEL\nUltimate\npay/qwen3.7-plus\n",
+            "pay/qwen3.7-plus",
+            "qwen3.7-plus"
+        ));
+        assert!(qoder_model_list_contains(
+            "MODEL\nPay: qwen3.7-plus\n",
+            "pay/qwen3.7-plus",
+            "qwen3.7-plus"
+        ));
+        assert!(!qoder_model_list_contains(
+            "MODEL\nUltimate\nQwen3.7-Plus\n",
+            "pay/qwen3.7-plus",
+            "qwen3.7-plus"
+        ));
     }
 }

--- a/rust/crates/cli/src/commands/qodercli/mod.rs
+++ b/rust/crates/cli/src/commands/qodercli/mod.rs
@@ -12,6 +12,7 @@ use std::process::{Command, Stdio};
 
 use clap::Args;
 
+use super::agent_args::args_without_model;
 use super::claude::{AlternateClient, AlternateProvider, prepare_alternate_provider};
 
 /// Allow-list of pay MCP tools surfaced to qodercli. Must stay in sync
@@ -220,22 +221,6 @@ fn qoder_model_list_contains(output: &str, provider_model: &str, model: &str) ->
     output.lines().map(str::trim).any(|line| {
         line == provider_model || line == format!("Pay: {model}") || line == format!("Pay {model}")
     })
-}
-
-fn args_without_model(args: &[String]) -> Vec<String> {
-    let mut out = Vec::with_capacity(args.len());
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        if matches!(arg.as_str(), "--model" | "-m") {
-            let _ = iter.next();
-            continue;
-        }
-        if arg.starts_with("--model=") {
-            continue;
-        }
-        out.push(arg.clone());
-    }
-    out
 }
 
 // On Windows, cmd.exe (used to execute .cmd batch wrappers) rejects

--- a/rust/crates/cli/src/commands/server/inference/mod.rs
+++ b/rust/crates/cli/src/commands/server/inference/mod.rs
@@ -55,11 +55,6 @@ pub fn local_gateway_provider_host(slug: &str) -> String {
     format!("{slug}.localhost:{}", default_gateway_port())
 }
 
-/// User-facing provider URL for the default local gateway.
-pub fn local_gateway_provider_url(slug: &str) -> String {
-    format!("http://{}", local_gateway_provider_host(slug))
-}
-
 fn default_gateway_port() -> &'static str {
     DEFAULT_BIND
         .rsplit_once(':')

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -16,6 +16,13 @@ pub const DEFAULT_CATALOG_FQNS: &[&str] = &[
     "solana-foundation/google/generativelanguage",
 ];
 
+const ALIBABA_MODELSTUDIO_FQN: &str = "solana-foundation/alibaba/modelstudio";
+const ALIBABA_MODELSTUDIO_GATEWAY_URL: &str = "https://modelstudio.alibaba.gateway-402.com";
+const ALIBABA_RESPONSES_PATH: &str = "compatible-mode/v1/responses";
+const GOOGLE_GEMINI_FQN: &str = "solana-foundation/google/generativelanguage";
+const GOOGLE_GEMINI_GATEWAY_URL: &str = "https://generativelanguage.google.gateway-402.com";
+const GOOGLE_OPENAI_CHAT_PATH: &str = "v1beta/openai/chat/completions";
+
 /// A hosted inference provider backed by a resolved catalog entry.
 pub struct CatalogProvider {
     fqn: String,
@@ -68,6 +75,167 @@ impl CatalogProvider {
     }
 }
 
+/// Built-in Alibaba provider used until its skills-catalog entry is
+/// published. The deployed gateway already exists, so making picker
+/// visibility depend on the separate catalog publication is unnecessary.
+/// Models and pricing stay sourced from the gateway YAML rather than a second
+/// hard-coded list.
+pub fn alibaba_modelstudio_fallback() -> CatalogProvider {
+    let yaml = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../web-ui/proxy/alibaba-qwen.yml"
+    ));
+    let mut provider = provider_from_embedded_spec(
+        ALIBABA_MODELSTUDIO_FQN,
+        "modelstudio",
+        ALIBABA_MODELSTUDIO_GATEWAY_URL,
+        yaml,
+    );
+    add_alibaba_responses_compat(&mut provider);
+    provider
+}
+
+/// Built-in Gemini provider. The spec includes Google's official OpenAI
+/// compatibility endpoint so OpenAI-chat agent harnesses can use Gemini
+/// without a Gemini-native client.
+pub fn google_gemini_fallback() -> CatalogProvider {
+    let yaml = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../web-ui/proxy/google-gemini.yml"
+    ));
+    provider_from_embedded_spec(
+        GOOGLE_GEMINI_FQN,
+        "generativelanguage",
+        GOOGLE_GEMINI_GATEWAY_URL,
+        yaml,
+    )
+}
+
+fn provider_from_embedded_spec(
+    fqn: &str,
+    slug: &str,
+    gateway_url: &str,
+    yaml: &str,
+) -> CatalogProvider {
+    let spec: pay_types::metering::ApiSpec =
+        serde_yml::from_str(yaml).expect("embedded inference gateway spec must be valid");
+    let endpoints = spec
+        .endpoints
+        .into_iter()
+        .map(|endpoint| pay_core::skills::Endpoint {
+            method: format!("{:?}", endpoint.method).to_ascii_uppercase(),
+            path: endpoint.path,
+            full_path: String::new(),
+            resource: endpoint.resource,
+            description: endpoint.description.unwrap_or_default(),
+            pricing: endpoint
+                .metering
+                .and_then(|metering| serde_json::to_value(metering).ok()),
+        })
+        .collect();
+
+    CatalogProvider {
+        fqn: fqn.to_string(),
+        slug: slug.to_string(),
+        title: display_title(fqn, &spec.title),
+        service_url: gateway_url.to_string(),
+        endpoints,
+    }
+}
+
+/// Add the compatibility endpoint to an older cached catalog entry. Copy its
+/// pricing from native `generateContent`, which keeps the overlay aligned with
+/// the live catalog's current model/rate variants.
+fn add_gemini_openai_compat(provider: &mut CatalogProvider) {
+    if provider
+        .endpoints
+        .iter()
+        .any(|endpoint| endpoint.path.trim_matches('/') == GOOGLE_OPENAI_CHAT_PATH)
+    {
+        return;
+    }
+    let mut endpoint = provider
+        .endpoints
+        .iter()
+        .find(|endpoint| {
+            endpoint.method.eq_ignore_ascii_case("POST")
+                && endpoint.path.trim_matches('/') == "v1beta/models/{modelsId}:generateContent"
+        })
+        .cloned()
+        .or_else(|| {
+            google_gemini_fallback()
+                .endpoints
+                .into_iter()
+                .find(|endpoint| endpoint.path.trim_matches('/') == GOOGLE_OPENAI_CHAT_PATH)
+        });
+    if let Some(endpoint) = endpoint.as_mut() {
+        endpoint.path = GOOGLE_OPENAI_CHAT_PATH.to_string();
+        endpoint.full_path.clear();
+        endpoint.resource = Some("chat".to_string());
+        endpoint.description = "OpenAI-compatible chat completions for Gemini models.".to_string();
+    }
+    if let Some(endpoint) = endpoint {
+        provider.endpoints.push(endpoint);
+    }
+}
+
+/// Upgrade older Model Studio catalog entries with the Responses API route
+/// used by Codex. The deployed upstream keeps all OpenAI-compatible surfaces
+/// below `compatible-mode/`.
+fn add_alibaba_responses_compat(provider: &mut CatalogProvider) {
+    if let Some(endpoint) = provider
+        .endpoints
+        .iter_mut()
+        .find(|endpoint| endpoint.path.trim_matches('/').ends_with("/responses"))
+    {
+        endpoint.path = ALIBABA_RESPONSES_PATH.to_string();
+        endpoint.full_path.clear();
+        return;
+    }
+    let mut endpoint = provider
+        .endpoints
+        .iter()
+        .find(|endpoint| {
+            endpoint.method.eq_ignore_ascii_case("POST")
+                && endpoint
+                    .path
+                    .to_ascii_lowercase()
+                    .contains("chat/completions")
+        })
+        .cloned();
+    if let Some(endpoint) = endpoint.as_mut() {
+        endpoint.path = ALIBABA_RESPONSES_PATH.to_string();
+        endpoint.full_path.clear();
+        endpoint.resource = Some("responses".to_string());
+        endpoint.description = "OpenAI Responses API for Qwen agent models.".to_string();
+    }
+    if let Some(endpoint) = endpoint {
+        provider.endpoints.push(endpoint);
+    }
+}
+
+/// Keep the live default gateways visible while their separate catalog entries
+/// are missing. Older cached Gemini entries are upgraded with the official
+/// OpenAI compatibility route until the refreshed gateway catalog includes it.
+pub fn append_default_fallbacks(providers: &mut Vec<CatalogProvider>) {
+    if let Some(provider) = providers
+        .iter_mut()
+        .find(|provider| provider.fqn == ALIBABA_MODELSTUDIO_FQN)
+    {
+        add_alibaba_responses_compat(provider);
+    } else {
+        providers.push(alibaba_modelstudio_fallback());
+    }
+    if let Some(provider) = providers
+        .iter_mut()
+        .find(|provider| provider.fqn == GOOGLE_GEMINI_FQN)
+    {
+        add_gemini_openai_compat(provider);
+    } else {
+        providers.push(google_gemini_fallback());
+    }
+}
+
 #[async_trait::async_trait]
 impl InferenceProvider for CatalogProvider {
     fn slug(&self) -> &str {
@@ -106,13 +274,14 @@ impl InferenceProvider for CatalogProvider {
         None
     }
     async fn list_models(&self, client: &reqwest::Client, base_url: &str) -> Vec<String> {
+        let fallback = || models_from_pricing_variants(&self.endpoints);
         let Some(ep) = self.model_list_endpoint() else {
-            return Vec::new();
+            return fallback();
         };
         let path = format!("/{}", ep.path.trim_start_matches('/'));
         match get_json(client, base_url.trim_end_matches('/'), &path).await {
             Some(json) => parse_model_names(&json),
-            None => Vec::new(),
+            None => fallback(),
         }
     }
     /// Metered catalog endpoints, in gate convention (no leading slash).
@@ -130,7 +299,15 @@ impl InferenceProvider for CatalogProvider {
     }
     fn dialect(&self) -> Dialect {
         if self.fqn.contains("google/generativelanguage") {
-            Dialect::GeminiNative
+            if self
+                .endpoints
+                .iter()
+                .any(|endpoint| endpoint.path.trim_matches('/') == GOOGLE_OPENAI_CHAT_PATH)
+            {
+                Dialect::OpenAiCompat
+            } else {
+                Dialect::GeminiNative
+            }
         } else if self.fqn.contains("alibaba/modelstudio") {
             Dialect::OpenAiCompat
         } else {
@@ -354,6 +531,27 @@ fn parse_model_names(json: &serde_json::Value) -> Vec<String> {
             .collect();
     }
     Vec::new()
+}
+
+/// Model variants are also the catalog for hosted gateways that cannot proxy
+/// an upstream model-list endpoint (Model Studio is one such provider).
+fn models_from_pricing_variants(endpoints: &[pay_core::skills::Endpoint]) -> Vec<String> {
+    let mut models = Vec::new();
+    for value in endpoints
+        .iter()
+        .filter_map(|endpoint| endpoint.pricing.as_ref())
+        .filter_map(|pricing| pricing.get("variants"))
+        .filter_map(serde_json::Value::as_array)
+        .flatten()
+        .filter_map(|variant| variant.get("value"))
+        .filter_map(serde_json::Value::as_str)
+        .filter(|value| *value != "default")
+    {
+        if !models.iter().any(|model| model == value) {
+            models.push(value.to_string());
+        }
+    }
+    models
 }
 
 /// Picker title for a catalog entry. Known default fqns get a short brand
@@ -652,9 +850,15 @@ mod tests {
 
     #[test]
     fn dialect_maps_known_fqns() {
-        assert_eq!(
-            gemini("https://example.com").dialect(),
-            Dialect::GeminiNative
+        let mut native_gemini = gemini("https://example.com");
+        assert_eq!(native_gemini.dialect(), Dialect::GeminiNative);
+        add_gemini_openai_compat(&mut native_gemini);
+        assert_eq!(native_gemini.dialect(), Dialect::OpenAiCompat);
+        assert!(
+            native_gemini
+                .paid_endpoints()
+                .iter()
+                .any(|endpoint| endpoint.path == GOOGLE_OPENAI_CHAT_PATH)
         );
 
         let alibaba: pay_core::skills::Service = serde_json::from_value(serde_json::json!({
@@ -695,6 +899,49 @@ mod tests {
             serde_json::from_str(r#"{"data":[{"id":"qwen-max"},{"id":"qwen-plus"}]}"#).unwrap();
         assert_eq!(parse_model_names(&json), vec!["qwen-max", "qwen-plus"]);
         assert!(parse_model_names(&serde_json::json!({"ok": true})).is_empty());
+    }
+
+    #[test]
+    fn pricing_variants_are_a_model_catalog_without_the_default_sentinel() {
+        let provider = gemini_variant_priced();
+        assert_eq!(
+            models_from_pricing_variants(&provider.endpoints),
+            vec!["gemini-2.5-flash-lite", "gemini-2.5-flash"]
+        );
+    }
+
+    #[test]
+    fn alibaba_qwen_gateway_spec_is_valid_for_all_agent_surfaces() {
+        let yaml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../web-ui/proxy/alibaba-qwen.yml"
+        ));
+        let spec: pay_types::metering::ApiSpec = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(
+            spec.endpoints
+                .iter()
+                .map(|endpoint| endpoint.path.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "compatible-mode/v1/chat/completions",
+                "v1/responses",
+                "v1/messages"
+            ]
+        );
+        assert!(pay_types::metering::validate_api_spec(&spec).is_empty());
+
+        for endpoint in &spec.endpoints {
+            let variants = &endpoint
+                .metering
+                .as_ref()
+                .expect("each Qwen surface is metered")
+                .variants;
+            assert!(
+                variants
+                    .iter()
+                    .any(|variant| variant.value == "qwen3-coder-next")
+            );
+        }
     }
 
     #[test]
@@ -746,6 +993,60 @@ mod tests {
             let slugs: Vec<&str> = providers.iter().map(|p| p.slug()).collect();
             assert_eq!(slugs, vec!["generativelanguage"]);
         });
+    }
+
+    #[test]
+    fn alibaba_fallback_is_picker_ready_without_a_catalog_entry() {
+        let provider = alibaba_modelstudio_fallback();
+
+        assert_eq!(provider.title(), "Alibaba Model Studio");
+        assert_eq!(provider.slug(), "modelstudio");
+        assert_eq!(
+            provider.service_url(),
+            "https://modelstudio.alibaba.gateway-402.com"
+        );
+        assert_eq!(provider.dialect(), Dialect::OpenAiCompat);
+        assert!(
+            provider
+                .paid_endpoints()
+                .iter()
+                .any(|endpoint| endpoint.path == ALIBABA_RESPONSES_PATH)
+        );
+        assert_eq!(
+            models_from_pricing_variants(&provider.endpoints),
+            [
+                "qwen3.7-plus",
+                "qwen3.7-max",
+                "qwen3.6-flash",
+                "qwen3-coder-next",
+                "qwen3-coder-plus",
+            ]
+        );
+
+        let mut providers = Vec::new();
+        append_default_fallbacks(&mut providers);
+        append_default_fallbacks(&mut providers);
+        assert_eq!(
+            providers.len(),
+            2,
+            "fallbacks must not duplicate themselves"
+        );
+    }
+
+    #[test]
+    fn gemini_fallback_is_openai_chat_compatible() {
+        let provider = google_gemini_fallback();
+
+        assert_eq!(provider.title(), "Google Gemini");
+        assert_eq!(provider.slug(), "generativelanguage");
+        assert_eq!(provider.service_url(), GOOGLE_GEMINI_GATEWAY_URL);
+        assert_eq!(provider.dialect(), Dialect::OpenAiCompat);
+        assert!(
+            provider
+                .paid_endpoints()
+                .iter()
+                .any(|endpoint| endpoint.path == GOOGLE_OPENAI_CHAT_PATH)
+        );
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -31,6 +31,9 @@ pub struct CatalogProvider {
     title: String,
     service_url: String,
     endpoints: Vec<pay_core::skills::Endpoint>,
+    /// Last-resort model IDs for gateways without a model-list endpoint.
+    /// The live skills catalog remains authoritative when it is available.
+    fallback_models: Vec<String>,
 }
 
 impl CatalogProvider {
@@ -45,6 +48,7 @@ impl CatalogProvider {
             title,
             service_url: svc.meta.service_url.trim_end_matches('/').to_string(),
             endpoints: svc.endpoints.clone(),
+            fallback_models: Vec::new(),
         }
     }
 
@@ -78,68 +82,90 @@ impl CatalogProvider {
 /// Built-in Alibaba provider used until its skills-catalog entry is
 /// published. The deployed gateway already exists, so making picker
 /// visibility depend on the separate catalog publication is unnecessary.
-/// Models and pricing stay sourced from the gateway YAML rather than a second
-/// hard-coded list.
+/// Endpoint pricing stays sourced from the live skills catalog. This fallback
+/// contains only the routing surface and model IDs required to launch an agent.
 pub fn alibaba_modelstudio_fallback() -> CatalogProvider {
-    let yaml = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../../web-ui/proxy/alibaba-qwen.yml"
-    ));
-    let mut provider = provider_from_embedded_spec(
-        ALIBABA_MODELSTUDIO_FQN,
-        "modelstudio",
-        ALIBABA_MODELSTUDIO_GATEWAY_URL,
-        yaml,
-    );
-    add_alibaba_responses_compat(&mut provider);
-    provider
-}
-
-/// Built-in Gemini provider. The spec includes Google's official OpenAI
-/// compatibility endpoint so OpenAI-chat agent harnesses can use Gemini
-/// without a Gemini-native client.
-pub fn google_gemini_fallback() -> CatalogProvider {
-    let yaml = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../../web-ui/proxy/google-gemini.yml"
-    ));
-    provider_from_embedded_spec(
-        GOOGLE_GEMINI_FQN,
-        "generativelanguage",
-        GOOGLE_GEMINI_GATEWAY_URL,
-        yaml,
-    )
-}
-
-fn provider_from_embedded_spec(
-    fqn: &str,
-    slug: &str,
-    gateway_url: &str,
-    yaml: &str,
-) -> CatalogProvider {
-    let spec: pay_types::metering::ApiSpec =
-        serde_yml::from_str(yaml).expect("embedded inference gateway spec must be valid");
-    let endpoints = spec
-        .endpoints
-        .into_iter()
-        .map(|endpoint| pay_core::skills::Endpoint {
-            method: format!("{:?}", endpoint.method).to_ascii_uppercase(),
-            path: endpoint.path,
-            full_path: String::new(),
-            resource: endpoint.resource,
-            description: endpoint.description.unwrap_or_default(),
-            pricing: endpoint
-                .metering
-                .and_then(|metering| serde_json::to_value(metering).ok()),
-        })
-        .collect();
-
     CatalogProvider {
-        fqn: fqn.to_string(),
-        slug: slug.to_string(),
-        title: display_title(fqn, &spec.title),
-        service_url: gateway_url.to_string(),
-        endpoints,
+        fqn: ALIBABA_MODELSTUDIO_FQN.to_string(),
+        slug: "modelstudio".to_string(),
+        title: "Alibaba Model Studio".to_string(),
+        service_url: ALIBABA_MODELSTUDIO_GATEWAY_URL.to_string(),
+        endpoints: vec![
+            paid_endpoint(
+                "compatible-mode/v1/chat/completions",
+                "chat",
+                "OpenAI-compatible chat completions for Qwen agent models.",
+            ),
+            paid_endpoint(
+                ALIBABA_RESPONSES_PATH,
+                "responses",
+                "OpenAI Responses API for Qwen agent models.",
+            ),
+            paid_endpoint(
+                "v1/messages",
+                "messages",
+                "Anthropic-compatible messages for Qwen agent models.",
+            ),
+        ],
+        fallback_models: [
+            "qwen3.7-plus",
+            "qwen3.7-max",
+            "qwen3.6-flash",
+            "qwen3-coder-next",
+            "qwen3-coder-plus",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+    }
+}
+
+/// Built-in Gemini provider with Google's official OpenAI compatibility path,
+/// so OpenAI-chat agent harnesses do not require a Gemini-native client.
+pub fn google_gemini_fallback() -> CatalogProvider {
+    CatalogProvider {
+        fqn: GOOGLE_GEMINI_FQN.to_string(),
+        slug: "generativelanguage".to_string(),
+        title: "Google Gemini".to_string(),
+        service_url: GOOGLE_GEMINI_GATEWAY_URL.to_string(),
+        endpoints: vec![
+            pay_core::skills::Endpoint {
+                method: "GET".to_string(),
+                path: "v1beta/models".to_string(),
+                full_path: String::new(),
+                resource: Some("models".to_string()),
+                description: "List available Gemini models.".to_string(),
+                pricing: None,
+            },
+            paid_endpoint(
+                GOOGLE_OPENAI_CHAT_PATH,
+                "chat",
+                "OpenAI-compatible chat completions for Gemini models.",
+            ),
+        ],
+        fallback_models: [
+            "gemini-3.1-pro-preview",
+            "gemini-3.1-flash-lite",
+            "gemini-2.5-pro",
+            "gemini-2.5-flash-lite",
+            "gemini-2.5-flash",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+    }
+}
+
+fn paid_endpoint(path: &str, resource: &str, description: &str) -> pay_core::skills::Endpoint {
+    pay_core::skills::Endpoint {
+        method: "POST".to_string(),
+        path: path.to_string(),
+        full_path: String::new(),
+        resource: Some(resource.to_string()),
+        description: description.to_string(),
+        // Endpoint presence is enough for local routing. Rates and dimensions
+        // belong to the live gateway catalog, not this client fallback.
+        pricing: Some(serde_json::json!({})),
     }
 }
 
@@ -274,13 +300,27 @@ impl InferenceProvider for CatalogProvider {
         None
     }
     async fn list_models(&self, client: &reqwest::Client, base_url: &str) -> Vec<String> {
-        let fallback = || models_from_pricing_variants(&self.endpoints);
+        let fallback = || {
+            let models = models_from_pricing_variants(&self.endpoints);
+            if models.is_empty() {
+                self.fallback_models.clone()
+            } else {
+                models
+            }
+        };
         let Some(ep) = self.model_list_endpoint() else {
             return fallback();
         };
         let path = format!("/{}", ep.path.trim_start_matches('/'));
         match get_json(client, base_url.trim_end_matches('/'), &path).await {
-            Some(json) => parse_model_names(&json),
+            Some(json) => {
+                let models = parse_model_names(&json);
+                if models.is_empty() {
+                    fallback()
+                } else {
+                    models
+                }
+            }
             None => fallback(),
         }
     }
@@ -911,37 +951,32 @@ mod tests {
     }
 
     #[test]
-    fn alibaba_qwen_gateway_spec_is_valid_for_all_agent_surfaces() {
-        let yaml = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../../web-ui/proxy/alibaba-qwen.yml"
-        ));
-        let spec: pay_types::metering::ApiSpec = serde_yml::from_str(yaml).unwrap();
+    fn alibaba_fallback_covers_all_agent_surfaces() {
+        let provider = alibaba_modelstudio_fallback();
         assert_eq!(
-            spec.endpoints
+            provider
+                .endpoints
                 .iter()
                 .map(|endpoint| endpoint.path.as_str())
                 .collect::<Vec<_>>(),
             [
                 "compatible-mode/v1/chat/completions",
-                "v1/responses",
+                "compatible-mode/v1/responses",
                 "v1/messages"
             ]
         );
-        assert!(pay_types::metering::validate_api_spec(&spec).is_empty());
-
-        for endpoint in &spec.endpoints {
-            let variants = &endpoint
-                .metering
-                .as_ref()
-                .expect("each Qwen surface is metered")
-                .variants;
-            assert!(
-                variants
-                    .iter()
-                    .any(|variant| variant.value == "qwen3-coder-next")
-            );
-        }
+        assert!(
+            provider
+                .endpoints
+                .iter()
+                .all(|endpoint| endpoint.pricing.is_some())
+        );
+        assert!(
+            provider
+                .fallback_models
+                .iter()
+                .any(|model| model == "qwen3-coder-next")
+        );
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_CATALOG_FQNS: &[&str] = &[
 
 const ALIBABA_MODELSTUDIO_FQN: &str = "solana-foundation/alibaba/modelstudio";
 const ALIBABA_MODELSTUDIO_GATEWAY_URL: &str = "https://modelstudio.alibaba.gateway-402.com";
-const ALIBABA_RESPONSES_PATH: &str = "compatible-mode/v1/responses";
+const ALIBABA_RESPONSES_PATH: &str = "v1/responses";
 const GOOGLE_GEMINI_FQN: &str = "solana-foundation/google/generativelanguage";
 const GOOGLE_GEMINI_GATEWAY_URL: &str = "https://generativelanguage.google.gateway-402.com";
 const GOOGLE_OPENAI_CHAT_PATH: &str = "v1beta/openai/chat/completions";
@@ -961,7 +961,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             [
                 "compatible-mode/v1/chat/completions",
-                "compatible-mode/v1/responses",
+                "v1/responses",
                 "v1/messages"
             ]
         );

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -1047,16 +1047,20 @@ mod tests {
                 .iter()
                 .any(|endpoint| endpoint.path == ALIBABA_RESPONSES_PATH)
         );
-        assert_eq!(
-            models_from_pricing_variants(&provider.endpoints),
-            [
-                "qwen3.7-plus",
-                "qwen3.7-max",
-                "qwen3.6-flash",
-                "qwen3-coder-next",
-                "qwen3-coder-plus",
-            ]
-        );
+        rt().block_on(async {
+            assert_eq!(
+                provider
+                    .list_models(&client(), provider.service_url())
+                    .await,
+                [
+                    "qwen3.7-plus",
+                    "qwen3.7-max",
+                    "qwen3.6-flash",
+                    "qwen3-coder-next",
+                    "qwen3-coder-plus",
+                ]
+            );
+        });
 
         let mut providers = Vec::new();
         append_default_fallbacks(&mut providers);

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -47,6 +47,43 @@ fn default_bind() -> String {
     }
 }
 
+async fn session_channel_store() -> pay_core::Result<Arc<dyn pay_kit::mpp::store::ChannelStore>> {
+    let redis_url = std::env::var("PAY_SESSION_REDIS_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let Some(redis_url) = redis_url else {
+        return Ok(Arc::new(pay_kit::mpp::store::MemoryChannelStore::new()));
+    };
+
+    #[cfg(feature = "redis-session-store")]
+    {
+        let prefix = std::env::var("PAY_SESSION_REDIS_PREFIX")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "pay:session:v1:".to_string());
+        let store = pay_kit::mpp::store::RedisChannelStore::connect(&redis_url, prefix)
+            .await
+            .map_err(|error| {
+                pay_core::Error::Config(format!("failed to connect session Redis store: {error}"))
+            })?;
+        tracing::info!("using durable Redis channel store for MPP sessions");
+        return Ok(Arc::new(store));
+    }
+
+    #[cfg(not(feature = "redis-session-store"))]
+    {
+        let _ = redis_url;
+        Err(pay_core::Error::Config(
+            "PAY_SESSION_REDIS_URL is set, but this pay binary was built without the \
+             redis-session-store feature"
+                .to_string(),
+        ))
+    }
+}
+
 /// Start the payment gateway proxy.
 ///
 /// Loads an API spec from a YAML file and starts an HTTP proxy that:
@@ -1036,6 +1073,7 @@ impl StartCommand {
                         .await?;
                 }
 
+                let session_channel_store = session_channel_store().await?;
                 let mut session_mpps = Vec::with_capacity(currency_configs.len());
                 for (_currency, session_mpp_currency, session_decimals) in &currency_configs {
                     let cap_base =
@@ -1058,7 +1096,11 @@ impl StartCommand {
                         program_id: Some(channel_program_id),
                     };
 
-                    let mut smpp = SessionMpp::new(config, session_secret.clone())
+                    let mut smpp = SessionMpp::new_with_channel_store(
+                        config,
+                        session_secret.clone(),
+                        Arc::clone(&session_channel_store),
+                    )
                         .with_realm(api.title.clone())
                         .with_pull_voucher_strategy(pull_voucher_strategy)
                         .with_blockhash_cache(blockhash_cache.clone());
@@ -1070,7 +1112,10 @@ impl StartCommand {
                     }
 
                     let smpp = Arc::new(smpp);
-                    smpp.start_lifecycle_runloop(Duration::from_millis(sess.close_delay_ms));
+                    smpp.start_lifecycle_runloop_with_settlement(
+                        Duration::from_millis(sess.close_delay_ms),
+                        Duration::from_millis(sess.settlement_interval_ms),
+                    );
                     session_mpps.push(smpp);
                 }
                 session_mpps

--- a/rust/crates/cli/src/components/help.rs
+++ b/rust/crates/cli/src/components/help.rs
@@ -7,7 +7,7 @@ Options:
 {options}";
 
 pub const SUPPORTED_PASS_THROUGH_COMMANDS: &[&str] = &[
-    "curl", "wget", "http", "claude", "codex", "qodercli", "whoami",
+    "curl", "wget", "http", "claude", "codex", "goose", "qodercli", "whoami",
 ];
 pub const DEVELOPER_COMMANDS: &[&str] = &["server", "catalog"];
 pub const AGENT_COMMANDS: &[&str] = &["mcp", "skills"];
@@ -17,7 +17,7 @@ pub const OTHER_COMMANDS: &[&str] = &["fetch", "install"];
 
 pub const ROOT_COMMAND_SUMMARY: &str = "\
 Supported pass-through:
-  \x1b[1mcurl\x1b[0m, \x1b[1mwget\x1b[0m, \x1b[1mhttp\x1b[0m, \x1b[1mclaude\x1b[0m, \x1b[1mcodex\x1b[0m, \x1b[1mqodercli\x1b[0m, \x1b[1mwhoami\x1b[0m
+  \x1b[1mcurl\x1b[0m, \x1b[1mwget\x1b[0m, \x1b[1mhttp\x1b[0m, \x1b[1mclaude\x1b[0m, \x1b[1mcodex\x1b[0m, \x1b[1mgoose\x1b[0m, \x1b[1mqodercli\x1b[0m, \x1b[1mwhoami\x1b[0m
 
 Developers:
   \x1b[1mserver\x1b[0m:  Gate your API with stablecoin payments

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -34,7 +34,7 @@ struct Opts {
     )]
     yolo_upto: Option<u64>,
 
-    /// Use the experimental alternate inference-provider picker for Claude.
+    /// Use the experimental alternate inference-provider picker for agent CLIs.
     #[arg(long, hide = true)]
     alt: bool,
 
@@ -253,6 +253,7 @@ fn main() {
                 | Command::Send(_)
                 | Command::Claude(_)
                 | Command::Codex(_)
+                | Command::Goose(_)
                 | Command::Qodercli(_)
                 | Command::Curl(_)
                 | Command::Wget(_)
@@ -599,6 +600,59 @@ mod tests {
                 assert_eq!(cmd.args, ["--model", "gpt-5", "hello"]);
             }
             _ => panic!("expected codex command"),
+        }
+    }
+
+    #[test]
+    fn qoder_alias_launches_qodercli() {
+        let opts = Opts::try_parse_from(["pay", "qoder", "--model", "performance"]).unwrap();
+
+        match opts.command {
+            Some(Command::Qodercli(cmd)) => {
+                assert_eq!(cmd.args, ["--model", "performance"]);
+            }
+            _ => panic!("expected qodercli command"),
+        }
+    }
+
+    #[test]
+    fn qoder_alt_enables_provider_picker_without_forwarding_flag() {
+        let opts =
+            Opts::try_parse_from(["pay", "--alt", "qoder", "--model", "qwen3-coder-next"]).unwrap();
+
+        assert!(opts.alt);
+        match opts.command {
+            Some(Command::Qodercli(cmd)) => {
+                assert_eq!(cmd.args, ["--model", "qwen3-coder-next"]);
+            }
+            _ => panic!("expected qodercli command"),
+        }
+    }
+
+    #[test]
+    fn goose_alt_enables_provider_picker_without_forwarding_flag() {
+        let opts =
+            Opts::try_parse_from(["pay", "--alt", "goose", "--model", "qwen3.7-plus"]).unwrap();
+
+        assert!(opts.alt);
+        match opts.command {
+            Some(Command::Goose(cmd)) => {
+                assert_eq!(cmd.args, ["--model", "qwen3.7-plus"]);
+            }
+            _ => panic!("expected goose command"),
+        }
+    }
+
+    #[test]
+    fn goose_defaults_to_paid_alternate_launcher() {
+        let opts = Opts::try_parse_from(["pay", "goose", "--model", "qwen3.7-plus"]).unwrap();
+
+        assert!(!opts.alt);
+        match opts.command {
+            Some(Command::Goose(cmd)) => {
+                assert_eq!(cmd.args, ["--model", "qwen3.7-plus"]);
+            }
+            _ => panic!("expected goose command"),
         }
     }
 

--- a/rust/crates/cli/src/tui/session.rs
+++ b/rust/crates/cli/src/tui/session.rs
@@ -403,6 +403,7 @@ fn render_card_panel(
                 ToolKind::Wget => "wget",
                 ToolKind::Http => "http",
                 ToolKind::Fetch => "fetch",
+                ToolKind::Goose => "goose",
                 ToolKind::Mcp => "mcp",
                 ToolKind::Claude | ToolKind::Codex | ToolKind::Qodercli => unreachable!(),
             };

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -18,6 +18,9 @@ network_tests = []
 # Activates openssl-sys/vendored which is pulled in transitively by
 # solana-rpc-client → reqwest → native-tls → openssl-sys.
 vendored-openssl = ["openssl-sys/vendored"]
+# Durable MPP session state backed by Redis. Runtime selection still requires
+# PAY_SESSION_REDIS_URL; without it the in-memory store remains the default.
+redis-session-store = ["pay-kit/redis-store"]
 
 [dependencies]
 axum = { workspace = true, optional = true }

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -113,13 +113,33 @@ pub struct SessionForward {
     pub channel_id: String,
     pub committed_base_units: u64,
     /// Response-metered settlement plan for a delegated session. The adapter
-    /// buffers the response, rates actual usage, and persists an
-    /// operator-signed cumulative voucher before releasing the response.
+    /// rates actual usage and persists an operator-signed cumulative voucher
+    /// before releasing the matching response bytes.
     pub settlement: Option<Box<metering::UptoSettlementPlan>>,
     /// Remaining channel capacity available to the metered delivery.
     pub available_base_units: u64,
     /// Releases the exclusive capacity reservation on every terminal path.
     _reservation: Option<DelegatedCapacityLease>,
+}
+
+impl SessionForward {
+    pub(crate) fn delegated(
+        handle: Arc<SessionMpp>,
+        channel_id: String,
+        committed_base_units: u64,
+        settlement: metering::UptoSettlementPlan,
+        available_base_units: u64,
+        reservation: DelegatedCapacityLease,
+    ) -> Self {
+        Self {
+            handle,
+            channel_id,
+            committed_base_units,
+            settlement: Some(Box::new(settlement)),
+            available_base_units,
+            _reservation: Some(reservation),
+        }
+    }
 }
 
 pub fn delegated_session_receipt_annotation(
@@ -1552,22 +1572,22 @@ async fn session_authorized(
             };
             let variant = variant_hint_from_path(path);
             let ceiling_usd = available_base_units as f64 / 10_f64.powi(sm.decimals() as i32);
-            let settlement = Some(Box::new(metering::UptoSettlementPlan {
+            let settlement = metering::UptoSettlementPlan {
                 metering: meter.clone(),
                 variant_hint: variant,
                 request_properties: props,
                 ceiling_usd,
                 inferred_usage: None,
-            }));
+            };
             GateDecision::Forward {
-                session: Some(SessionForward {
+                session: Some(SessionForward::delegated(
                     handle,
-                    channel_id: state.channel_id,
-                    committed_base_units: state.cumulative,
+                    state.channel_id,
+                    state.cumulative,
                     settlement,
                     available_base_units,
-                    _reservation: Some(reservation),
-                }),
+                    reservation,
+                )),
                 receipt: signature
                     .map(|reference| session_receipt_annotation(sm.network(), reference)),
                 upto: None,

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -42,11 +42,9 @@ pub struct UptoSettlementPlan {
     pub request_properties: RequestProperties,
     pub ceiling_usd: f64,
     /// Token counts observed on the (possibly streamed) response body by the
-    /// proxy's inference observer. When present, token dimensions
-    /// (`unit == Tokens`) settle from these counts — `Input →
-    /// tokens_prompt`, `Output → tokens_completion` — instead of the
-    /// JSON-pointer / meter extraction. `None` keeps the pure axum/JSON path
-    /// (the buffered response body is parsed as before).
+    /// proxy's inference observer. Token and quota-unit dimensions settle from
+    /// these counts — `Input → tokens_prompt`, `Output → tokens_completion` —
+    /// instead of JSON-pointer extraction. `None` keeps the buffered-body path.
     pub inferred_usage: Option<crate::InferenceUsage>,
 }
 
@@ -245,7 +243,7 @@ pub fn upto_uses_response_usage(metering: &Metering, variant_hint: Option<&str>)
         .is_some()
         || effective_dimensions(metering, variant_hint)
             .iter()
-            .any(|dim| dim.meter.is_some())
+            .any(|dim| dim.meter.is_some() || dim.unit == BillingUnit::QuotaUnits)
 }
 
 pub fn upto_requires_response_body(metering: &Metering, variant_hint: Option<&str>) -> bool {
@@ -257,9 +255,11 @@ pub fn upto_requires_response_body(metering: &Metering, variant_hint: Option<&st
         || effective_dimensions(metering, variant_hint)
             .iter()
             .any(|dim| {
-                dim.meter
-                    .as_ref()
-                    .is_some_and(|meter| matches!(meter.source, UsageMeterSource::ResponseJson))
+                dim.unit == BillingUnit::QuotaUnits
+                    || dim
+                        .meter
+                        .as_ref()
+                        .is_some_and(|meter| matches!(meter.source, UsageMeterSource::ResponseJson))
             })
 }
 
@@ -374,7 +374,8 @@ fn extract_and_price_usage(
                 .meter
                 .as_ref()
                 .is_some_and(|m| matches!(m.source, UsageMeterSource::ResponseJson))
-                || preset_json_path(preset, dim).is_some();
+                || preset_json_path(preset, dim).is_some()
+                || dim.unit == BillingUnit::QuotaUnits;
             !covered_by_inferred && reads_body
         });
     let json = if body_still_needed {
@@ -402,18 +403,77 @@ fn extract_and_price_usage(
     Ok(total)
 }
 
-/// The observer count for a token dimension, if any: `Input → tokens_prompt`,
-/// `Output → tokens_completion`. Non-token dimensions and unset counts yield
-/// `None`, so the caller falls back to JSON/meter extraction.
+/// The observer count for a token or quota-unit dimension, if any.
 fn inferred_quantity_for_dim(usage: &crate::InferenceUsage, dim: &MeterDimension) -> Option<u64> {
-    if !matches!(dim.unit, BillingUnit::Tokens) {
-        return None;
-    }
-    match dim.direction {
+    let tokens = match dim.direction {
         MeterDirection::Input => usage.tokens_prompt,
         MeterDirection::Output => usage.tokens_completion,
         _ => None,
+    }?;
+    match dim.unit {
+        BillingUnit::Tokens => Some(tokens),
+        BillingUnit::QuotaUnits => {
+            quota_tokens_per_unit(dim).map(|per_unit| ceil_div_u64(tokens, per_unit))
+        }
+        _ => None,
     }
+}
+
+fn quota_tokens_per_unit(dim: &MeterDimension) -> Option<u64> {
+    dim.tiers
+        .iter()
+        .filter_map(|tier| tier.notes.as_deref())
+        .find_map(parse_tokens_per_quota_unit)
+}
+
+pub(crate) fn parse_tokens_per_quota_unit(notes: &str) -> Option<u64> {
+    let lower = notes.to_ascii_lowercase();
+    let index = lower.find(" tokens per quota unit")?;
+    lower[..index].split_whitespace().rev().find_map(|part| {
+        part.replace(',', "")
+            .parse::<u64>()
+            .ok()
+            .filter(|value| *value > 0)
+    })
+}
+
+fn quota_token_quantity(json: &serde_json::Value, direction: MeterDirection) -> Option<u64> {
+    let openai_usage = json.get("usage");
+    match direction {
+        MeterDirection::Input => openai_usage
+            .and_then(|usage| usage.get("prompt_tokens"))
+            .and_then(serde_json::Value::as_u64)
+            .or_else(|| {
+                json.pointer("/usageMetadata/promptTokenCount")
+                    .and_then(serde_json::Value::as_u64)
+            }),
+        MeterDirection::Output => openai_usage
+            .and_then(|usage| usage.get("completion_tokens"))
+            .and_then(serde_json::Value::as_u64)
+            .or_else(|| {
+                let usage = json.get("usageMetadata")?;
+                let input = usage.get("promptTokenCount")?.as_u64()?;
+                let candidates = usage
+                    .get("candidatesTokenCount")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+                let thoughts = usage
+                    .get("thoughtsTokenCount")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+                let derived = usage
+                    .get("totalTokenCount")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|total| total.checked_sub(input))
+                    .unwrap_or(0);
+                Some(candidates.saturating_add(thoughts).max(derived))
+            }),
+        _ => None,
+    }
+}
+
+fn ceil_div_u64(value: u64, divisor: u64) -> u64 {
+    value.saturating_add(divisor.saturating_sub(1)) / divisor.max(1)
 }
 
 fn extract_dimension_quantity(
@@ -441,6 +501,24 @@ fn extract_dimension_quantity(
     }
     if let Some(meter) = &dim.meter {
         return extract_from_meter(meter, headers, json);
+    }
+
+    if dim.unit == BillingUnit::QuotaUnits {
+        let json =
+            json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+        let tokens = quota_token_quantity(json, dim.direction).ok_or_else(|| {
+            UptoUsageError::MissingUsage(format!(
+                "no token usage for {:?} quota units",
+                dim.direction
+            ))
+        })?;
+        let per_unit = quota_tokens_per_unit(dim).ok_or_else(|| {
+            UptoUsageError::MissingUsage(format!(
+                "no tokens-per-quota-unit hint for {:?}",
+                dim.direction
+            ))
+        })?;
+        return Ok(ceil_div_u64(tokens, per_unit));
     }
 
     if let Some(path) = preset_json_path(preset, dim) {
@@ -1609,6 +1687,39 @@ mod tests {
 
         assert_eq!(actual.usd, 0.05);
         assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn quota_units_support_openai_compatible_usage() {
+        let mut input = usage_dim(
+            MeterDirection::Input,
+            BillingUnit::QuotaUnits,
+            1,
+            0.000001,
+            None,
+        );
+        input.tiers[0].notes = Some("4 input tokens per quota unit".to_string());
+        let mut output = usage_dim(
+            MeterDirection::Output,
+            BillingUnit::QuotaUnits,
+            1,
+            0.000003,
+            None,
+        );
+        output.tiers[0].notes = Some("2 output tokens per quota unit".to_string());
+        let metering = upto_metering(vec![input, output], None);
+        let body = br#"{"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert!((actual.usd - 0.000011).abs() < f64::EPSILON);
+        assert_eq!(actual.base_units, 11);
     }
 
     #[test]

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -368,14 +368,9 @@ fn extract_and_price_usage(
     let body_still_needed = upto_requires_response_body(metering, variant_hint)
         && dimensions.iter().any(|dim| {
             let covered_by_inferred = inferred_usage
-                .and_then(|usage| inferred_quantity_for_dim(usage, dim))
+                .and_then(|usage| inferred_quantity_for_dim(usage, dim, props))
                 .is_some();
-            let reads_body = dim
-                .meter
-                .as_ref()
-                .is_some_and(|m| matches!(m.source, UsageMeterSource::ResponseJson))
-                || preset_json_path(preset, dim).is_some()
-                || dim.unit == BillingUnit::QuotaUnits;
+            let reads_body = dimension_reads_response_body(dim, preset);
             !covered_by_inferred && reads_body
         });
     let json = if body_still_needed {
@@ -397,14 +392,18 @@ fn extract_and_price_usage(
             .map(|d| d.price_usd)
             .unwrap_or(0.0);
         let quantity =
-            extract_dimension_quantity(dim, preset, headers, json.as_ref(), inferred_usage)?;
+            extract_dimension_quantity(dim, preset, props, headers, json.as_ref(), inferred_usage)?;
         total += quantity as f64 / dim.scale.max(1) as f64 * price;
     }
     Ok(total)
 }
 
 /// The observer count for a token or quota-unit dimension, if any.
-fn inferred_quantity_for_dim(usage: &crate::InferenceUsage, dim: &MeterDimension) -> Option<u64> {
+fn inferred_quantity_for_dim(
+    usage: &crate::InferenceUsage,
+    dim: &MeterDimension,
+    props: &RequestProperties,
+) -> Option<u64> {
     let tokens = match dim.direction {
         MeterDirection::Input => usage.tokens_prompt,
         MeterDirection::Output => usage.tokens_completion,
@@ -413,17 +412,19 @@ fn inferred_quantity_for_dim(usage: &crate::InferenceUsage, dim: &MeterDimension
     match dim.unit {
         BillingUnit::Tokens => Some(tokens),
         BillingUnit::QuotaUnits => {
-            quota_tokens_per_unit(dim).map(|per_unit| ceil_div_u64(tokens, per_unit))
+            quota_tokens_per_unit(dim, props).map(|per_unit| ceil_div_u64(tokens, per_unit))
         }
         _ => None,
     }
 }
 
-fn quota_tokens_per_unit(dim: &MeterDimension) -> Option<u64> {
-    dim.tiers
-        .iter()
-        .filter_map(|tier| tier.notes.as_deref())
-        .find_map(parse_tokens_per_quota_unit)
+pub(crate) fn quota_tokens_per_unit(
+    dim: &MeterDimension,
+    props: &RequestProperties,
+) -> Option<u64> {
+    select_price_tier(dim, props)
+        .and_then(|tier| tier.notes.as_deref())
+        .and_then(parse_tokens_per_quota_unit)
 }
 
 pub(crate) fn parse_tokens_per_quota_unit(notes: &str) -> Option<u64> {
@@ -461,10 +462,14 @@ fn quota_token_quantity(json: &serde_json::Value, direction: MeterDirection) -> 
                     .get("thoughtsTokenCount")
                     .and_then(serde_json::Value::as_u64)
                     .unwrap_or(0);
+                let tool_prompt = usage
+                    .get("toolUsePromptTokenCount")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
                 let derived = usage
                     .get("totalTokenCount")
                     .and_then(serde_json::Value::as_u64)
-                    .and_then(|total| total.checked_sub(input))
+                    .map(|total| total.saturating_sub(input).saturating_sub(tool_prompt))
                     .unwrap_or(0);
                 Some(candidates.saturating_add(thoughts).max(derived))
             }),
@@ -479,15 +484,24 @@ fn ceil_div_u64(value: u64, divisor: u64) -> u64 {
 fn extract_dimension_quantity(
     dim: &MeterDimension,
     preset: Option<&str>,
+    props: &RequestProperties,
     headers: &HeaderMap,
     json: Option<&serde_json::Value>,
     inferred_usage: Option<&crate::InferenceUsage>,
 ) -> Result<u64, UptoUsageError> {
     // Observer token counts take precedence for token dimensions.
     if let Some(usage) = inferred_usage
-        && let Some(quantity) = inferred_quantity_for_dim(usage, dim)
+        && let Some(quantity) = inferred_quantity_for_dim(usage, dim, props)
     {
         return Ok(quantity);
+    }
+    // A response-header meter is already explicit and does not require
+    // buffering a JSON body. Endpoint presets only disambiguate inherited
+    // JSON meters whose field names differ by API dialect.
+    if let Some(meter) = &dim.meter
+        && matches!(meter.source, UsageMeterSource::ResponseHeader)
+    {
+        return extract_from_meter(meter, headers, json);
     }
     // Responses and Chat Completions use different names for the same token
     // dimensions. Let the endpoint-level Responses preset override meters
@@ -512,7 +526,7 @@ fn extract_dimension_quantity(
                 dim.direction
             ))
         })?;
-        let per_unit = quota_tokens_per_unit(dim).ok_or_else(|| {
+        let per_unit = quota_tokens_per_unit(dim, props).ok_or_else(|| {
             UptoUsageError::MissingUsage(format!(
                 "no tokens-per-quota-unit hint for {:?}",
                 dim.direction
@@ -535,6 +549,14 @@ fn extract_dimension_quantity(
         "no usage meter for {:?} {:?}",
         dim.direction, dim.unit
     )))
+}
+
+fn dimension_reads_response_body(dim: &MeterDimension, preset: Option<&str>) -> bool {
+    match dim.meter.as_ref().map(|meter| &meter.source) {
+        Some(UsageMeterSource::ResponseHeader) => false,
+        Some(UsageMeterSource::ResponseJson) => true,
+        None => dim.unit == BillingUnit::QuotaUnits || preset_json_path(preset, dim).is_some(),
+    }
 }
 
 fn extract_from_meter(
@@ -688,12 +710,19 @@ pub fn record_usage(
     resolve_price(metering, props, variant_hint, Some(ctx))
 }
 
-fn resolve_variant<'a>(
+pub(crate) fn resolve_variant<'a>(
     variants: &'a [MeterVariant],
     hint: Option<&str>,
 ) -> Option<&'a MeterVariant> {
-    let hint = hint?;
-    variants.iter().find(|v| hint.contains(&v.value))
+    let mut default = None;
+    for variant in variants {
+        if variant.value.eq_ignore_ascii_case("default") {
+            default.get_or_insert(variant);
+        } else if hint.is_some_and(|hint| hint.contains(&variant.value)) {
+            return Some(variant);
+        }
+    }
+    default
 }
 
 fn resolve_dimensions(
@@ -747,17 +776,37 @@ fn resolve_tier(
         return first_non_free_price(tiers);
     }
 
-    // No volume tiers — resolve by condition
-    for tier in tiers {
-        if let Some(ref condition) = tier.condition
-            && !evaluate_condition(condition, props)
-        {
-            continue;
-        }
-        return tier.price_usd;
-    }
+    select_price_tier_from_tiers(tiers, props)
+        .map(|tier| tier.price_usd)
+        .unwrap_or(0.0)
+}
 
-    tiers.last().map(|t| t.price_usd).unwrap_or(0.0)
+pub(crate) fn select_price_tier<'a>(
+    dimension: &'a MeterDimension,
+    props: &RequestProperties,
+) -> Option<&'a PriceTier> {
+    if dimension.tiers.iter().any(|tier| tier.up_to.is_some()) {
+        return dimension
+            .tiers
+            .iter()
+            .find(|tier| tier.price_usd > 0.0)
+            .or_else(|| dimension.tiers.first());
+    }
+    select_price_tier_from_tiers(&dimension.tiers, props)
+}
+
+fn select_price_tier_from_tiers<'a>(
+    tiers: &'a [PriceTier],
+    props: &RequestProperties,
+) -> Option<&'a PriceTier> {
+    tiers
+        .iter()
+        .find(|tier| {
+            tier.condition
+                .as_ref()
+                .is_none_or(|condition| evaluate_condition(condition, props))
+        })
+        .or_else(|| tiers.last())
 }
 
 /// Resolve tier based on cumulative volume usage.
@@ -1254,6 +1303,54 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_price_uses_explicit_default_variant_for_unknown_hint() {
+        let metering = Metering {
+            dimensions: vec![],
+            variants: vec![
+                MeterVariant {
+                    param: "model".to_string(),
+                    value: "qwen-turbo".to_string(),
+                    description: None,
+                    dimensions: vec![usage_dim(
+                        MeterDirection::Usage,
+                        BillingUnit::Requests,
+                        1,
+                        0.001,
+                        None,
+                    )],
+                },
+                MeterVariant {
+                    param: "model".to_string(),
+                    value: "default".to_string(),
+                    description: None,
+                    dimensions: vec![usage_dim(
+                        MeterDirection::Usage,
+                        BillingUnit::Requests,
+                        1,
+                        0.100,
+                        None,
+                    )],
+                },
+            ],
+            sku_tiers: vec![],
+            splits: vec![],
+            schemes: None,
+            min_usd: None,
+            upto: None,
+        };
+
+        let price = resolve_price(
+            &metering,
+            &RequestProperties::default(),
+            Some("unknown-model"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(price.dimensions[0].price_usd, 0.100);
+    }
+
+    #[test]
     fn test_resolve_price_variant_no_match_uses_first() {
         let metering = Metering {
             dimensions: vec![],
@@ -1723,6 +1820,76 @@ mod tests {
     }
 
     #[test]
+    fn quota_units_use_notes_from_the_selected_conditional_tier() {
+        let mut input = usage_dim(
+            MeterDirection::Input,
+            BillingUnit::QuotaUnits,
+            1,
+            0.000005,
+            None,
+        );
+        input.tiers = vec![
+            PriceTier {
+                up_to: None,
+                price_usd: 0.000005,
+                condition: Some(MeterCondition::ContextLength {
+                    op: CompareOp::Lte,
+                    value: 200_000,
+                }),
+                notes: Some("4 input tokens per quota unit".to_string()),
+                splits: vec![],
+            },
+            PriceTier {
+                up_to: None,
+                price_usd: 0.000005,
+                condition: Some(MeterCondition::ContextLength {
+                    op: CompareOp::Gt,
+                    value: 200_000,
+                }),
+                notes: Some("2 input tokens per quota unit".to_string()),
+                splits: vec![],
+            },
+        ];
+        let mut plan = settlement_plan(upto_metering(vec![input], None), 0.10);
+        plan.request_properties.context_length = Some(250_000);
+        plan.inferred_usage = Some(crate::InferenceUsage {
+            tokens_prompt: Some(5),
+            ..Default::default()
+        });
+
+        let actual =
+            upto_actual_amount_from_response(&plan, 100_000, &HeaderMap::new(), None).unwrap();
+
+        assert!((actual.usd - 0.000015).abs() < f64::EPSILON);
+        assert_eq!(actual.base_units, 15);
+    }
+
+    #[test]
+    fn gemini_tool_prompt_tokens_are_not_billed_as_output() {
+        let mut output = usage_dim(
+            MeterDirection::Output,
+            BillingUnit::QuotaUnits,
+            1,
+            0.000001,
+            None,
+        );
+        output.tiers[0].notes = Some("1 output tokens per quota unit".to_string());
+        let metering = upto_metering(vec![output], None);
+        let body = br#"{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":3,"thoughtsTokenCount":2,"toolUsePromptTokenCount":20,"totalTokenCount":35}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert!((actual.usd - 0.000005).abs() < f64::EPSILON);
+        assert_eq!(actual.base_units, 5);
+    }
+
+    #[test]
     fn openai_responses_preset_overrides_shared_chat_usage_meters() {
         let metering = upto_metering(
             vec![
@@ -1773,6 +1940,37 @@ mod tests {
             )],
             Some(pay_types::metering::UptoMetering {
                 max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-usage-tokens", HeaderValue::from_static("2500"));
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &headers,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn openai_responses_preset_honors_explicit_response_header_meter() {
+        let metering = upto_metering(
+            vec![usage_dim(
+                MeterDirection::Input,
+                BillingUnit::Tokens,
+                1_000,
+                0.02,
+                Some(response_header("x-usage-tokens")),
+            )],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                usage_preset: Some("openai-responses".to_string()),
                 ..Default::default()
             }),
         );

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -429,6 +429,16 @@ fn extract_dimension_quantity(
     {
         return Ok(quantity);
     }
+    // Responses and Chat Completions use different names for the same token
+    // dimensions. Let the endpoint-level Responses preset override meters
+    // inherited from a shared model-pricing table.
+    if preset.is_some_and(|preset| preset.eq_ignore_ascii_case("openai-responses"))
+        && let Some(path) = preset_json_path(preset, dim)
+    {
+        let json =
+            json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+        return extract_from_json_pointer(json, path);
+    }
     if let Some(meter) = &dim.meter {
         return extract_from_meter(meter, headers, json);
     }
@@ -480,17 +490,33 @@ fn extract_from_meter(
 
 fn preset_json_path(preset: Option<&str>, dim: &MeterDimension) -> Option<&'static str> {
     let preset = preset?;
-    if !preset.eq_ignore_ascii_case("google-generativelanguage") {
-        return None;
+    if preset.eq_ignore_ascii_case("google-generativelanguage") {
+        return match (dim.direction, dim.unit) {
+            (MeterDirection::Input, BillingUnit::Tokens) => Some("/usageMetadata/promptTokenCount"),
+            (MeterDirection::Output, BillingUnit::Tokens) => {
+                Some("/usageMetadata/candidatesTokenCount")
+            }
+            (MeterDirection::Usage, BillingUnit::Tokens) => Some("/usageMetadata/totalTokenCount"),
+            _ => None,
+        };
     }
-    match (dim.direction, dim.unit) {
-        (MeterDirection::Input, BillingUnit::Tokens) => Some("/usageMetadata/promptTokenCount"),
-        (MeterDirection::Output, BillingUnit::Tokens) => {
-            Some("/usageMetadata/candidatesTokenCount")
-        }
-        (MeterDirection::Usage, BillingUnit::Tokens) => Some("/usageMetadata/totalTokenCount"),
-        _ => None,
+    if preset.eq_ignore_ascii_case("openai-compatible") {
+        return match (dim.direction, dim.unit) {
+            (MeterDirection::Input, BillingUnit::Tokens) => Some("/usage/prompt_tokens"),
+            (MeterDirection::Output, BillingUnit::Tokens) => Some("/usage/completion_tokens"),
+            (MeterDirection::Usage, BillingUnit::Tokens) => Some("/usage/total_tokens"),
+            _ => None,
+        };
     }
+    if preset.eq_ignore_ascii_case("openai-responses") {
+        return match (dim.direction, dim.unit) {
+            (MeterDirection::Input, BillingUnit::Tokens) => Some("/usage/input_tokens"),
+            (MeterDirection::Output, BillingUnit::Tokens) => Some("/usage/output_tokens"),
+            (MeterDirection::Usage, BillingUnit::Tokens) => Some("/usage/total_tokens"),
+            _ => None,
+        };
+    }
+    None
 }
 
 fn extract_from_json_pointer(json: &serde_json::Value, path: &str) -> Result<u64, UptoUsageError> {
@@ -1532,6 +1558,85 @@ mod tests {
             }),
         );
         let body = br#"{"usageMetadata":{"promptTokenCount":2000,"candidatesTokenCount":1000}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn upto_actual_amount_supports_openai_compatible_preset() {
+        let metering = upto_metering(
+            vec![
+                usage_dim(
+                    MeterDirection::Input,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.01,
+                    None,
+                ),
+                usage_dim(
+                    MeterDirection::Output,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.03,
+                    None,
+                ),
+            ],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                usage_preset: Some("openai-compatible".to_string()),
+                ..Default::default()
+            }),
+        );
+        let body =
+            br#"{"usage":{"prompt_tokens":2000,"completion_tokens":1000,"total_tokens":3000}}"#;
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(body),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.05);
+        assert_eq!(actual.base_units, 50_000);
+    }
+
+    #[test]
+    fn openai_responses_preset_overrides_shared_chat_usage_meters() {
+        let metering = upto_metering(
+            vec![
+                usage_dim(
+                    MeterDirection::Input,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.01,
+                    Some(response_json("/usage/prompt_tokens")),
+                ),
+                usage_dim(
+                    MeterDirection::Output,
+                    BillingUnit::Tokens,
+                    1_000,
+                    0.03,
+                    Some(response_json("/usage/completion_tokens")),
+                ),
+            ],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                usage_preset: Some("openai-responses".to_string()),
+                ..Default::default()
+            }),
+        );
+        let body = br#"{"usage":{"input_tokens":2000,"output_tokens":1000,"total_tokens":3000}}"#;
 
         let actual = upto_actual_amount_from_response(
             &settlement_plan(metering, 0.10),

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -247,20 +247,13 @@ pub fn upto_uses_response_usage(metering: &Metering, variant_hint: Option<&str>)
 }
 
 pub fn upto_requires_response_body(metering: &Metering, variant_hint: Option<&str>) -> bool {
-    metering
+    let preset = metering
         .upto
         .as_ref()
-        .and_then(|upto| upto.usage_preset.as_deref())
-        .is_some()
-        || effective_dimensions(metering, variant_hint)
-            .iter()
-            .any(|dim| {
-                dim.unit == BillingUnit::QuotaUnits
-                    || dim
-                        .meter
-                        .as_ref()
-                        .is_some_and(|meter| matches!(meter.source, UsageMeterSource::ResponseJson))
-            })
+        .and_then(|upto| upto.usage_preset.as_deref());
+    effective_dimensions(metering, variant_hint)
+        .iter()
+        .any(|dim| dimension_reads_response_body(dim, preset))
 }
 
 pub fn upto_response_body_limit(metering: &Metering) -> usize {
@@ -353,8 +346,6 @@ fn extract_and_price_usage(
         ));
     }
 
-    let prices = resolve_price(metering, props, variant_hint, None)
-        .ok_or_else(|| UptoUsageError::MissingUsage("no resolved price".to_string()))?;
     // Observer-supplied token counts supersede body/meter extraction for token
     // dimensions. When every dimension that would otherwise read from the
     // response body is satisfiable from `inferred_usage`, we can skip parsing
@@ -384,6 +375,18 @@ fn extract_and_price_usage(
         None
     };
 
+    let mut priced_props = *props;
+    if priced_props.context_length.is_none() {
+        priced_props.context_length = inferred_usage
+            .and_then(|usage| usage.tokens_prompt)
+            .or_else(|| {
+                json.as_ref()
+                    .and_then(|json| quota_token_quantity(json, MeterDirection::Input))
+            });
+    }
+    let prices = resolve_price(metering, &priced_props, variant_hint, None)
+        .ok_or_else(|| UptoUsageError::MissingUsage("no resolved price".to_string()))?;
+
     let mut total = 0.0;
     for (idx, dim) in dimensions.iter().enumerate() {
         let price = prices
@@ -391,8 +394,14 @@ fn extract_and_price_usage(
             .get(idx)
             .map(|d| d.price_usd)
             .unwrap_or(0.0);
-        let quantity =
-            extract_dimension_quantity(dim, preset, props, headers, json.as_ref(), inferred_usage)?;
+        let quantity = extract_dimension_quantity(
+            dim,
+            preset,
+            &priced_props,
+            headers,
+            json.as_ref(),
+            inferred_usage,
+        )?;
         total += quantity as f64 / dim.scale.max(1) as f64 * price;
     }
     Ok(total)
@@ -535,6 +544,14 @@ fn extract_dimension_quantity(
         return Ok(ceil_div_u64(tokens, per_unit));
     }
 
+    if dim.unit == BillingUnit::Tokens {
+        let json =
+            json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
+        return quota_token_quantity(json, dim.direction).ok_or_else(|| {
+            UptoUsageError::MissingUsage(format!("no token usage for {:?} tokens", dim.direction))
+        });
+    }
+
     if let Some(path) = preset_json_path(preset, dim) {
         let json =
             json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
@@ -555,7 +572,10 @@ fn dimension_reads_response_body(dim: &MeterDimension, preset: Option<&str>) -> 
     match dim.meter.as_ref().map(|meter| &meter.source) {
         Some(UsageMeterSource::ResponseHeader) => false,
         Some(UsageMeterSource::ResponseJson) => true,
-        None => dim.unit == BillingUnit::QuotaUnits || preset_json_path(preset, dim).is_some(),
+        None => {
+            matches!(dim.unit, BillingUnit::Tokens | BillingUnit::QuotaUnits)
+                || preset_json_path(preset, dim).is_some()
+        }
     }
 }
 
@@ -2471,6 +2491,56 @@ mod tests {
 
         let expected = 12.0 / 1_000_000.0 * 0.10 + 214.0 / 1_000_000.0 * 0.30;
         assert!((actual.usd - expected).abs() < 1e-12, "usd={}", actual.usd);
+    }
+
+    #[test]
+    fn buffered_usage_selects_context_tier_from_provider_prompt_tokens() {
+        let metering = upto_metering(
+            vec![MeterDimension {
+                direction: MeterDirection::Output,
+                unit: BillingUnit::Tokens,
+                scale: 1,
+                period: None,
+                tiers: vec![
+                    PriceTier {
+                        up_to: None,
+                        price_usd: 0.000001,
+                        condition: Some(MeterCondition::ContextLength {
+                            op: CompareOp::Lte,
+                            value: 2,
+                        }),
+                        notes: None,
+                        splits: vec![],
+                    },
+                    PriceTier {
+                        up_to: None,
+                        price_usd: 0.000005,
+                        condition: Some(MeterCondition::ContextLength {
+                            op: CompareOp::Gt,
+                            value: 2,
+                        }),
+                        notes: None,
+                        splits: vec![],
+                    },
+                ],
+                meter: None,
+            }],
+            Some(pay_types::metering::UptoMetering {
+                max_usd: Some(0.10),
+                ..Default::default()
+            }),
+        );
+
+        let actual = upto_actual_amount_from_response(
+            &settlement_plan(metering, 0.10),
+            100_000,
+            &HeaderMap::new(),
+            Some(br#"{"usage":{"prompt_tokens":3,"completion_tokens":2}}"#),
+        )
+        .unwrap();
+
+        assert_eq!(actual.usd, 0.000010);
+        assert_eq!(actual.base_units, 10);
     }
 
     #[test]

--- a/rust/crates/core/src/server/metering.rs
+++ b/rust/crates/core/src/server/metering.rs
@@ -381,7 +381,7 @@ fn extract_and_price_usage(
             .and_then(|usage| usage.tokens_prompt)
             .or_else(|| {
                 json.as_ref()
-                    .and_then(|json| quota_token_quantity(json, MeterDirection::Input))
+                    .and_then(|json| provider_token_quantity(json, MeterDirection::Input))
             });
     }
     let prices = resolve_price(metering, &priced_props, variant_hint, None)
@@ -447,19 +447,40 @@ pub(crate) fn parse_tokens_per_quota_unit(notes: &str) -> Option<u64> {
     })
 }
 
-fn quota_token_quantity(json: &serde_json::Value, direction: MeterDirection) -> Option<u64> {
-    let openai_usage = json.get("usage");
+pub(crate) fn provider_token_quantity(
+    json: &serde_json::Value,
+    direction: MeterDirection,
+) -> Option<u64> {
+    let usage_objects = [
+        json.get("usage"),
+        json.pointer("/response/usage"),
+        json.pointer("/message/usage"),
+    ];
     match direction {
-        MeterDirection::Input => openai_usage
-            .and_then(|usage| usage.get("prompt_tokens"))
-            .and_then(serde_json::Value::as_u64)
+        MeterDirection::Input => usage_objects
+            .into_iter()
+            .flatten()
+            .filter_map(|usage| {
+                usage
+                    .get("prompt_tokens")
+                    .or_else(|| usage.get("input_tokens"))
+                    .and_then(serde_json::Value::as_u64)
+            })
+            .max()
             .or_else(|| {
                 json.pointer("/usageMetadata/promptTokenCount")
                     .and_then(serde_json::Value::as_u64)
             }),
-        MeterDirection::Output => openai_usage
-            .and_then(|usage| usage.get("completion_tokens"))
-            .and_then(serde_json::Value::as_u64)
+        MeterDirection::Output => usage_objects
+            .into_iter()
+            .flatten()
+            .filter_map(|usage| {
+                usage
+                    .get("completion_tokens")
+                    .or_else(|| usage.get("output_tokens"))
+                    .and_then(serde_json::Value::as_u64)
+            })
+            .max()
             .or_else(|| {
                 let usage = json.get("usageMetadata")?;
                 let input = usage.get("promptTokenCount")?.as_u64()?;
@@ -529,7 +550,7 @@ fn extract_dimension_quantity(
     if dim.unit == BillingUnit::QuotaUnits {
         let json =
             json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
-        let tokens = quota_token_quantity(json, dim.direction).ok_or_else(|| {
+        let tokens = provider_token_quantity(json, dim.direction).ok_or_else(|| {
             UptoUsageError::MissingUsage(format!(
                 "no token usage for {:?} quota units",
                 dim.direction
@@ -547,7 +568,7 @@ fn extract_dimension_quantity(
     if dim.unit == BillingUnit::Tokens {
         let json =
             json.ok_or_else(|| UptoUsageError::MissingUsage("response body unavailable".into()))?;
-        return quota_token_quantity(json, dim.direction).ok_or_else(|| {
+        return provider_token_quantity(json, dim.direction).ok_or_else(|| {
             UptoUsageError::MissingUsage(format!("no token usage for {:?} tokens", dim.direction))
         });
     }
@@ -2531,16 +2552,24 @@ mod tests {
             }),
         );
 
-        let actual = upto_actual_amount_from_response(
-            &settlement_plan(metering, 0.10),
-            100_000,
-            &HeaderMap::new(),
-            Some(br#"{"usage":{"prompt_tokens":3,"completion_tokens":2}}"#),
-        )
-        .unwrap();
+        for body in [
+            br#"{"usage":{"prompt_tokens":3,"completion_tokens":2}}"#.as_slice(),
+            br#"{"usage":{"input_tokens":3,"output_tokens":2}}"#.as_slice(),
+            br#"{"response":{"usage":{"input_tokens":3,"output_tokens":2}}}"#.as_slice(),
+            br#"{"message":{"usage":{"input_tokens":3,"output_tokens":2}}}"#.as_slice(),
+            br#"{"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}"#.as_slice(),
+        ] {
+            let actual = upto_actual_amount_from_response(
+                &settlement_plan(metering.clone(), 0.10),
+                100_000,
+                &HeaderMap::new(),
+                Some(body),
+            )
+            .unwrap();
 
-        assert_eq!(actual.usd, 0.000010);
-        assert_eq!(actual.base_units, 10);
+            assert_eq!(actual.usd, 0.000010);
+            assert_eq!(actual.base_units, 10);
+        }
     }
 
     #[test]

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -12,7 +12,7 @@ use pay_kit::mpp::AUTHORIZATION_HEADER;
 
 use crate::PaymentState;
 use crate::server::metering::{self, RequestProperties};
-use crate::server::session_stream::SessionStreamContext;
+use crate::server::session_stream::{self, SessionStreamContext};
 use crate::server::telemetry;
 
 /// Axum middleware that gates metered endpoints behind MPP payment.
@@ -200,6 +200,39 @@ async fn settle_axum_delegated_response(
         // Dropping `forward` releases the capacity lease without charging for
         // a response that was not successfully served.
         return response;
+    }
+
+    let is_sse = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(';')
+                .any(|part| part.trim().eq_ignore_ascii_case("text/event-stream"))
+        });
+    if is_sse && session_stream::DelegatedSessionStreamMeter::supports(&forward) {
+        let (mut parts, body) = response.into_parts();
+        let meter = match session_stream::DelegatedSessionStreamMeter::from_forward(forward) {
+            Ok(meter) => meter,
+            Err(error) => {
+                tracing::error!(%error, "failed to configure delegated session stream metering");
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"error":"session_metering_failed"}"#))
+                    .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+            }
+        };
+        parts.headers.remove(header::CONTENT_LENGTH);
+        return Response::from_parts(
+            parts,
+            Body::from_stream(session_stream::meter_delegated_response_stream(
+                body.into_data_stream(),
+                meter,
+                true,
+            )),
+        );
     }
 
     let limit = forward

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -99,23 +99,18 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                     // Delegated sessions are settled from the completed
                     // response below. The client-voucher stream context waits
                     // for client commits and must not be installed here.
-                    if sf.settlement.is_some() {
-                        let (restored, body_hints) = match request_body_metering_hints(req).await {
+                    if sf
+                        .settlement
+                        .as_deref()
+                        .is_some_and(|plan| plan.variant_hint.is_none())
+                    {
+                        let (restored, body_variant) = match request_body_variant_hint(req).await {
                             Ok(result) => result,
                             Err(response) => return response,
                         };
                         req = restored;
                         if let Some(plan) = sf.settlement.as_deref_mut() {
-                            let RequestBodyMeteringHints {
-                                variant,
-                                estimated_context_tokens,
-                            } = body_hints;
-                            if plan.variant_hint.is_none() {
-                                plan.variant_hint = variant;
-                            }
-                            if let Some(context_length) = estimated_context_tokens {
-                                plan.request_properties.context_length = Some(context_length);
-                            }
+                            plan.variant_hint = body_variant;
                         }
                     }
                     delegated_session = Some(sf);
@@ -216,9 +211,9 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
 /// Read the model selected by OpenAI/Anthropic-compatible JSON requests and
 /// restore the body for the upstream handler. Native model routes already
 /// carry their variant in the path and never enter this path.
-async fn request_body_metering_hints(
+async fn request_body_variant_hint(
     request: Request<Body>,
-) -> Result<(Request<Body>, RequestBodyMeteringHints), Response> {
+) -> Result<(Request<Body>, Option<String>), Response> {
     let (parts, body) = request.into_parts();
     let bytes = axum::body::to_bytes(body, MAX_DELEGATED_MODEL_HINT_BODY_BYTES)
         .await
@@ -230,75 +225,17 @@ async fn request_body_metering_hints(
                 .body(Body::from(r#"{"error":"request_body_too_large"}"#))
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         })?;
-    let hints = request_body_hints(&bytes);
-    Ok((Request::from_parts(parts, Body::from(bytes)), hints))
+    let variant = request_model_variant_hint(&bytes);
+    Ok((Request::from_parts(parts, Body::from(bytes)), variant))
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
-struct RequestBodyMeteringHints {
-    variant: Option<String>,
-    estimated_context_tokens: Option<u64>,
-}
-
-fn request_body_hints(body: &[u8]) -> RequestBodyMeteringHints {
-    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
-        return RequestBodyMeteringHints::default();
-    };
-    let variant = json
-        .get("model")
+fn request_model_variant_hint(body: &[u8]) -> Option<String> {
+    let json = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    json.get("model")
         .and_then(serde_json::Value::as_str)
         .map(str::trim)
         .filter(|model| !model.is_empty())
-        .map(str::to_string);
-    let estimated_context_tokens = estimate_request_context_tokens(&json);
-    RequestBodyMeteringHints {
-        variant,
-        estimated_context_tokens,
-    }
-}
-
-fn estimate_request_context_tokens(json: &serde_json::Value) -> Option<u64> {
-    const CONTEXT_FIELDS: [&str; 7] = [
-        "messages",
-        "input",
-        "prompt",
-        "instructions",
-        "system",
-        "contents",
-        "tools",
-    ];
-    let mut estimate = 0u64;
-    let mut found = false;
-    for field in CONTEXT_FIELDS {
-        if let Some(value) = json.get(field) {
-            found = true;
-            estimate = estimate.saturating_add(estimate_json_tokens(value));
-        }
-    }
-    found.then_some(estimate)
-}
-
-/// Conservative tokenizer-independent estimate used only to select a pricing
-/// tier before provider usage arrives. ASCII text averages roughly three or
-/// more bytes per token for agent prompts; non-ASCII scalars count as one each.
-fn estimate_json_tokens(value: &serde_json::Value) -> u64 {
-    match value {
-        serde_json::Value::Null => 0,
-        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => 1,
-        serde_json::Value::String(text) => {
-            let ascii = text.chars().filter(char::is_ascii).count() as u64;
-            let non_ascii = text.chars().filter(|ch| !ch.is_ascii()).count() as u64;
-            ascii.saturating_add(2) / 3 + non_ascii
-        }
-        serde_json::Value::Array(items) => items.iter().map(estimate_json_tokens).sum(),
-        serde_json::Value::Object(fields) => fields
-            .iter()
-            .map(|(key, value)| {
-                estimate_json_tokens(&serde_json::Value::String(key.clone()))
-                    .saturating_add(estimate_json_tokens(value))
-            })
-            .sum(),
-    }
+        .map(str::to_string)
 }
 
 async fn settle_axum_delegated_response(
@@ -620,49 +557,18 @@ mod tests {
     }
 
     #[test]
-    fn request_body_hints_read_model_and_estimate_context() {
+    fn request_model_variant_hint_reads_openai_compatible_model() {
         assert_eq!(
-            request_body_hints(
-                br#"{"model":"qwen3.7-max","messages":[{"role":"user","content":"hello world"}],"stream":true}"#
-            ),
-            RequestBodyMeteringHints {
-                variant: Some("qwen3.7-max".to_string()),
-                estimated_context_tokens: Some(11),
-            }
+            request_model_variant_hint(br#"{"model":"qwen3.7-max","stream":true}"#),
+            Some("qwen3.7-max".to_string())
         );
     }
 
     #[test]
-    fn request_body_hints_handle_missing_blank_and_invalid_models() {
-        assert_eq!(
-            request_body_hints(br#"{"messages":["hello"]}"#),
-            RequestBodyMeteringHints {
-                variant: None,
-                estimated_context_tokens: Some(2),
-            }
-        );
-        assert_eq!(
-            request_body_hints(br#"{"model":"  "}"#),
-            RequestBodyMeteringHints::default()
-        );
-        assert_eq!(
-            request_body_hints(b"not json"),
-            RequestBodyMeteringHints::default()
-        );
-    }
-
-    #[test]
-    fn request_context_estimate_crosses_long_context_pricing_tiers() {
-        let prompt = "a".repeat(600_003);
-        let body = serde_json::json!({
-            "model": "gemini-3.1-pro-preview",
-            "contents": [{"parts": [{"text": prompt}]}],
-        });
-
-        assert!(
-            estimate_request_context_tokens(&body).unwrap() > 200_000,
-            "long prompts must select the configured high-context tier"
-        );
+    fn request_model_variant_hint_rejects_missing_or_invalid_models() {
+        assert_eq!(request_model_variant_hint(br#"{"stream":true}"#), None);
+        assert_eq!(request_model_variant_hint(br#"{"model":"  "}"#), None);
+        assert_eq!(request_model_variant_hint(b"not json"), None);
     }
 
     #[test]

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -15,6 +15,8 @@ use crate::server::metering::{self, RequestProperties};
 use crate::server::session_stream::{self, SessionStreamContext};
 use crate::server::telemetry;
 
+const MAX_DELEGATED_MODEL_HINT_BODY_BYTES: usize = 10 * 1024 * 1024;
+
 /// Axum middleware that gates metered endpoints behind MPP payment.
 pub async fn payment_middleware<S: PaymentState>(
     axum::extract::State(state): axum::extract::State<S>,
@@ -92,11 +94,25 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
         } => {
             let mut req = req;
             let mut delegated_session = None;
-            if let Some(sf) = session {
+            if let Some(mut sf) = session {
                 if sf.settlement.is_some() {
                     // Delegated sessions are settled from the completed
                     // response below. The client-voucher stream context waits
                     // for client commits and must not be installed here.
+                    if sf
+                        .settlement
+                        .as_deref()
+                        .is_some_and(|plan| plan.variant_hint.is_none())
+                    {
+                        let (restored, body_variant) = match request_body_variant_hint(req).await {
+                            Ok(result) => result,
+                            Err(response) => return response,
+                        };
+                        req = restored;
+                        if let Some(plan) = sf.settlement.as_deref_mut() {
+                            plan.variant_hint = body_variant;
+                        }
+                    }
                     delegated_session = Some(sf);
                 } else {
                     req.extensions_mut().insert(SessionStreamContext::new(
@@ -190,6 +206,37 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
         }
         GateDecision::Passthrough => next.run(req).await,
     }
+}
+
+/// Read the model selected by OpenAI/Anthropic-compatible JSON requests and
+/// restore the body for the upstream handler. Native model routes already
+/// carry their variant in the path and never enter this path.
+async fn request_body_variant_hint(
+    request: Request<Body>,
+) -> Result<(Request<Body>, Option<String>), Response> {
+    let (parts, body) = request.into_parts();
+    let bytes = axum::body::to_bytes(body, MAX_DELEGATED_MODEL_HINT_BODY_BYTES)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "failed to read delegated session request model");
+            Response::builder()
+                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"error":"request_body_too_large"}"#))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+        })?;
+    let variant = request_model_variant_hint(&bytes);
+    Ok((Request::from_parts(parts, Body::from(bytes)), variant))
+}
+
+fn request_model_variant_hint(body: &[u8]) -> Option<String> {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()?
+        .get("model")?
+        .as_str()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
 }
 
 async fn settle_axum_delegated_response(
@@ -508,6 +555,21 @@ mod tests {
     fn extract_variant_hint_models_at_end() {
         // "models" is the last segment — no next segment
         assert_eq!(extract_variant_hint("v1/models"), None);
+    }
+
+    #[test]
+    fn request_model_variant_hint_reads_openai_compatible_model() {
+        assert_eq!(
+            request_model_variant_hint(br#"{"model":"qwen3.7-max","stream":true}"#),
+            Some("qwen3.7-max".to_string())
+        );
+    }
+
+    #[test]
+    fn request_model_variant_hint_rejects_missing_or_invalid_models() {
+        assert_eq!(request_model_variant_hint(br#"{"stream":true}"#), None);
+        assert_eq!(request_model_variant_hint(br#"{"model":"  "}"#), None);
+        assert_eq!(request_model_variant_hint(b"not json"), None);
     }
 
     #[test]

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -99,18 +99,23 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                     // Delegated sessions are settled from the completed
                     // response below. The client-voucher stream context waits
                     // for client commits and must not be installed here.
-                    if sf
-                        .settlement
-                        .as_deref()
-                        .is_some_and(|plan| plan.variant_hint.is_none())
-                    {
-                        let (restored, body_variant) = match request_body_variant_hint(req).await {
+                    if sf.settlement.is_some() {
+                        let (restored, body_hints) = match request_body_metering_hints(req).await {
                             Ok(result) => result,
                             Err(response) => return response,
                         };
                         req = restored;
                         if let Some(plan) = sf.settlement.as_deref_mut() {
-                            plan.variant_hint = body_variant;
+                            let RequestBodyMeteringHints {
+                                variant,
+                                estimated_context_tokens,
+                            } = body_hints;
+                            if plan.variant_hint.is_none() {
+                                plan.variant_hint = variant;
+                            }
+                            if let Some(context_length) = estimated_context_tokens {
+                                plan.request_properties.context_length = Some(context_length);
+                            }
                         }
                     }
                     delegated_session = Some(sf);
@@ -211,9 +216,9 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
 /// Read the model selected by OpenAI/Anthropic-compatible JSON requests and
 /// restore the body for the upstream handler. Native model routes already
 /// carry their variant in the path and never enter this path.
-async fn request_body_variant_hint(
+async fn request_body_metering_hints(
     request: Request<Body>,
-) -> Result<(Request<Body>, Option<String>), Response> {
+) -> Result<(Request<Body>, RequestBodyMeteringHints), Response> {
     let (parts, body) = request.into_parts();
     let bytes = axum::body::to_bytes(body, MAX_DELEGATED_MODEL_HINT_BODY_BYTES)
         .await
@@ -225,18 +230,75 @@ async fn request_body_variant_hint(
                 .body(Body::from(r#"{"error":"request_body_too_large"}"#))
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         })?;
-    let variant = request_model_variant_hint(&bytes);
-    Ok((Request::from_parts(parts, Body::from(bytes)), variant))
+    let hints = request_body_hints(&bytes);
+    Ok((Request::from_parts(parts, Body::from(bytes)), hints))
 }
 
-fn request_model_variant_hint(body: &[u8]) -> Option<String> {
-    serde_json::from_slice::<serde_json::Value>(body)
-        .ok()?
-        .get("model")?
-        .as_str()
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RequestBodyMeteringHints {
+    variant: Option<String>,
+    estimated_context_tokens: Option<u64>,
+}
+
+fn request_body_hints(body: &[u8]) -> RequestBodyMeteringHints {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return RequestBodyMeteringHints::default();
+    };
+    let variant = json
+        .get("model")
+        .and_then(serde_json::Value::as_str)
         .map(str::trim)
         .filter(|model| !model.is_empty())
-        .map(str::to_string)
+        .map(str::to_string);
+    let estimated_context_tokens = estimate_request_context_tokens(&json);
+    RequestBodyMeteringHints {
+        variant,
+        estimated_context_tokens,
+    }
+}
+
+fn estimate_request_context_tokens(json: &serde_json::Value) -> Option<u64> {
+    const CONTEXT_FIELDS: [&str; 7] = [
+        "messages",
+        "input",
+        "prompt",
+        "instructions",
+        "system",
+        "contents",
+        "tools",
+    ];
+    let mut estimate = 0u64;
+    let mut found = false;
+    for field in CONTEXT_FIELDS {
+        if let Some(value) = json.get(field) {
+            found = true;
+            estimate = estimate.saturating_add(estimate_json_tokens(value));
+        }
+    }
+    found.then_some(estimate)
+}
+
+/// Conservative tokenizer-independent estimate used only to select a pricing
+/// tier before provider usage arrives. ASCII text averages roughly three or
+/// more bytes per token for agent prompts; non-ASCII scalars count as one each.
+fn estimate_json_tokens(value: &serde_json::Value) -> u64 {
+    match value {
+        serde_json::Value::Null => 0,
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => 1,
+        serde_json::Value::String(text) => {
+            let ascii = text.chars().filter(char::is_ascii).count() as u64;
+            let non_ascii = text.chars().filter(|ch| !ch.is_ascii()).count() as u64;
+            ascii.saturating_add(2) / 3 + non_ascii
+        }
+        serde_json::Value::Array(items) => items.iter().map(estimate_json_tokens).sum(),
+        serde_json::Value::Object(fields) => fields
+            .iter()
+            .map(|(key, value)| {
+                estimate_json_tokens(&serde_json::Value::String(key.clone()))
+                    .saturating_add(estimate_json_tokens(value))
+            })
+            .sum(),
+    }
 }
 
 async fn settle_axum_delegated_response(
@@ -558,18 +620,49 @@ mod tests {
     }
 
     #[test]
-    fn request_model_variant_hint_reads_openai_compatible_model() {
+    fn request_body_hints_read_model_and_estimate_context() {
         assert_eq!(
-            request_model_variant_hint(br#"{"model":"qwen3.7-max","stream":true}"#),
-            Some("qwen3.7-max".to_string())
+            request_body_hints(
+                br#"{"model":"qwen3.7-max","messages":[{"role":"user","content":"hello world"}],"stream":true}"#
+            ),
+            RequestBodyMeteringHints {
+                variant: Some("qwen3.7-max".to_string()),
+                estimated_context_tokens: Some(11),
+            }
         );
     }
 
     #[test]
-    fn request_model_variant_hint_rejects_missing_or_invalid_models() {
-        assert_eq!(request_model_variant_hint(br#"{"stream":true}"#), None);
-        assert_eq!(request_model_variant_hint(br#"{"model":"  "}"#), None);
-        assert_eq!(request_model_variant_hint(b"not json"), None);
+    fn request_body_hints_handle_missing_blank_and_invalid_models() {
+        assert_eq!(
+            request_body_hints(br#"{"messages":["hello"]}"#),
+            RequestBodyMeteringHints {
+                variant: None,
+                estimated_context_tokens: Some(2),
+            }
+        );
+        assert_eq!(
+            request_body_hints(br#"{"model":"  "}"#),
+            RequestBodyMeteringHints::default()
+        );
+        assert_eq!(
+            request_body_hints(b"not json"),
+            RequestBodyMeteringHints::default()
+        );
+    }
+
+    #[test]
+    fn request_context_estimate_crosses_long_context_pricing_tiers() {
+        let prompt = "a".repeat(600_003);
+        let body = serde_json::json!({
+            "model": "gemini-3.1-pro-preview",
+            "contents": [{"parts": [{"text": prompt}]}],
+        });
+
+        assert!(
+            estimate_request_context_tokens(&body).unwrap() > 200_000,
+            "long prompts must select the configured high-context tier"
+        );
     }
 
     #[test]

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -104,10 +104,12 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                         .as_deref()
                         .is_some_and(|plan| plan.variant_hint.is_none())
                     {
-                        let (restored, body_variant) = match request_body_variant_hint(req).await {
-                            Ok(result) => result,
-                            Err(response) => return response,
-                        };
+                        let force_stream_usage = path.ends_with("chat/completions");
+                        let (restored, body_variant) =
+                            match prepare_delegated_request_body(req, force_stream_usage).await {
+                                Ok(result) => result,
+                                Err(response) => return response,
+                            };
                         req = restored;
                         if let Some(plan) = sf.settlement.as_deref_mut() {
                             plan.variant_hint = body_variant;
@@ -211,10 +213,11 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
 /// Read the model selected by OpenAI/Anthropic-compatible JSON requests and
 /// restore the body for the upstream handler. Native model routes already
 /// carry their variant in the path and never enter this path.
-async fn request_body_variant_hint(
+async fn prepare_delegated_request_body(
     request: Request<Body>,
+    force_stream_usage: bool,
 ) -> Result<(Request<Body>, Option<String>), Response> {
-    let (parts, body) = request.into_parts();
+    let (mut parts, body) = request.into_parts();
     let bytes = axum::body::to_bytes(body, MAX_DELEGATED_MODEL_HINT_BODY_BYTES)
         .await
         .map_err(|error| {
@@ -225,17 +228,49 @@ async fn request_body_variant_hint(
                 .body(Body::from(r#"{"error":"request_body_too_large"}"#))
                 .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         })?;
-    let variant = request_model_variant_hint(&bytes);
+    let (variant, bytes) = prepare_delegated_json_body(&bytes, force_stream_usage);
+    if force_stream_usage && let Ok(content_length) = bytes.len().to_string().parse() {
+        parts.headers.insert(header::CONTENT_LENGTH, content_length);
+    }
     Ok((Request::from_parts(parts, Body::from(bytes)), variant))
 }
 
-fn request_model_variant_hint(body: &[u8]) -> Option<String> {
-    let json = serde_json::from_slice::<serde_json::Value>(body).ok()?;
-    json.get("model")
+fn prepare_delegated_json_body(body: &[u8], force_stream_usage: bool) -> (Option<String>, Vec<u8>) {
+    let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return (None, body.to_vec());
+    };
+    let variant = json
+        .get("model")
         .and_then(serde_json::Value::as_str)
         .map(str::trim)
         .filter(|model| !model.is_empty())
-        .map(str::to_string)
+        .map(str::to_string);
+
+    let is_stream = json
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !force_stream_usage || !is_stream {
+        return (variant, body.to_vec());
+    }
+
+    let Some(object) = json.as_object_mut() else {
+        return (variant, body.to_vec());
+    };
+    let stream_options = object
+        .entry("stream_options")
+        .or_insert_with(|| serde_json::json!({}));
+    if !stream_options.is_object() {
+        *stream_options = serde_json::json!({});
+    }
+    if let Some(stream_options) = stream_options.as_object_mut() {
+        stream_options.insert("include_usage".to_string(), serde_json::Value::Bool(true));
+    }
+
+    (
+        variant,
+        serde_json::to_vec(&json).unwrap_or_else(|_| body.to_vec()),
+    )
 }
 
 async fn settle_axum_delegated_response(
@@ -557,18 +592,46 @@ mod tests {
     }
 
     #[test]
-    fn request_model_variant_hint_reads_openai_compatible_model() {
+    fn delegated_json_body_reads_openai_compatible_model() {
         assert_eq!(
-            request_model_variant_hint(br#"{"model":"qwen3.7-max","stream":true}"#),
+            prepare_delegated_json_body(br#"{"model":"qwen3.7-max","stream":true}"#, false).0,
             Some("qwen3.7-max".to_string())
         );
     }
 
     #[test]
-    fn request_model_variant_hint_rejects_missing_or_invalid_models() {
-        assert_eq!(request_model_variant_hint(br#"{"stream":true}"#), None);
-        assert_eq!(request_model_variant_hint(br#"{"model":"  "}"#), None);
-        assert_eq!(request_model_variant_hint(b"not json"), None);
+    fn delegated_json_body_rejects_missing_or_invalid_models() {
+        assert_eq!(
+            prepare_delegated_json_body(br#"{"stream":true}"#, false).0,
+            None
+        );
+        assert_eq!(
+            prepare_delegated_json_body(br#"{"model":"  "}"#, false).0,
+            None
+        );
+        assert_eq!(prepare_delegated_json_body(b"not json", false).0, None);
+    }
+
+    #[test]
+    fn delegated_chat_stream_forces_provider_usage_frames() {
+        let (variant, body) = prepare_delegated_json_body(
+            br#"{"model":"qwen3.7-plus","stream":true,"stream_options":{"include_usage":false}}"#,
+            true,
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(variant.as_deref(), Some("qwen3.7-plus"));
+        assert_eq!(
+            json.pointer("/stream_options/include_usage"),
+            Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn delegated_non_stream_request_body_is_unchanged() {
+        let body = br#"{"model":"qwen3.7-plus","stream":false}"#;
+        let (_, prepared) = prepare_delegated_json_body(body, true);
+        assert_eq!(prepared, body);
     }
 
     #[test]

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -37,12 +37,13 @@ use crate::{Error, Result};
 const INTENT: &str = "session";
 const METHOD: &str = "solana";
 const DEFAULT_REALM: &str = "MPP Session";
-fn session_close_already_requested(error: &pay_kit::mpp::Error) -> bool {
-    error.to_string().contains("Close already requested")
-}
-
 fn session_close_already_finalized(error: &pay_kit::mpp::Error) -> bool {
     error.to_string().contains("already finalized")
+}
+
+fn session_close_needs_reconciliation(error: &pay_kit::mpp::Error) -> bool {
+    let message = error.to_string();
+    message.contains("Close already requested") || message.contains("Channel is already sealed")
 }
 
 // ── Session outcome ────────────────────────────────────────────────────────
@@ -238,7 +239,7 @@ impl SessionOperatorRuntime {
             Err(error) if session_close_already_finalized(&error) => {
                 return Ok(SessionCloseResult::AlreadyFinalized);
             }
-            Err(error) if session_close_already_requested(&error) => self
+            Err(error) if session_close_needs_reconciliation(&error) => self
                 .server
                 .seal_params(channel_id)
                 .await
@@ -270,6 +271,7 @@ impl SessionOperatorRuntime {
             // surface the on-chain receipt URL (sessions settle out-of-band).
             self.record_settlement_signature(params.channel_id.to_string(), signature.clone());
             tracing::info!(
+                monotonic_counter.pay_payment_channels_closed_total = 1_u64,
                 %signature,
                 channel = %params.channel_id,
                 "payment-channel settlement confirmed"
@@ -423,6 +425,7 @@ impl SessionOperatorRuntime {
             .settlement_worker
             .get_or_init(|| {
                 let signer = Arc::clone(&signer);
+                let rpc_url = rpc_url.clone();
                 async move {
                     spawn(
                         SettlementConfig::new(operator, signer),
@@ -431,10 +434,12 @@ impl SessionOperatorRuntime {
                 }
             })
             .await;
-        match handle.settle(channel_id, instructions).await {
-            Ok(signature) => Ok(Some(signature)),
-            Err(e) => Err(Error::Mpp(format!("payment-channel settlement: {e}"))),
-        }
+        let signature = handle
+            .settle(channel_id, instructions)
+            .await
+            .map_err(|e| Error::Mpp(format!("payment-channel settlement: {e}")))?;
+        wait_for_transaction_confirmed(&rpc_url, &signature, "payment-channel settlement").await?;
+        Ok(Some(signature))
     }
 }
 
@@ -1132,11 +1137,17 @@ impl SessionMpp {
             }
 
             SessionAction::Close(p) => {
-                let params = self
-                    .server
-                    .process_close(p)
-                    .await
-                    .map_err(|e| Error::Mpp(format!("Session close failed: {e}")))?;
+                let params = match self.server.process_close(p).await {
+                    Ok(params) => params,
+                    Err(error) if session_close_needs_reconciliation(&error) => self
+                        .server
+                        .seal_params(&p.channel_id)
+                        .await
+                        .map_err(|e| Error::Mpp(format!("Failed to get seal params: {e}")))?,
+                    Err(error) => {
+                        return Err(Error::Mpp(format!("Session close failed: {error}")));
+                    }
+                };
                 self.record_committed_watermark(params.channel_id.to_string(), params.settled);
                 let settlement = self.submit_payment_channel_settlement(&params).await;
                 let signature = match settlement {
@@ -1166,7 +1177,12 @@ impl SessionMpp {
                         params.channel_id.to_string(),
                         signature.clone(),
                     );
-                    tracing::info!(%signature, channel = %params.channel_id, "payment-channel settlement confirmed");
+                    tracing::info!(
+                        monotonic_counter.pay_payment_channels_closed_total = 1_u64,
+                        %signature,
+                        channel = %params.channel_id,
+                        "payment-channel settlement confirmed"
+                    );
                 }
                 self.unschedule_channel_close(params.channel_id.to_string());
                 Ok(SessionOutcome::Closed { params, signature })
@@ -1534,6 +1550,44 @@ async fn submit_versioned_transaction(
     })
     .await
     .map_err(|e| Error::Mpp(format!("spawn_blocking join error: {e}")))?
+}
+
+/// Wait for a previously broadcast transaction to succeed at confirmed
+/// commitment before allowing durable state to advance.
+async fn wait_for_transaction_confirmed(
+    rpc_url: &str,
+    signature: &str,
+    context: &'static str,
+) -> Result<()> {
+    use pay_kit::mpp::solana_rpc_client::nonblocking::rpc_client::RpcClient;
+    use solana_commitment_config::CommitmentConfig;
+
+    let signature = solana_signature::Signature::from_str(signature)
+        .map_err(|e| Error::Mpp(format!("invalid {context} signature: {e}")))?;
+    let rpc = RpcClient::new(rpc_url.to_string());
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last_status_error = None;
+    while Instant::now() < deadline {
+        match rpc
+            .get_signature_status_with_commitment(&signature, CommitmentConfig::confirmed())
+            .await
+        {
+            Ok(Some(Ok(()))) => return Ok(()),
+            Ok(Some(Err(error))) => {
+                return Err(Error::Mpp(format!("{context} transaction failed: {error}")));
+            }
+            Ok(None) => {}
+            Err(error) => last_status_error = Some(error.to_string()),
+        }
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    }
+
+    let detail = last_status_error
+        .map(|error| format!("; last status error: {error}"))
+        .unwrap_or_default();
+    Err(Error::Mpp(format!(
+        "{context} transaction was not confirmed before timeout{detail}"
+    )))
 }
 
 /// Wait for the transaction's first successful status. `get_signature_status`
@@ -2294,5 +2348,16 @@ mod tests {
         assert!(close_voucher_required(4_330, 4_331));
         assert!(!close_voucher_required(4_331, 4_331));
         assert!(!close_voucher_required(4_332, 4_331));
+    }
+
+    #[test]
+    fn close_reconciles_durable_state_after_failed_broadcast() {
+        let close_pending = pay_kit::mpp::Error::Other("Close already requested".to_string());
+        let sealed = pay_kit::mpp::Error::Other("Channel is already sealed".to_string());
+        let missing = pay_kit::mpp::Error::Other("Channel not found".to_string());
+
+        assert!(session_close_needs_reconciliation(&close_pending));
+        assert!(session_close_needs_reconciliation(&sealed));
+        assert!(!session_close_needs_reconciliation(&missing));
     }
 }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1137,6 +1137,14 @@ impl SessionMpp {
             }
 
             SessionAction::Close(p) => {
+                let _lease = self
+                    .reserve_delegated_capacity(&p.channel_id, 0)
+                    .ok_or_else(|| {
+                        Error::Mpp(format!(
+                            "Session channel {} is busy with another request",
+                            p.channel_id
+                        ))
+                    })?;
                 let params = match self.server.process_close(p).await {
                     Ok(params) => params,
                     Err(error) if session_close_needs_reconciliation(&error) => self
@@ -1803,6 +1811,16 @@ mod tests {
         assert_eq!(topped_up.deposit, CAP + 500);
 
         let close_header = handle.close_header(Some(25)).await.unwrap();
+        let competing_lease = session
+            .reserve_delegated_capacity(&opened.channel_id, 0)
+            .expect("test should reserve the channel");
+        let error = session.process(&close_header).await.unwrap_err();
+        assert!(
+            error.to_string().contains("busy with another request"),
+            "client close must not race another channel owner: {error}"
+        );
+        drop(competing_lease);
+
         let SessionOutcome::Closed { params, signature } =
             session.process(&close_header).await.unwrap()
         else {

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -355,10 +355,22 @@ impl SessionOperatorRuntime {
         })?;
         let token_program = spl_token_program();
 
-        let signature = match params.voucher_signature.as_deref() {
-            Some(signature) => Some(decode_voucher_signature(signature)?),
-            None if params.settled == 0 => None,
-            None => {
+        // A periodic watermark push may have landed immediately before this
+        // close. Reusing that same cumulative voucher in `settle_and_seal`
+        // fails with VoucherWatermarkNotMonotonic (0xEA). When chain already
+        // has the latest accepted watermark, seal it without another voucher.
+        let channel_id = params.channel_id.to_string();
+        let onchain_settled = self
+            .fetch_payment_channel(&channel_id)
+            .await?
+            .map(|channel| channel.settlement.settled)
+            .unwrap_or_default();
+        let voucher_required = close_voucher_required(onchain_settled, params.settled);
+        let signature = match (voucher_required, params.voucher_signature.as_deref()) {
+            (false, _) => None,
+            (true, Some(signature)) => Some(decode_voucher_signature(signature)?),
+            (true, None) if params.settled == 0 => None,
+            (true, None) => {
                 return Err(Error::Mpp(
                     "payment-channel settlement missing highest voucher signature".to_string(),
                 ));
@@ -419,14 +431,15 @@ impl SessionOperatorRuntime {
                 }
             })
             .await;
-        match handle
-            .settle(params.channel_id.to_string(), instructions)
-            .await
-        {
+        match handle.settle(channel_id, instructions).await {
             Ok(signature) => Ok(Some(signature)),
             Err(e) => Err(Error::Mpp(format!("payment-channel settlement: {e}"))),
         }
     }
+}
+
+fn close_voucher_required(onchain_settled: u64, latest_accepted: u64) -> bool {
+    onchain_settled < latest_accepted
 }
 
 /// Exclusive claim on a delegated session's remaining capacity.
@@ -2274,5 +2287,12 @@ mod tests {
         let err = validate_payment_channel_open_transaction(&tx, &expected, &wrong_fee_payer)
             .unwrap_err();
         assert!(err.to_string().contains("fee payer"));
+    }
+
+    #[test]
+    fn close_omits_voucher_when_watermark_already_landed() {
+        assert!(close_voucher_required(4_330, 4_331));
+        assert!(!close_voucher_required(4_331, 4_331));
+        assert!(!close_voucher_required(4_332, 4_331));
     }
 }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -20,7 +20,7 @@ use pay_kit::mpp::blockhash::{BlockhashCache, CachedBlockhash};
 use pay_kit::mpp::server::session::{SealParams, SessionConfig, SessionServer};
 use pay_kit::mpp::settlement::worker::{RpcBroadcaster, SettlementConfig, SettlementHandle, spawn};
 use pay_kit::mpp::solana_keychain::SolanaSigner;
-use pay_kit::mpp::store::{ChannelState, MemoryChannelStore};
+use pay_kit::mpp::store::{ChannelState, ChannelStore, MemoryChannelStore};
 use pay_kit::mpp::{
     Base64UrlJson, CommitReceipt, OpenPayload, PaymentChallenge, SessionAction, SessionMode,
     SessionPullVoucherStrategy, SessionSettlementAuthority, SignedVoucher, VoucherData,
@@ -70,7 +70,7 @@ pub enum SessionOutcome {
 
 #[derive(Clone)]
 struct SessionOperatorRuntime {
-    server: Arc<SessionServer<MemoryChannelStore>>,
+    server: Arc<SessionServer<Arc<dyn ChannelStore>>>,
     rpc_url: Option<String>,
     payment_channel_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     payment_channel_payer_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
@@ -137,6 +137,85 @@ impl SessionOperatorRuntime {
             .ok()
             .and_then(|signer| signer.clone())
             .or_else(|| self.payment_channel_signer())
+    }
+
+    /// Push the latest accepted cumulative voucher on-chain without sealing
+    /// the channel. The on-chain watermark is read first, so retries are
+    /// idempotent and a successfully landed watermark is not re-broadcast on
+    /// every lifecycle tick.
+    async fn operator_push_watermark(&self, channel_id: &str) -> Result<()> {
+        let Some(signer) = self.payment_channel_signer() else {
+            // Verification-only servers have no authority to settle. Idle
+            // close retains its existing no-op behavior for these instances.
+            return Ok(());
+        };
+        let Some(rpc_url) = self.rpc_url.clone() else {
+            return Ok(());
+        };
+        let params = self
+            .server
+            .seal_params(channel_id)
+            .await
+            .map_err(|e| Error::Mpp(format!("Failed to get watermark params: {e}")))?;
+        if params.settled == 0 {
+            return Ok(());
+        }
+
+        let channel = self.fetch_payment_channel(channel_id).await?;
+        let Some(channel) = channel else {
+            // A missing/deallocated channel has nothing left to settle.
+            return Ok(());
+        };
+        // Only OPEN channels accept an intermediate settle. CLOSING/SEALED/
+        // DISTRIBUTED channels are already advancing through the close path.
+        if channel.status != 0 || channel.settlement.settled >= params.settled {
+            return Ok(());
+        }
+
+        let authorized_signer = params.authorized_signer.ok_or_else(|| {
+            Error::Mpp("payment-channel watermark missing authorized signer".to_string())
+        })?;
+        let voucher_signature = params.voucher_signature.as_deref().ok_or_else(|| {
+            Error::Mpp("payment-channel watermark missing voucher signature".to_string())
+        })?;
+        let signature = decode_voucher_signature(voucher_signature)?;
+        let expires_at = params.voucher_expires_at.ok_or_else(|| {
+            Error::Mpp("payment-channel watermark missing voucher expiry".to_string())
+        })?;
+        let instructions = pay_kit::mpp::program::payment_channels::build_settle_instructions(
+            &params.channel_id,
+            &authorized_signer,
+            &signature,
+            params.settled,
+            expires_at,
+            &params.program_id,
+        )
+        .map_err(|e| Error::Mpp(format!("failed to build watermark instruction: {e}")))?;
+
+        let operator = signer.pubkey();
+        let handle = self
+            .settlement_worker
+            .get_or_init(|| {
+                let signer = Arc::clone(&signer);
+                async move {
+                    spawn(
+                        SettlementConfig::new(operator, signer),
+                        Arc::new(RpcBroadcaster::new(rpc_url)),
+                    )
+                }
+            })
+            .await;
+        let signature = handle
+            .settle(params.channel_id.to_string(), instructions)
+            .await
+            .map_err(|e| Error::Mpp(format!("payment-channel watermark settlement: {e}")))?;
+        tracing::info!(
+            channel_id,
+            cumulative = params.settled,
+            %signature,
+            "payment-channel watermark broadcast"
+        );
+        Ok(())
     }
 
     async fn operator_close_channel(&self, channel_id: &str) -> Result<SessionCloseResult> {
@@ -216,6 +295,32 @@ impl SessionOperatorRuntime {
             .await
             .map(|account| account.data.as_slice() == [2])
             .unwrap_or(false)
+    }
+
+    async fn fetch_payment_channel(
+        &self,
+        channel_id: &str,
+    ) -> Result<
+        Option<pay_kit::mpp::program::payment_channels::generated::generated::accounts::Channel>,
+    > {
+        let Some(rpc_url) = self.rpc_url.clone() else {
+            return Ok(None);
+        };
+        let channel = solana_pubkey::Pubkey::from_str(channel_id)
+            .map_err(|e| Error::Mpp(format!("invalid payment channel: {e}")))?;
+        use pay_kit::mpp::program::payment_channels::generated::generated::accounts::Channel;
+        use pay_kit::mpp::solana_rpc_client::nonblocking::rpc_client::RpcClient;
+        use solana_commitment_config::CommitmentConfig;
+        RpcClient::new(rpc_url)
+            .get_account_with_commitment(&channel, CommitmentConfig::confirmed())
+            .await
+            .map_err(|error| Error::Mpp(format!("failed to fetch payment channel: {error}")))?
+            .value
+            .map(|account| {
+                Channel::from_bytes(&account.data)
+                    .map_err(|e| Error::Mpp(format!("failed to decode payment channel: {e}")))
+            })
+            .transpose()
     }
 
     async fn submit_payment_channel_settlement(
@@ -354,16 +459,25 @@ impl SessionLifecycleHandle {
 
 #[derive(Debug)]
 enum SessionLifecycleCommand {
-    ConfigureCloseDelay { close_delay: Option<Duration> },
-    Touch { channel_id: String },
-    Remove { channel_id: String },
+    Configure {
+        close_delay: Option<Duration>,
+        settlement_interval: Option<Duration>,
+    },
+    Touch {
+        channel_id: String,
+    },
+    Remove {
+        channel_id: String,
+    },
 }
 
 struct SessionLifecycleRunloop {
     runtime: SessionOperatorRuntime,
     close_delay: Option<Duration>,
+    settlement_interval: Option<Duration>,
+    next_settlement: Option<Instant>,
     rx: mpsc::UnboundedReceiver<SessionLifecycleCommand>,
-    deadlines: HashMap<String, Instant>,
+    last_activity: HashMap<String, Instant>,
 }
 
 impl SessionLifecycleRunloop {
@@ -374,8 +488,10 @@ impl SessionLifecycleRunloop {
         Self {
             runtime,
             close_delay: None,
+            settlement_interval: None,
+            next_settlement: None,
             rx,
-            deadlines: HashMap::new(),
+            last_activity: HashMap::new(),
         }
     }
 
@@ -390,6 +506,7 @@ impl SessionLifecycleRunloop {
                     }
                     _ = tokio::time::sleep_until(deadline) => {
                         self.close_due_channels().await;
+                        self.push_due_watermarks().await;
                     }
                 }
             } else {
@@ -403,22 +520,31 @@ impl SessionLifecycleRunloop {
 
     fn handle_command(&mut self, command: Option<SessionLifecycleCommand>) -> bool {
         match command {
-            Some(SessionLifecycleCommand::ConfigureCloseDelay { close_delay }) => {
+            Some(SessionLifecycleCommand::Configure {
+                close_delay,
+                settlement_interval,
+            }) => {
                 self.close_delay = close_delay;
-                if self.close_delay.is_none() {
-                    self.deadlines.clear();
-                }
+                self.settlement_interval = settlement_interval;
+                self.next_settlement = settlement_interval
+                    .filter(|_| !self.last_activity.is_empty())
+                    .map(|interval| Instant::now() + interval);
                 true
             }
             Some(SessionLifecycleCommand::Touch { channel_id }) => {
-                if let Some(close_delay) = self.close_delay {
-                    let deadline = Instant::now() + close_delay;
-                    self.deadlines.insert(channel_id, deadline);
+                self.last_activity.insert(channel_id, Instant::now());
+                if self.next_settlement.is_none()
+                    && let Some(interval) = self.settlement_interval
+                {
+                    self.next_settlement = Some(Instant::now() + interval);
                 }
                 true
             }
             Some(SessionLifecycleCommand::Remove { channel_id }) => {
-                self.deadlines.remove(&channel_id);
+                self.last_activity.remove(&channel_id);
+                if self.last_activity.is_empty() {
+                    self.next_settlement = None;
+                }
                 true
             }
             None => false,
@@ -426,32 +552,51 @@ impl SessionLifecycleRunloop {
     }
 
     fn next_wakeup(&self) -> Option<Instant> {
-        self.deadlines.values().copied().min()
+        let close = self.close_delay.and_then(|delay| {
+            self.last_activity
+                .values()
+                .map(|last_activity| *last_activity + delay)
+                .min()
+        });
+        match (close, self.next_settlement) {
+            (Some(close), Some(settlement)) => Some(close.min(settlement)),
+            (Some(close), None) => Some(close),
+            (None, Some(settlement)) => Some(settlement),
+            (None, None) => None,
+        }
     }
 
     async fn close_due_channels(&mut self) {
+        let Some(close_delay) = self.close_delay else {
+            return;
+        };
         let now = Instant::now();
         let due = self
-            .deadlines
+            .last_activity
             .iter()
-            .filter(|(_, deadline)| **deadline <= now)
+            .filter(|(_, last_activity)| **last_activity + close_delay <= now)
             .map(|(channel_id, _)| channel_id.clone())
             .collect::<Vec<_>>();
 
+        let mut closing = Vec::with_capacity(due.len());
         for channel_id in due {
-            self.deadlines.remove(&channel_id);
+            self.last_activity.remove(&channel_id);
             // Closing and serving both claim the same channel slot. This makes
             // the reservation check atomic with the start of close: a request
             // already in flight defers close, while a close already in progress
             // prevents a new request from reserving stale capacity.
             if !self.runtime.reserve_capacity(&channel_id, 0) {
-                if let Some(close_delay) = self.close_delay {
-                    self.deadlines
-                        .insert(channel_id, Instant::now() + close_delay);
-                }
+                self.last_activity.insert(channel_id, Instant::now());
                 continue;
             }
-            let close_result = self.runtime.operator_close_channel(&channel_id).await;
+            let runtime = self.runtime.clone();
+            closing.push(async move {
+                let result = runtime.operator_close_channel(&channel_id).await;
+                (channel_id, result)
+            });
+        }
+
+        for (channel_id, close_result) in futures_util::future::join_all(closing).await {
             self.runtime.release_capacity(&channel_id);
             match close_result {
                 Ok(SessionCloseResult::Closed { settled }) => {
@@ -466,13 +611,48 @@ impl SessionLifecycleRunloop {
                         error = %error,
                         "operator auto-close failed; retrying after delay"
                     );
-                    if let Some(close_delay) = self.close_delay {
-                        self.deadlines
-                            .insert(channel_id, Instant::now() + close_delay);
-                    }
+                    self.last_activity.insert(channel_id, Instant::now());
                 }
             }
         }
+    }
+
+    async fn push_due_watermarks(&mut self) {
+        let Some(interval) = self.settlement_interval else {
+            self.next_settlement = None;
+            return;
+        };
+        let now = Instant::now();
+        if self.next_settlement.is_some_and(|deadline| deadline > now) {
+            return;
+        }
+
+        // Idle channels were removed (or rescheduled after an error) by
+        // `close_due_channels`; everything left here should remain open.
+        let channels = self.last_activity.keys().cloned().collect::<Vec<_>>();
+        let mut settlements = Vec::with_capacity(channels.len());
+        for channel_id in channels {
+            if !self.runtime.reserve_capacity(&channel_id, 0) {
+                continue;
+            }
+            let runtime = self.runtime.clone();
+            settlements.push(async move {
+                let result = runtime.operator_push_watermark(&channel_id).await;
+                (channel_id, result)
+            });
+        }
+        for (channel_id, result) in futures_util::future::join_all(settlements).await {
+            self.runtime.release_capacity(&channel_id);
+            if let Err(error) = result {
+                tracing::warn!(
+                    channel_id,
+                    error = %error,
+                    "operator watermark push failed; retrying next interval"
+                );
+            }
+        }
+
+        self.next_settlement = (!self.last_activity.is_empty()).then(|| now + interval);
     }
 }
 
@@ -492,7 +672,7 @@ enum SessionCloseResult {
 /// server validates and co-signs. Pull-mode delegation setup remains available
 /// for compatibility, but it no longer opens a synthetic channel.
 pub struct SessionMpp {
-    server: Arc<SessionServer<MemoryChannelStore>>,
+    server: Arc<SessionServer<Arc<dyn ChannelStore>>>,
     session_config: SessionConfig,
     challenge_binding_secret: String,
     realm: String,
@@ -527,8 +707,21 @@ impl SessionMpp {
 
     /// Create from a [`SessionConfig`] and an HMAC secret key.
     pub fn new(config: SessionConfig, challenge_binding_secret: impl Into<String>) -> Self {
+        Self::new_with_channel_store(
+            config,
+            challenge_binding_secret,
+            Arc::new(MemoryChannelStore::new()),
+        )
+    }
+
+    /// Create with a caller-provided durable channel store.
+    pub fn new_with_channel_store(
+        config: SessionConfig,
+        challenge_binding_secret: impl Into<String>,
+        channel_store: Arc<dyn ChannelStore>,
+    ) -> Self {
         let session_config = config.clone();
-        let server = Arc::new(SessionServer::new(config, MemoryChannelStore::new()));
+        let server = Arc::new(SessionServer::new(config, channel_store));
         let payment_channel_signer = Arc::new(Mutex::new(None));
         let payment_channel_payer_signer = Arc::new(Mutex::new(None));
         let committed_watermarks = Arc::new(Mutex::new(HashMap::new()));
@@ -617,19 +810,26 @@ impl SessionMpp {
     /// The runloop is intentionally centralized: request handlers only record
     /// activity, while this task owns the close/settle/distribute sequence.
     pub fn start_lifecycle_runloop(&self, close_delay: Duration) {
-        if close_delay.is_zero() {
-            self.lifecycle
-                .send(SessionLifecycleCommand::ConfigureCloseDelay { close_delay: None });
-            tracing::info!("session auto-close disabled");
-            return;
-        }
+        self.start_lifecycle_runloop_with_settlement(close_delay, Duration::ZERO);
+    }
 
-        self.lifecycle
-            .send(SessionLifecycleCommand::ConfigureCloseDelay {
-                close_delay: Some(close_delay),
-            });
+    /// Configure the lifecycle runloop to reconcile active channels' latest
+    /// cumulative voucher on-chain and to settle+seal channels after an idle
+    /// period. Either duration may be zero to disable that behavior.
+    pub fn start_lifecycle_runloop_with_settlement(
+        &self,
+        close_delay: Duration,
+        settlement_interval: Duration,
+    ) {
+        let close_delay = (!close_delay.is_zero()).then_some(close_delay);
+        let settlement_interval = (!settlement_interval.is_zero()).then_some(settlement_interval);
+        self.lifecycle.send(SessionLifecycleCommand::Configure {
+            close_delay,
+            settlement_interval,
+        });
         tracing::info!(
-            close_delay_ms = close_delay.as_millis(),
+            close_delay_ms = close_delay.map(|delay| delay.as_millis()),
+            settlement_interval_ms = settlement_interval.map(|interval| interval.as_millis()),
             "started session lifecycle runloop"
         );
     }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -72,6 +72,7 @@ pub enum SessionOutcome {
 #[derive(Clone)]
 struct SessionOperatorRuntime {
     server: Arc<SessionServer<Arc<dyn ChannelStore>>>,
+    channel_store: Arc<dyn ChannelStore>,
     rpc_url: Option<String>,
     payment_channel_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     payment_channel_payer_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
@@ -739,7 +740,7 @@ impl SessionMpp {
         channel_store: Arc<dyn ChannelStore>,
     ) -> Self {
         let session_config = config.clone();
-        let server = Arc::new(SessionServer::new(config, channel_store));
+        let server = Arc::new(SessionServer::new(config, Arc::clone(&channel_store)));
         let payment_channel_signer = Arc::new(Mutex::new(None));
         let payment_channel_payer_signer = Arc::new(Mutex::new(None));
         let committed_watermarks = Arc::new(Mutex::new(HashMap::new()));
@@ -749,6 +750,7 @@ impl SessionMpp {
         let pull_sessions = Arc::new(Mutex::new(HashSet::new()));
         let operator_runtime = SessionOperatorRuntime {
             server: Arc::clone(&server),
+            channel_store,
             rpc_url: session_config.rpc_url.clone(),
             payment_channel_signer: Arc::clone(&payment_channel_signer),
             payment_channel_payer_signer: Arc::clone(&payment_channel_payer_signer),
@@ -875,16 +877,28 @@ impl SessionMpp {
                 "session does not delegate voucher authority to the operator".to_string(),
             ));
         }
-        if amount == 0 {
-            return Ok(self.committed_watermark(channel_id).unwrap_or_default());
-        }
-
         // Serialize read/sign/verify so concurrent responses cannot construct
         // two vouchers from the same cumulative watermark.
         let _guard = self.operator_runtime.delegated_voucher_lock.lock().await;
-        let current = self.committed_watermark(channel_id).ok_or_else(|| {
-            Error::Mpp(format!("unknown delegated session channel: {channel_id}"))
-        })?;
+        // The durable store is authoritative. Reading it on every delegated
+        // authorization also lets a restarted or different gateway replica
+        // continue from a watermark advanced by another process.
+        let current = self
+            .operator_runtime
+            .channel_store
+            .get_channel(channel_id)
+            .await
+            .map_err(|error| {
+                Error::Mpp(format!(
+                    "failed to restore delegated session channel {channel_id}: {error}"
+                ))
+            })?
+            .ok_or_else(|| Error::Mpp(format!("unknown delegated session channel: {channel_id}")))?
+            .cumulative;
+        self.record_committed_watermark(channel_id.to_string(), current);
+        if amount == 0 {
+            return Ok(current);
+        }
         let cumulative = current
             .checked_add(amount)
             .ok_or_else(|| Error::Mpp("session cumulative amount overflow".to_string()))?;
@@ -2098,6 +2112,11 @@ mod tests {
             .unwrap(),
             75
         );
+        session
+            .committed_watermarks
+            .lock()
+            .expect("watermark lock")
+            .clear();
         assert_eq!(
             tokio::time::timeout(
                 Duration::from_secs(2),

--- a/rust/crates/core/src/server/session_metering.rs
+++ b/rust/crates/core/src/server/session_metering.rs
@@ -4,8 +4,8 @@
 //! voucher dependencies. The proxy can feed it provider-specific observations
 //! and use the returned base-unit deltas to decide when a new voucher is needed.
 
-use super::metering::{RequestProperties, evaluate_condition};
-use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering, PriceTier};
+use super::metering::{RequestProperties, resolve_variant, select_price_tier};
+use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering};
 use thiserror::Error;
 
 const MICRO_USD_PER_USD: u128 = 1_000_000;
@@ -564,12 +564,7 @@ fn select_dimensions<'a>(
     variant_hint: Option<&str>,
 ) -> Result<&'a [MeterDimension]> {
     if !metering.variants.is_empty() {
-        if let Some(hint) = variant_hint
-            && let Some(variant) = metering
-                .variants
-                .iter()
-                .find(|variant| hint.contains(&variant.value))
-        {
+        if let Some(variant) = resolve_variant(&metering.variants, variant_hint) {
             return Ok(&variant.dimensions);
         }
 
@@ -602,7 +597,11 @@ fn dimension_from_metering(
         });
     }
 
-    let tier = select_price_tier(dimension, properties)?;
+    let tier =
+        select_price_tier(dimension, properties).ok_or(SessionMeteringError::NoPriceTier {
+            direction: dimension.direction,
+            unit: dimension.unit,
+        })?;
     let price_micro_usd = price_usd_to_micro_usd(tier.price_usd)?;
     Ok(SessionMeterDimension::required(
         dimension.direction,
@@ -610,43 +609,6 @@ fn dimension_from_metering(
         dimension.scale,
         price_micro_usd,
     ))
-}
-
-fn select_price_tier<'a>(
-    dimension: &'a MeterDimension,
-    properties: &RequestProperties,
-) -> Result<&'a PriceTier> {
-    if dimension.tiers.is_empty() {
-        return Err(SessionMeteringError::NoPriceTier {
-            direction: dimension.direction,
-            unit: dimension.unit,
-        });
-    }
-
-    if dimension.tiers.iter().any(|tier| tier.up_to.is_some()) {
-        return Ok(dimension
-            .tiers
-            .iter()
-            .find(|tier| tier.price_usd > 0.0)
-            .unwrap_or(&dimension.tiers[0]));
-    }
-
-    for tier in &dimension.tiers {
-        if let Some(condition) = &tier.condition
-            && !evaluate_condition(condition, properties)
-        {
-            continue;
-        }
-        return Ok(tier);
-    }
-
-    dimension
-        .tiers
-        .last()
-        .ok_or(SessionMeteringError::NoPriceTier {
-            direction: dimension.direction,
-            unit: dimension.unit,
-        })
 }
 
 fn price_usd_to_micro_usd(price_usd: f64) -> Result<u64> {
@@ -684,6 +646,7 @@ fn ceil_div(numerator: u128, denominator: u128) -> Result<u128> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pay_types::metering::PriceTier;
 
     fn gemini_spec() -> SessionMeterSpec {
         SessionMeterSpec::new([
@@ -845,20 +808,33 @@ endpoints:
     }
 
     #[test]
-    fn adapter_falls_back_to_first_variant_for_unknown_hint() {
+    fn adapter_uses_explicit_default_variant_for_unknown_hint() {
         let metering = Metering {
             dimensions: vec![],
-            variants: vec![pay_types::metering::MeterVariant {
-                param: "model".to_string(),
-                value: "default".to_string(),
-                description: None,
-                dimensions: vec![one_tier_dimension(
-                    MeterDirection::Usage,
-                    BillingUnit::Requests,
-                    1,
-                    0.001,
-                )],
-            }],
+            variants: vec![
+                pay_types::metering::MeterVariant {
+                    param: "model".to_string(),
+                    value: "qwen-turbo".to_string(),
+                    description: None,
+                    dimensions: vec![one_tier_dimension(
+                        MeterDirection::Usage,
+                        BillingUnit::Requests,
+                        1,
+                        0.001,
+                    )],
+                },
+                pay_types::metering::MeterVariant {
+                    param: "model".to_string(),
+                    value: "default".to_string(),
+                    description: None,
+                    dimensions: vec![one_tier_dimension(
+                        MeterDirection::Usage,
+                        BillingUnit::Requests,
+                        1,
+                        0.100,
+                    )],
+                },
+            ],
             sku_tiers: vec![],
             splits: vec![],
             schemes: None,
@@ -872,7 +848,7 @@ endpoints:
         )
         .unwrap();
 
-        assert_eq!(spec.dimensions[0].price_micro_usd, 1_000);
+        assert_eq!(spec.dimensions[0].price_micro_usd, 100_000);
     }
 
     #[test]

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -13,7 +13,7 @@ use futures_util::{Stream, StreamExt};
 use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering};
 use serde_json::Value;
 
-use crate::server::metering::RequestProperties;
+use crate::server::metering::{RequestProperties, parse_tokens_per_quota_unit};
 use crate::server::session::SessionMpp;
 use crate::server::session_metering::{
     GateMode, Result as MeteringResult, SessionGateDecision, SessionMeterDimension,
@@ -366,6 +366,17 @@ impl StreamUsageAccumulator {
                     changed = true;
                 }
             }
+
+            if let Some(usage) = value.get("usage") {
+                if let Some(input) = usage_u64(usage, "prompt_tokens") {
+                    self.input_tokens = self.input_tokens.max(input);
+                    changed = true;
+                }
+                if let Some(output) = usage_u64(usage, "completion_tokens") {
+                    self.output_tokens = self.output_tokens.max(output);
+                    changed = true;
+                }
+            }
         }
 
         changed
@@ -503,19 +514,6 @@ fn select_meter_dimensions<'a>(
     }
 
     (!metering.dimensions.is_empty()).then_some(&metering.dimensions)
-}
-
-fn parse_tokens_per_quota_unit(notes: &str) -> Option<u64> {
-    let lower = notes.to_ascii_lowercase();
-    let marker = " tokens per quota unit";
-    let index = lower.find(marker)?;
-    let prefix = lower[..index].trim_end();
-    prefix.split_whitespace().find_map(|part| {
-        part.replace(',', "")
-            .parse::<u64>()
-            .ok()
-            .filter(|value| *value > 0)
-    })
 }
 
 fn gemini_text_char_count(value: &Value) -> u64 {
@@ -669,6 +667,48 @@ mod tests {
         assert_eq!(
             observation.get(MeterDirection::Output, BillingUnit::QuotaUnits),
             Some(224)
+        );
+    }
+
+    #[test]
+    fn sse_accumulator_observes_openai_compatible_usage() {
+        let spec = SessionMeterSpec::new([
+            SessionMeterDimension::required(MeterDirection::Input, BillingUnit::QuotaUnits, 1, 3),
+            SessionMeterDimension::required(MeterDirection::Output, BillingUnit::QuotaUnits, 1, 5),
+        ]);
+        let hints = SessionUsageHints::from_metering(
+            &metering(vec![
+                dimension(
+                    MeterDirection::Input,
+                    BillingUnit::QuotaUnits,
+                    Some("4 input tokens per quota unit"),
+                ),
+                dimension(
+                    MeterDirection::Output,
+                    BillingUnit::QuotaUnits,
+                    Some("2 output tokens per quota unit"),
+                ),
+            ]),
+            None,
+        );
+        let mut accumulator = StreamUsageAccumulator::new(spec, hints);
+
+        let changed = accumulator.observe_chunk(
+            br#"data: {"usage":{"prompt_tokens":8,"completion_tokens":5,"total_tokens":13}}
+
+"#,
+            true,
+        );
+        let observation = accumulator.observation();
+
+        assert!(changed);
+        assert_eq!(
+            observation.get(MeterDirection::Input, BillingUnit::QuotaUnits),
+            Some(2)
+        );
+        assert_eq!(
+            observation.get(MeterDirection::Output, BillingUnit::QuotaUnits),
+            Some(3)
         );
     }
 

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -216,10 +216,12 @@ where
             let chunk = next.map_err(box_error)?;
             meter.touch_channel();
             let decision = meter.observe_chunk(&chunk, is_sse).map_err(box_error)?;
-            yield chunk;
             if let Some(decision) = decision {
                 settle_decision(&mut meter, decision).await?;
             }
+            // Do not release the bytes that crossed the voucher threshold
+            // until the corresponding cumulative commit is durable.
+            yield chunk;
         }
 
         if let Some(decision) = meter.finish().map_err(box_error)? {
@@ -581,7 +583,12 @@ impl<'a> OptionalVariantHint<'a> for SessionMeteringContext<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::session::SessionHandle;
     use crate::server::metering::parse_tokens_per_quota_unit;
+    use crate::server::session::SessionOutcome;
+    use pay_kit::mpp::SessionMode;
+    use pay_kit::mpp::server::session::SessionConfig;
+    use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
     use pay_types::metering::{MeterDimension, PriceTier};
 
     fn dimension(
@@ -615,6 +622,17 @@ mod tests {
             min_usd: None,
             upto: None,
         }
+    }
+
+    fn stream_test_signer() -> Box<dyn SolanaSigner> {
+        use ed25519_dalek::SigningKey;
+
+        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let verifying_key = signing_key.verifying_key();
+        let mut keypair = [0_u8; 64];
+        keypair[..32].copy_from_slice(signing_key.as_bytes());
+        keypair[32..].copy_from_slice(verifying_key.as_bytes());
+        Box::new(MemorySigner::from_bytes(&keypair).unwrap())
     }
 
     #[test]
@@ -826,5 +844,62 @@ mod tests {
         )]);
 
         assert!(!has_stream_observable_dimension(&spec));
+    }
+
+    #[tokio::test]
+    async fn chargeable_stream_chunk_waits_for_matching_commit() {
+        let session = Arc::new(SessionMpp::new(
+            SessionConfig {
+                operator: solana_pubkey::Pubkey::new_unique().to_string(),
+                recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+                max_cap: 1_000,
+                currency: solana_pubkey::Pubkey::new_unique().to_string(),
+                network: "localnet".to_string(),
+                min_voucher_delta: 1,
+                modes: vec![SessionMode::Push],
+                ..SessionConfig::default()
+            },
+            "stream-test-secret",
+        ));
+        let challenge = session.challenge(1_000).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            stream_test_signer(),
+            challenge,
+        );
+        let open_header = handle.open_header(1_000, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state, .. } = session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected an active session");
+        };
+        let context = SessionStreamContext::new(session.clone(), state.channel_id, 0);
+        let spec = SessionMeterSpec::new([SessionMeterDimension::required(
+            MeterDirection::Output,
+            BillingUnit::Bytes,
+            1,
+            1,
+        )]);
+        let meter = SessionStreamMeter::new(spec, SessionUsageHints::default(), context).unwrap();
+        let upstream =
+            futures_util::stream::iter([Ok::<_, reqwest::Error>(Bytes::from_static(b"paid"))]);
+        let metered = meter_response_stream(upstream, meter, false);
+        futures_util::pin_mut!(metered);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), metered.next())
+                .await
+                .is_err(),
+            "chargeable output must remain withheld while its commit is pending"
+        );
+
+        let voucher = handle.voucher_header(4).await.unwrap();
+        session.process(&voucher).await.unwrap();
+        let released = tokio::time::timeout(Duration::from_secs(1), metered.next())
+            .await
+            .expect("stream should resume after the commit")
+            .expect("stream should yield the withheld chunk")
+            .expect("upstream chunk should remain successful");
+
+        assert_eq!(released, Bytes::from_static(b"paid"));
     }
 }

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -13,6 +13,7 @@ use futures_util::{Stream, StreamExt};
 use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering};
 use serde_json::Value;
 
+use crate::server::gate::SessionForward;
 use crate::server::metering::{RequestProperties, quota_tokens_per_unit, resolve_variant};
 use crate::server::session::SessionMpp;
 use crate::server::session_metering::{
@@ -147,6 +148,119 @@ pub struct SessionStreamMeter {
     current: UsageObservation,
 }
 
+/// Server-authorized meter for a delegated session response stream.
+///
+/// The meter owns the session's capacity lease for the lifetime of the body.
+/// Each cumulative usage increase is signed and persisted before the bytes
+/// that exposed it are released to the client.
+pub(crate) struct DelegatedSessionStreamMeter {
+    forward: SessionForward,
+    gate: SessionUsageGate,
+    accumulator: StreamUsageAccumulator,
+    current: UsageObservation,
+}
+
+impl DelegatedSessionStreamMeter {
+    pub(crate) fn from_forward(forward: SessionForward) -> Result<Self, BoxError> {
+        let plan = forward.settlement.as_deref().ok_or_else(|| {
+            box_error(std::io::Error::other(
+                "delegated stream forward is missing its settlement plan",
+            ))
+        })?;
+        let spec = spec_from_metering(
+            &plan.metering,
+            SessionMeteringContext::new()
+                .with_request_properties(&plan.request_properties)
+                .with_optional_variant_hint(plan.variant_hint.as_deref()),
+        )
+        .map_err(box_error)?;
+        let hints = SessionUsageHints::from_metering(
+            &plan.metering,
+            plan.variant_hint.as_deref(),
+            &plan.request_properties,
+        );
+        let settlement = StablecoinSettlement::new(forward.handle.decimals());
+        // A delegated signer is local to the gateway, so there is no reason to
+        // release chargeable output while waiting to batch a client voucher.
+        // Stablecoin precision still naturally batches sub-base-unit usage.
+        let gate = SessionUsageGate::new(spec.clone(), settlement, forward.committed_base_units, 1)
+            .map_err(box_error)?;
+        let current = zero_observation(&spec);
+        Ok(Self {
+            forward,
+            gate,
+            accumulator: StreamUsageAccumulator::new(spec, hints),
+            current,
+        })
+    }
+
+    pub(crate) fn supports(forward: &SessionForward) -> bool {
+        let Some(plan) = forward.settlement.as_deref() else {
+            return false;
+        };
+        spec_from_metering(
+            &plan.metering,
+            SessionMeteringContext::new()
+                .with_request_properties(&plan.request_properties)
+                .with_optional_variant_hint(plan.variant_hint.as_deref()),
+        )
+        .is_ok_and(|spec| has_stream_observable_dimension(&spec))
+    }
+
+    fn observe_chunk(
+        &mut self,
+        chunk: &[u8],
+        is_sse: bool,
+    ) -> MeteringResult<Option<SessionGateDecision>> {
+        if !self.accumulator.observe_chunk(chunk, is_sse) {
+            return Ok(None);
+        }
+        self.current = self.accumulator.observation();
+        self.gate
+            .observe(self.current.clone(), GateMode::Streaming)
+            .map(Some)
+    }
+
+    fn finish(&mut self) -> MeteringResult<Option<SessionGateDecision>> {
+        if !self.accumulator.has_observation() {
+            return Ok(None);
+        }
+        self.gate
+            .observe(self.current.clone(), GateMode::Final)
+            .map(Some)
+    }
+
+    async fn settle(&mut self, decision: SessionGateDecision) -> Result<(), BoxError> {
+        if !decision.requires_voucher() {
+            return Ok(());
+        }
+        let target = decision.target_cumulative_base_units();
+        let committed = self.gate.committed_base_units();
+        let amount = target.saturating_sub(committed);
+        if amount == 0 {
+            return Ok(());
+        }
+        let authorized = self
+            .forward
+            .committed_base_units
+            .saturating_add(self.forward.available_base_units);
+        if target > authorized {
+            return Err(box_error(std::io::Error::other(format!(
+                "delegated session {} requires cumulative {target}, above authorized {authorized}",
+                self.forward.channel_id
+            ))));
+        }
+        let accepted = self
+            .forward
+            .handle
+            .authorize_delegated_usage(&self.forward.channel_id, amount)
+            .await
+            .map_err(box_error)?;
+        self.gate.record_commit(accepted);
+        Ok(())
+    }
+}
+
 impl SessionStreamMeter {
     pub fn new(
         spec: SessionMeterSpec,
@@ -226,6 +340,37 @@ where
 
         if let Some(decision) = meter.finish().map_err(box_error)? {
             settle_decision(&mut meter, decision).await?;
+        }
+    }
+}
+
+/// Wrap a delegated-session response stream without buffering it.
+///
+/// Chargeable chunks remain behind the payment gate until the gateway's
+/// cumulative voucher has been persisted. Dropping the returned stream drops
+/// the owned meter and releases its exclusive capacity lease.
+pub(crate) fn meter_delegated_response_stream<S, E>(
+    stream: S,
+    mut meter: DelegatedSessionStreamMeter,
+    is_sse: bool,
+) -> impl Stream<Item = Result<Bytes, BoxError>> + Send + 'static
+where
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
+    E: StdError + Send + Sync + 'static,
+{
+    async_stream::try_stream! {
+        futures_util::pin_mut!(stream);
+        while let Some(next) = stream.next().await {
+            let chunk = next.map_err(box_error)?;
+            let decision = meter.observe_chunk(&chunk, is_sse).map_err(box_error)?;
+            if let Some(decision) = decision {
+                meter.settle(decision).await?;
+            }
+            yield chunk;
+        }
+
+        if let Some(decision) = meter.finish().map_err(box_error)? {
+            meter.settle(decision).await?;
         }
     }
 }
@@ -340,12 +485,12 @@ impl StreamUsageAccumulator {
                 continue;
             };
 
-            let text_chars = gemini_text_char_count(&value);
+            let text_chars = streamed_text_char_count(&value);
             if text_chars > 0 {
                 self.output_chars = self.output_chars.saturating_add(text_chars);
                 self.output_words = self
                     .output_words
-                    .saturating_add(gemini_text_word_count(&value));
+                    .saturating_add(streamed_text_word_count(&value));
                 changed = true;
             }
 
@@ -518,18 +663,18 @@ fn select_meter_dimensions<'a>(
     (!metering.dimensions.is_empty()).then_some(&metering.dimensions)
 }
 
-fn gemini_text_char_count(value: &Value) -> u64 {
-    gemini_texts(value)
+fn streamed_text_char_count(value: &Value) -> u64 {
+    streamed_texts(value)
         .map(|text| text.chars().count() as u64)
         .sum()
 }
 
-fn gemini_text_word_count(value: &Value) -> u64 {
-    gemini_texts(value).map(count_words).sum()
+fn streamed_text_word_count(value: &Value) -> u64 {
+    streamed_texts(value).map(count_words).sum()
 }
 
-fn gemini_texts(value: &Value) -> impl Iterator<Item = &str> {
-    value
+fn streamed_texts(value: &Value) -> impl Iterator<Item = &str> {
+    let gemini = value
         .get("candidates")
         .and_then(Value::as_array)
         .into_iter()
@@ -542,7 +687,29 @@ fn gemini_texts(value: &Value) -> impl Iterator<Item = &str> {
                 .into_iter()
                 .flatten()
         })
-        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .filter_map(|part| part.get("text").and_then(Value::as_str));
+    let openai = value
+        .get("choices")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|choice| {
+            choice
+                .get("delta")
+                .and_then(|delta| delta.get("content"))
+                .and_then(Value::as_str)
+                .or_else(|| choice.get("text").and_then(Value::as_str))
+        });
+    let top_level_delta = value
+        .get("delta")
+        .and_then(|delta| {
+            delta
+                .as_str()
+                .or_else(|| delta.get("text").and_then(Value::as_str))
+        })
+        .into_iter();
+
+    gemini.chain(openai).chain(top_level_delta)
 }
 
 fn usage_u64(value: &Value, key: &str) -> Option<u64> {
@@ -586,9 +753,9 @@ mod tests {
     use crate::client::session::SessionHandle;
     use crate::server::metering::parse_tokens_per_quota_unit;
     use crate::server::session::SessionOutcome;
-    use pay_kit::mpp::SessionMode;
     use pay_kit::mpp::server::session::SessionConfig;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
+    use pay_kit::mpp::{SessionMode, SessionSettlementAuthority};
     use pay_types::metering::{MeterDimension, PriceTier};
 
     fn dimension(
@@ -765,6 +932,32 @@ mod tests {
     }
 
     #[test]
+    fn sse_accumulator_uses_openai_delta_words_as_live_output_floor() {
+        let spec = SessionMeterSpec::new([SessionMeterDimension::required(
+            MeterDirection::Output,
+            BillingUnit::Tokens,
+            1,
+            1,
+        )]);
+        let mut accumulator = StreamUsageAccumulator::new(spec, SessionUsageHints::default());
+
+        let changed = accumulator.observe_chunk(
+            br#"data: {"choices":[{"delta":{"content":"one two three"}}]}
+
+"#,
+            true,
+        );
+
+        assert!(changed);
+        assert_eq!(
+            accumulator
+                .observation()
+                .get(MeterDirection::Output, BillingUnit::Tokens),
+            Some(3)
+        );
+    }
+
+    #[test]
     fn sse_accumulator_excludes_gemini_tool_prompt_tokens_from_output() {
         let spec = SessionMeterSpec::new([SessionMeterDimension::required(
             MeterDirection::Output,
@@ -901,5 +1094,119 @@ mod tests {
             .expect("upstream chunk should remain successful");
 
         assert_eq!(released, Bytes::from_static(b"paid"));
+    }
+
+    #[tokio::test]
+    async fn delegated_stream_releases_each_chunk_after_its_voucher() {
+        use ed25519_dalek::SigningKey;
+
+        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let verifying_key = signing_key.verifying_key();
+        let mut operator_keypair = [0_u8; 64];
+        operator_keypair[..32].copy_from_slice(signing_key.as_bytes());
+        operator_keypair[32..].copy_from_slice(verifying_key.as_bytes());
+        let operator: Arc<dyn SolanaSigner> =
+            Arc::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
+        let client_operator: Box<dyn SolanaSigner> =
+            Box::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
+        let mut config = SessionConfig {
+            operator: operator.pubkey().to_string(),
+            recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+            max_cap: 1_000,
+            currency: solana_pubkey::Pubkey::new_unique().to_string(),
+            network: "localnet".to_string(),
+            min_voucher_delta: 1,
+            modes: vec![SessionMode::Push],
+            ..SessionConfig::default()
+        };
+        config.settlement_authority = SessionSettlementAuthority::Delegated;
+        let session = Arc::new(
+            SessionMpp::new(config, "delegated-stream-test-secret")
+                .with_payment_channel_signer(operator),
+        );
+        let challenge = session.challenge(1_000).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            client_operator,
+            challenge,
+        );
+        let open_header = handle.open_header(1_000, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state, .. } = session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected an active delegated session");
+        };
+        let reservation = session
+            .reserve_delegated_capacity(&state.channel_id, 1_000)
+            .expect("session capacity should be available");
+        let forward = SessionForward::delegated(
+            session.clone(),
+            state.channel_id.clone(),
+            0,
+            crate::server::metering::UptoSettlementPlan {
+                metering: metering(vec![MeterDimension {
+                    direction: MeterDirection::Output,
+                    unit: BillingUnit::Tokens,
+                    scale: 1,
+                    period: None,
+                    tiers: vec![PriceTier {
+                        up_to: None,
+                        price_usd: 0.000001,
+                        condition: None,
+                        notes: None,
+                        splits: vec![],
+                    }],
+                    meter: None,
+                }]),
+                variant_hint: None,
+                request_properties: RequestProperties::default(),
+                ceiling_usd: 0.001,
+                inferred_usage: None,
+            },
+            1_000,
+            reservation,
+        );
+        let meter = DelegatedSessionStreamMeter::from_forward(forward).unwrap();
+        let release_second = Arc::new(tokio::sync::Notify::new());
+        let upstream_release = Arc::clone(&release_second);
+        let upstream = async_stream::stream! {
+            yield Ok::<_, std::io::Error>(Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two\"}}]}\n\n"
+            ));
+            upstream_release.notified().await;
+            yield Ok::<_, std::io::Error>(Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}]}\n\n"
+            ));
+        };
+        let metered = meter_delegated_response_stream(upstream, meter, true);
+        futures_util::pin_mut!(metered);
+
+        let first = tokio::time::timeout(Duration::from_secs(1), metered.next())
+            .await
+            .expect("first chunk must not wait for upstream EOF")
+            .expect("stream should yield its first chunk")
+            .expect("first chunk should remain successful");
+        assert_eq!(
+            first,
+            Bytes::from_static(b"data: {\"choices\":[{\"delta\":{\"content\":\"one two\"}}]}\n\n")
+        );
+        assert_eq!(session.committed_watermark(&state.channel_id), Some(2));
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), metered.next())
+                .await
+                .is_err(),
+            "second chunk should still be waiting on the upstream"
+        );
+        release_second.notify_one();
+        let second = tokio::time::timeout(Duration::from_secs(1), metered.next())
+            .await
+            .expect("second chunk should resume")
+            .expect("stream should yield its second chunk")
+            .expect("second chunk should remain successful");
+        assert_eq!(
+            second,
+            Bytes::from_static(b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}]}\n\n")
+        );
+        assert_eq!(session.committed_watermark(&state.channel_id), Some(3));
     }
 }

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -13,7 +13,7 @@ use futures_util::{Stream, StreamExt};
 use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering};
 use serde_json::Value;
 
-use crate::server::metering::{RequestProperties, parse_tokens_per_quota_unit};
+use crate::server::metering::{RequestProperties, quota_tokens_per_unit, resolve_variant};
 use crate::server::session::SessionMpp;
 use crate::server::session_metering::{
     GateMode, Result as MeteringResult, SessionGateDecision, SessionMeterDimension,
@@ -87,7 +87,11 @@ struct QuotaUnitHint {
 }
 
 impl SessionUsageHints {
-    pub fn from_metering(metering: &Metering, variant_hint: Option<&str>) -> Self {
+    pub fn from_metering(
+        metering: &Metering,
+        variant_hint: Option<&str>,
+        request_properties: &RequestProperties,
+    ) -> Self {
         let dimensions = select_meter_dimensions(metering, variant_hint).unwrap_or(&[]);
         let quota_units = dimensions
             .iter()
@@ -95,11 +99,7 @@ impl SessionUsageHints {
                 if dimension.unit != BillingUnit::QuotaUnits {
                     return None;
                 }
-                let tokens_per_unit = dimension
-                    .tiers
-                    .iter()
-                    .filter_map(|tier| tier.notes.as_deref())
-                    .find_map(parse_tokens_per_quota_unit)?;
+                let tokens_per_unit = quota_tokens_per_unit(dimension, request_properties)?;
                 Some(QuotaUnitHint {
                     direction: dimension.direction,
                     tokens_per_unit,
@@ -136,7 +136,7 @@ pub fn meter_from_config(
         return Ok(None);
     }
 
-    let hints = SessionUsageHints::from_metering(metering, variant_hint);
+    let hints = SessionUsageHints::from_metering(metering, variant_hint, request_properties);
     SessionStreamMeter::new(spec, hints, context).map(Some)
 }
 
@@ -355,8 +355,13 @@ impl StreamUsageAccumulator {
 
                 let candidate_tokens = usage_u64(usage, "candidatesTokenCount").unwrap_or(0);
                 let thought_tokens = usage_u64(usage, "thoughtsTokenCount").unwrap_or(0);
+                let tool_prompt_tokens = usage_u64(usage, "toolUsePromptTokenCount").unwrap_or(0);
                 let metered_output = usage_u64(usage, "totalTokenCount")
-                    .and_then(|total| total.checked_sub(self.input_tokens))
+                    .map(|total| {
+                        total
+                            .saturating_sub(self.input_tokens)
+                            .saturating_sub(tool_prompt_tokens)
+                    })
                     .unwrap_or(0);
                 let output = candidate_tokens
                     .saturating_add(thought_tokens)
@@ -496,12 +501,7 @@ fn select_meter_dimensions<'a>(
     variant_hint: Option<&str>,
 ) -> Option<&'a [MeterDimension]> {
     if !metering.variants.is_empty() {
-        if let Some(hint) = variant_hint
-            && let Some(variant) = metering
-                .variants
-                .iter()
-                .find(|variant| hint.contains(&variant.value))
-        {
+        if let Some(variant) = resolve_variant(&metering.variants, variant_hint) {
             return Some(&variant.dimensions);
         }
         if !metering.dimensions.is_empty() {
@@ -581,6 +581,7 @@ impl<'a> OptionalVariantHint<'a> for SessionMeteringContext<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::metering::parse_tokens_per_quota_unit;
     use pay_types::metering::{MeterDimension, PriceTier};
 
     fn dimension(
@@ -629,6 +630,37 @@ mod tests {
     }
 
     #[test]
+    fn quota_unit_hints_follow_the_selected_conditional_tier() {
+        let mut quota = dimension(
+            MeterDirection::Input,
+            BillingUnit::QuotaUnits,
+            Some("4 input tokens per quota unit"),
+        );
+        quota.tiers[0].condition = Some(pay_types::metering::MeterCondition::ContextLength {
+            op: pay_types::metering::CompareOp::Lte,
+            value: 200_000,
+        });
+        quota.tiers.push(PriceTier {
+            up_to: None,
+            price_usd: 0.000001,
+            condition: Some(pay_types::metering::MeterCondition::ContextLength {
+                op: pay_types::metering::CompareOp::Gt,
+                value: 200_000,
+            }),
+            notes: Some("2 input tokens per quota unit".to_string()),
+            splits: vec![],
+        });
+        let properties = RequestProperties {
+            context_length: Some(250_000),
+            ..Default::default()
+        };
+
+        let hints = SessionUsageHints::from_metering(&metering(vec![quota]), None, &properties);
+
+        assert_eq!(hints.tokens_per_quota_unit(MeterDirection::Input), Some(2));
+    }
+
+    #[test]
     fn sse_accumulator_observes_gemini_usage_metadata() {
         let spec = SessionMeterSpec::new([
             SessionMeterDimension::required(MeterDirection::Input, BillingUnit::QuotaUnits, 1, 3),
@@ -648,6 +680,7 @@ mod tests {
                 ),
             ]),
             None,
+            &RequestProperties::default(),
         );
         let mut accumulator = StreamUsageAccumulator::new(spec, hints);
 
@@ -690,6 +723,7 @@ mod tests {
                 ),
             ]),
             None,
+            &RequestProperties::default(),
         );
         let mut accumulator = StreamUsageAccumulator::new(spec, hints);
 
@@ -713,6 +747,41 @@ mod tests {
     }
 
     #[test]
+    fn sse_accumulator_excludes_gemini_tool_prompt_tokens_from_output() {
+        let spec = SessionMeterSpec::new([SessionMeterDimension::required(
+            MeterDirection::Output,
+            BillingUnit::QuotaUnits,
+            1,
+            5,
+        )]);
+        let hints = SessionUsageHints::from_metering(
+            &metering(vec![dimension(
+                MeterDirection::Output,
+                BillingUnit::QuotaUnits,
+                Some("1 output tokens per quota unit"),
+            )]),
+            None,
+            &RequestProperties::default(),
+        );
+        let mut accumulator = StreamUsageAccumulator::new(spec, hints);
+
+        let changed = accumulator.observe_chunk(
+            br#"data: {"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":3,"thoughtsTokenCount":2,"toolUsePromptTokenCount":20,"totalTokenCount":35}}
+
+"#,
+            true,
+        );
+
+        assert!(changed);
+        assert_eq!(
+            accumulator
+                .observation()
+                .get(MeterDirection::Output, BillingUnit::QuotaUnits),
+            Some(5)
+        );
+    }
+
+    #[test]
     fn sse_accumulator_uses_text_words_as_live_output_floor() {
         let spec = SessionMeterSpec::new([SessionMeterDimension::required(
             MeterDirection::Output,
@@ -727,6 +796,7 @@ mod tests {
                 Some("2 output tokens per quota unit"),
             )]),
             None,
+            &RequestProperties::default(),
         );
         let mut accumulator = StreamUsageAccumulator::new(spec, hints);
 

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -158,6 +158,7 @@ pub(crate) struct DelegatedSessionStreamMeter {
     gate: SessionUsageGate,
     accumulator: StreamUsageAccumulator,
     current: UsageObservation,
+    priced_context_length: Option<u64>,
 }
 
 impl DelegatedSessionStreamMeter {
@@ -186,11 +187,13 @@ impl DelegatedSessionStreamMeter {
         let gate = SessionUsageGate::new(spec.clone(), settlement, forward.committed_base_units, 1)
             .map_err(box_error)?;
         let current = zero_observation(&spec);
+        let priced_context_length = plan.request_properties.context_length;
         Ok(Self {
             forward,
             gate,
             accumulator: StreamUsageAccumulator::new(spec, hints),
             current,
+            priced_context_length,
         })
     }
 
@@ -211,14 +214,20 @@ impl DelegatedSessionStreamMeter {
         &mut self,
         chunk: &[u8],
         is_sse: bool,
-    ) -> MeteringResult<Option<SessionGateDecision>> {
+    ) -> Result<Option<SessionGateDecision>, BoxError> {
         if !self.accumulator.observe_chunk(chunk, is_sse) {
             return Ok(None);
+        }
+        if let Some(context_length) = self.accumulator.observed_input_tokens()
+            && self.priced_context_length != Some(context_length)
+        {
+            self.reprice_for_context_length(context_length)?;
         }
         self.current = self.accumulator.observation();
         self.gate
             .observe(self.current.clone(), GateMode::Streaming)
             .map(Some)
+            .map_err(box_error)
     }
 
     fn finish(&mut self) -> MeteringResult<Option<SessionGateDecision>> {
@@ -257,6 +266,41 @@ impl DelegatedSessionStreamMeter {
             .await
             .map_err(box_error)?;
         self.gate.record_commit(accepted);
+        Ok(())
+    }
+
+    fn reprice_for_context_length(&mut self, context_length: u64) -> Result<(), BoxError> {
+        let plan = self.forward.settlement.as_deref().ok_or_else(|| {
+            box_error(std::io::Error::other(
+                "delegated stream meter lost its settlement plan",
+            ))
+        })?;
+        let mut properties = plan.request_properties;
+        properties.context_length = Some(context_length);
+        let spec = spec_from_metering(
+            &plan.metering,
+            SessionMeteringContext::new()
+                .with_request_properties(&properties)
+                .with_optional_variant_hint(plan.variant_hint.as_deref()),
+        )
+        .map_err(box_error)?;
+        let hints = SessionUsageHints::from_metering(
+            &plan.metering,
+            plan.variant_hint.as_deref(),
+            &properties,
+        );
+        let committed = self.gate.committed_base_units();
+        let mut gate = SessionUsageGate::new(
+            spec.clone(),
+            StablecoinSettlement::new(self.forward.handle.decimals()),
+            self.forward.committed_base_units,
+            1,
+        )
+        .map_err(box_error)?;
+        gate.record_commit(committed);
+        self.accumulator.reconfigure(spec, hints);
+        self.gate = gate;
+        self.priced_context_length = Some(context_length);
         Ok(())
     }
 }
@@ -362,7 +406,7 @@ where
         futures_util::pin_mut!(stream);
         while let Some(next) = stream.next().await {
             let chunk = next.map_err(box_error)?;
-            let decision = meter.observe_chunk(&chunk, is_sse).map_err(box_error)?;
+            let decision = meter.observe_chunk(&chunk, is_sse)?;
             if let Some(decision) = decision {
                 meter.settle(decision).await?;
             }
@@ -570,6 +614,15 @@ impl StreamUsageAccumulator {
 
     fn has_observation(&self) -> bool {
         self.observed
+    }
+
+    fn observed_input_tokens(&self) -> Option<u64> {
+        (self.input_tokens > 0).then_some(self.input_tokens)
+    }
+
+    fn reconfigure(&mut self, spec: SessionMeterSpec, hints: SessionUsageHints) {
+        self.spec = spec;
+        self.hints = hints;
     }
 }
 
@@ -1148,13 +1201,28 @@ mod tests {
                     unit: BillingUnit::Tokens,
                     scale: 1,
                     period: None,
-                    tiers: vec![PriceTier {
-                        up_to: None,
-                        price_usd: 0.000001,
-                        condition: None,
-                        notes: None,
-                        splits: vec![],
-                    }],
+                    tiers: vec![
+                        PriceTier {
+                            up_to: None,
+                            price_usd: 0.000001,
+                            condition: Some(pay_types::metering::MeterCondition::ContextLength {
+                                op: pay_types::metering::CompareOp::Lte,
+                                value: 2,
+                            }),
+                            notes: None,
+                            splits: vec![],
+                        },
+                        PriceTier {
+                            up_to: None,
+                            price_usd: 0.000005,
+                            condition: Some(pay_types::metering::MeterCondition::ContextLength {
+                                op: pay_types::metering::CompareOp::Gt,
+                                value: 2,
+                            }),
+                            notes: None,
+                            splits: vec![],
+                        },
+                    ],
                     meter: None,
                 }]),
                 variant_hint: None,
@@ -1174,7 +1242,7 @@ mod tests {
             ));
             upstream_release.notified().await;
             yield Ok::<_, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}]}\n\n"
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
             ));
         };
         let metered = meter_delegated_response_stream(upstream, meter, true);
@@ -1205,8 +1273,14 @@ mod tests {
             .expect("second chunk should remain successful");
         assert_eq!(
             second,
-            Bytes::from_static(b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}]}\n\n")
+            Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
+            )
         );
-        assert_eq!(session.committed_watermark(&state.channel_id), Some(3));
+        assert_eq!(
+            session.committed_watermark(&state.channel_id),
+            Some(15),
+            "actual prompt usage must reprice all output at the high-context tier"
+        );
     }
 }

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -14,7 +14,9 @@ use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering}
 use serde_json::Value;
 
 use crate::server::gate::SessionForward;
-use crate::server::metering::{RequestProperties, quota_tokens_per_unit, resolve_variant};
+use crate::server::metering::{
+    RequestProperties, provider_token_quantity, quota_tokens_per_unit, resolve_variant,
+};
 use crate::server::session::SessionMpp;
 use crate::server::session_metering::{
     GateMode, Result as MeteringResult, SessionGateDecision, SessionMeterDimension,
@@ -159,6 +161,8 @@ pub(crate) struct DelegatedSessionStreamMeter {
     accumulator: StreamUsageAccumulator,
     current: UsageObservation,
     priced_context_length: Option<u64>,
+    clamp_reprice_to_authorized: bool,
+    authorization_exhausted: bool,
 }
 
 impl DelegatedSessionStreamMeter {
@@ -194,6 +198,8 @@ impl DelegatedSessionStreamMeter {
             accumulator: StreamUsageAccumulator::new(spec, hints),
             current,
             priced_context_length,
+            clamp_reprice_to_authorized: false,
+            authorization_exhausted: false,
         })
     }
 
@@ -215,13 +221,21 @@ impl DelegatedSessionStreamMeter {
         chunk: &[u8],
         is_sse: bool,
     ) -> Result<Option<SessionGateDecision>, BoxError> {
+        let output_chars_before = self.accumulator.output_chars;
         if !self.accumulator.observe_chunk(chunk, is_sse) {
             return Ok(None);
+        }
+        if self.authorization_exhausted {
+            return Err(box_error(std::io::Error::other(format!(
+                "delegated session {} exhausted its authorization",
+                self.forward.channel_id
+            ))));
         }
         if let Some(context_length) = self.accumulator.observed_input_tokens()
             && self.priced_context_length != Some(context_length)
         {
-            self.reprice_for_context_length(context_length)?;
+            let usage_only_chunk = self.accumulator.output_chars == output_chars_before;
+            self.reprice_for_context_length(context_length, usage_only_chunk)?;
         }
         self.current = self.accumulator.observation();
         self.gate
@@ -231,7 +245,7 @@ impl DelegatedSessionStreamMeter {
     }
 
     fn finish(&mut self) -> MeteringResult<Option<SessionGateDecision>> {
-        if !self.accumulator.has_observation() {
+        if !self.accumulator.has_observation() || self.authorization_exhausted {
             return Ok(None);
         }
         self.gate
@@ -240,24 +254,32 @@ impl DelegatedSessionStreamMeter {
     }
 
     async fn settle(&mut self, decision: SessionGateDecision) -> Result<(), BoxError> {
+        let clamp_reprice_to_authorized = std::mem::take(&mut self.clamp_reprice_to_authorized);
         if !decision.requires_voucher() {
             return Ok(());
         }
-        let target = decision.target_cumulative_base_units();
+        let requested_target = decision.target_cumulative_base_units();
         let committed = self.gate.committed_base_units();
-        let amount = target.saturating_sub(committed);
-        if amount == 0 {
-            return Ok(());
-        }
         let authorized = self
             .forward
             .committed_base_units
             .saturating_add(self.forward.available_base_units);
+        let target = if clamp_reprice_to_authorized {
+            requested_target.min(authorized)
+        } else {
+            requested_target
+        };
+        let exhausted_by_reprice = clamp_reprice_to_authorized && requested_target > authorized;
         if target > authorized {
             return Err(box_error(std::io::Error::other(format!(
                 "delegated session {} requires cumulative {target}, above authorized {authorized}",
                 self.forward.channel_id
             ))));
+        }
+        let amount = target.saturating_sub(committed);
+        if amount == 0 {
+            self.authorization_exhausted |= exhausted_by_reprice;
+            return Ok(());
         }
         let accepted = self
             .forward
@@ -266,10 +288,15 @@ impl DelegatedSessionStreamMeter {
             .await
             .map_err(box_error)?;
         self.gate.record_commit(accepted);
+        self.authorization_exhausted |= exhausted_by_reprice;
         Ok(())
     }
 
-    fn reprice_for_context_length(&mut self, context_length: u64) -> Result<(), BoxError> {
+    fn reprice_for_context_length(
+        &mut self,
+        context_length: u64,
+        usage_only_chunk: bool,
+    ) -> Result<(), BoxError> {
         let plan = self.forward.settlement.as_deref().ok_or_else(|| {
             box_error(std::io::Error::other(
                 "delegated stream meter lost its settlement plan",
@@ -301,6 +328,7 @@ impl DelegatedSessionStreamMeter {
         self.accumulator.reconfigure(spec, hints);
         self.gate = gate;
         self.priced_context_length = Some(context_length);
+        self.clamp_reprice_to_authorized = usage_only_chunk;
         Ok(())
     }
 }
@@ -538,40 +566,14 @@ impl StreamUsageAccumulator {
                 changed = true;
             }
 
-            if let Some(usage) = value.get("usageMetadata") {
-                if let Some(input) = usage_u64(usage, "promptTokenCount") {
-                    self.input_tokens = self.input_tokens.max(input);
-                    changed = true;
-                }
-
-                let candidate_tokens = usage_u64(usage, "candidatesTokenCount").unwrap_or(0);
-                let thought_tokens = usage_u64(usage, "thoughtsTokenCount").unwrap_or(0);
-                let tool_prompt_tokens = usage_u64(usage, "toolUsePromptTokenCount").unwrap_or(0);
-                let metered_output = usage_u64(usage, "totalTokenCount")
-                    .map(|total| {
-                        total
-                            .saturating_sub(self.input_tokens)
-                            .saturating_sub(tool_prompt_tokens)
-                    })
-                    .unwrap_or(0);
-                let output = candidate_tokens
-                    .saturating_add(thought_tokens)
-                    .max(metered_output);
-                if output > 0 {
-                    self.output_tokens = self.output_tokens.max(output);
-                    changed = true;
-                }
+            if let Some(input) = provider_token_quantity(&value, MeterDirection::Input) {
+                self.input_tokens = self.input_tokens.max(input);
+                changed = true;
             }
 
-            if let Some(usage) = value.get("usage") {
-                if let Some(input) = usage_u64(usage, "prompt_tokens") {
-                    self.input_tokens = self.input_tokens.max(input);
-                    changed = true;
-                }
-                if let Some(output) = usage_u64(usage, "completion_tokens") {
-                    self.output_tokens = self.output_tokens.max(output);
-                    changed = true;
-                }
+            if let Some(output) = provider_token_quantity(&value, MeterDirection::Output) {
+                self.output_tokens = self.output_tokens.max(output);
+                changed = true;
             }
         }
 
@@ -763,10 +765,6 @@ fn streamed_texts(value: &Value) -> impl Iterator<Item = &str> {
         .into_iter();
 
     gemini.chain(openai).chain(top_level_delta)
-}
-
-fn usage_u64(value: &Value, key: &str) -> Option<u64> {
-    value.get(key).and_then(Value::as_u64)
 }
 
 fn count_words(text: &str) -> u64 {
@@ -982,6 +980,39 @@ mod tests {
             observation.get(MeterDirection::Output, BillingUnit::QuotaUnits),
             Some(3)
         );
+    }
+
+    #[test]
+    fn sse_accumulator_observes_responses_and_anthropic_usage() {
+        let spec = SessionMeterSpec::new([
+            SessionMeterDimension::required(MeterDirection::Input, BillingUnit::Tokens, 1, 1),
+            SessionMeterDimension::required(MeterDirection::Output, BillingUnit::Tokens, 1, 1),
+        ]);
+
+        for chunk in [
+            br#"data: {"type":"response.completed","response":{"usage":{"input_tokens":8,"output_tokens":5}}}
+
+"#
+            .as_slice(),
+            br#"data: {"type":"message_start","message":{"usage":{"input_tokens":8,"output_tokens":0}}}
+
+data: {"type":"message_delta","usage":{"output_tokens":5}}
+
+"#
+            .as_slice(),
+        ] {
+            let mut accumulator =
+                StreamUsageAccumulator::new(spec.clone(), SessionUsageHints::default());
+
+            assert!(accumulator.observe_chunk(chunk, true));
+            assert_eq!(accumulator.observed_input_tokens(), Some(8));
+            assert_eq!(
+                accumulator
+                    .observation()
+                    .get(MeterDirection::Output, BillingUnit::Tokens),
+                Some(5)
+            );
+        }
     }
 
     #[test]
@@ -1230,7 +1261,7 @@ mod tests {
                 ceiling_usd: 0.001,
                 inferred_usage: None,
             },
-            1_000,
+            10,
             reservation,
         );
         let meter = DelegatedSessionStreamMeter::from_forward(forward).unwrap();
@@ -1238,11 +1269,11 @@ mod tests {
         let upstream_release = Arc::clone(&release_second);
         let upstream = async_stream::stream! {
             yield Ok::<_, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two\"}}]}\n\n"
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n"
             ));
             upstream_release.notified().await;
             yield Ok::<_, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
+                b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
             ));
         };
         let metered = meter_delegated_response_stream(upstream, meter, true);
@@ -1255,9 +1286,11 @@ mod tests {
             .expect("first chunk should remain successful");
         assert_eq!(
             first,
-            Bytes::from_static(b"data: {\"choices\":[{\"delta\":{\"content\":\"one two\"}}]}\n\n")
+            Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n"
+            )
         );
-        assert_eq!(session.committed_watermark(&state.channel_id), Some(2));
+        assert_eq!(session.committed_watermark(&state.channel_id), Some(3));
 
         assert!(
             tokio::time::timeout(Duration::from_millis(50), metered.next())
@@ -1274,13 +1307,17 @@ mod tests {
         assert_eq!(
             second,
             Bytes::from_static(
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"three\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
+                b"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":3}}\n\n"
             )
         );
         assert_eq!(
             session.committed_watermark(&state.channel_id),
-            Some(15),
-            "actual prompt usage must reprice all output at the high-context tier"
+            Some(10),
+            "retroactive repricing must collect the remaining authorization without failing the stream"
+        );
+        assert!(
+            metered.next().await.is_none(),
+            "a clamped usage-only reprice must complete cleanly"
         );
     }
 }

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -34,6 +34,7 @@ pub struct PaymentAmount {
 /// other than `"periodic"`) always warn so they surface for the
 /// in-flight request that just lost telemetry.
 const PERIODIC_WARN_AFTER_CONSECUTIVE_FAILURES: u64 = 5;
+const MAX_METRIC_ERROR_LABEL_BYTES: usize = 512;
 
 /// Timeout for a single `getBalance` round-trip. Without this, a stalled
 /// RPC connection can hang the periodic probe forever and accumulate
@@ -314,6 +315,7 @@ pub fn record_settlement_error(
     error: &str,
     retryable: bool,
 ) {
+    let error = bounded_metric_label(error, MAX_METRIC_ERROR_LABEL_BYTES);
     tracing::warn!(
         monotonic_counter.pay_payment_settlement_errors_total = 1_u64,
         protocol,
@@ -324,6 +326,17 @@ pub fn record_settlement_error(
         metric = METRIC_SETTLEMENT_ERRORS,
         "payment settlement failed",
     );
+}
+
+fn bounded_metric_label(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
 }
 
 pub fn record_upstream_error(subdomain: &str, path: &str, upstream: &str, error: &str) {
@@ -377,5 +390,15 @@ mod tests {
     fn paid_delivery_error_is_5xx() {
         assert!(is_paid_delivery_error(StatusCode::BAD_GATEWAY));
         assert!(!is_paid_delivery_error(StatusCode::BAD_REQUEST));
+    }
+
+    #[test]
+    fn metric_error_labels_are_bounded_on_utf8_boundaries() {
+        let error = format!("{}failure", "é".repeat(300));
+        let bounded = bounded_metric_label(&error, MAX_METRIC_ERROR_LABEL_BYTES);
+
+        assert!(bounded.len() <= MAX_METRIC_ERROR_LABEL_BYTES);
+        assert!(bounded.is_char_boundary(bounded.len()));
+        assert_eq!(bounded.len(), 512);
     }
 }

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -866,6 +866,15 @@ pub struct SessionSpec {
     /// Defaults to `15000` when omitted. Set to `0` to disable automatic close.
     #[serde(default = "default_session_close_delay_ms")]
     pub close_delay_ms: u64,
+    /// Interval between operator pushes of the latest accepted cumulative
+    /// watermark to the payment-channel program.
+    ///
+    /// This keeps an active channel open while bounding the amount represented
+    /// only by an off-chain voucher. Defaults to `5000` when omitted. Set to
+    /// `0` to disable intermediate settlement (the idle close still settles
+    /// the latest voucher).
+    #[serde(default = "default_session_settlement_interval_ms")]
+    pub settlement_interval_ms: u64,
     /// Channel settlement splits. Session splits are percentage-only and are
     /// converted to basis points for the payment channel distribution.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -887,6 +896,10 @@ fn default_session_batch_open_interval_ms() -> u64 {
 
 fn default_session_close_delay_ms() -> u64 {
     15_000
+}
+
+fn default_session_settlement_interval_ms() -> u64 {
+    5_000
 }
 
 /// Named recipient alias declared at the API spec level.
@@ -2517,11 +2530,12 @@ mod tests {
     }
 
     #[test]
-    fn session_spec_defaults_auto_close_delay() {
+    fn session_spec_defaults_lifecycle_intervals() {
         let session: SessionSpec = serde_json::from_str(r#"{"cap_usdc":10.0}"#).unwrap();
 
         assert_eq!(session.batch_open_interval_ms, 400);
         assert_eq!(session.close_delay_ms, 15_000);
+        assert_eq!(session.settlement_interval_ms, 5_000);
         assert_eq!(
             session.settlement_authority,
             SessionSettlementAuthority::ClientVoucher
@@ -3725,6 +3739,7 @@ value_from_env: PAY_SIGNER_KEYPAIR
             pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
             batch_open_interval_ms: 400,
             close_delay_ms: 15_000,
+            settlement_interval_ms: 5_000,
             splits: vec![],
         });
 
@@ -3890,6 +3905,7 @@ value_from_env: PAY_SIGNER_KEYPAIR
             pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
             batch_open_interval_ms: 400,
             close_delay_ms: 15_000,
+            settlement_interval_ms: 5_000,
             splits,
         });
         spec

--- a/typescript/packages/solana-pay/core/package.json
+++ b/typescript/packages/solana-pay/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "1.0.23",
+    "version": "1.0.24",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-foundation/pay",
     "license": "MIT",

--- a/web-ui/proxy/alibaba-qwen.yml
+++ b/web-ui/proxy/alibaba-qwen.yml
@@ -33,8 +33,7 @@ session:
   settlement_authority: delegated
   close_delay_ms: 15000
   settlement_interval_ms: 5000
-  modes: [pull]
-  pull_voucher_strategy: client_voucher
+  modes: [push]
   splits:
     - recipient: gateway
       percent: 0.1

--- a/web-ui/proxy/alibaba-qwen.yml
+++ b/web-ui/proxy/alibaba-qwen.yml
@@ -30,6 +30,7 @@ recipients:
 session:
   cap_usdc: 10.0
   min_voucher_delta: 1
+  settlement_authority: delegated
   close_delay_ms: 15000
   settlement_interval_ms: 5000
   modes: [pull]

--- a/web-ui/proxy/alibaba-qwen.yml
+++ b/web-ui/proxy/alibaba-qwen.yml
@@ -1,0 +1,201 @@
+name: alibaba-qwen
+subdomain: qwen
+title: "Alibaba Model Studio"
+description: >
+  Run current Qwen general-purpose and coding models through Alibaba Cloud
+  Model Studio's OpenAI- and Anthropic-compatible APIs.
+category: ai_ml
+version: v1
+routing:
+  type: proxy
+  url: https://dashscope-us.aliyuncs.com/compatible-mode
+  auth: &dashscope_auth
+    method: header
+    key: Authorization
+    prefix: "Bearer "
+    value_from_env: DASHSCOPE_API_KEY
+
+operator:
+  currencies:
+    usd: ["USDC", "USDT", "CASH"]
+  network: "localnet"
+  fee_payer: true
+
+recipients:
+  gateway:
+    account: "DxyXRSjEgHzRwXiaDpkPRJwZizpFk4g15eJVDh1ea2M8"
+    label: "Gateway"
+
+# Streaming agent sessions are metered from the usage reported by Model Studio.
+session:
+  cap_usdc: 10.0
+  min_voucher_delta: 1
+  close_delay_ms: 15000
+  settlement_interval_ms: 5000
+  modes: [pull]
+  pull_voucher_strategy: client_voucher
+  splits:
+    - recipient: gateway
+      percent: 0.1
+      memo: "Agentic gateway fee"
+
+# Global list prices for the US (Virginia) Model Studio endpoint. Keep the
+# model names here as the gateway's discoverable model catalog as well as its
+# metering variants.
+x-qwen-model-pricing: &qwen_model_pricing
+  - param: model
+    value: qwen3.7-plus
+    description: "Flagship multimodal agent model with a 1M context window."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 0.276
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 0.826
+            condition: { field: context_length, op: ">", value: 256000 }
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 1.101
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 3.301
+            condition: { field: context_length, op: ">", value: 256000 }
+  - param: model
+    value: qwen3.7-max
+    description: "Highest-capability Qwen model for long-horizon agent tasks."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers: [{ price_usd: 2.5 }]
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers: [{ price_usd: 7.5 }]
+  - param: model
+    value: qwen3.6-flash
+    description: "Low-latency multimodal Qwen model."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 0.165
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 0.66
+            condition: { field: context_length, op: ">", value: 256000 }
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 0.99
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 3.961
+            condition: { field: context_length, op: ">", value: 256000 }
+  - param: model
+    value: qwen3-coder-next
+    description: "Coding-specialized Qwen model optimized for agent workflows."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 0.3
+            condition: { field: context_length, op: "<=", value: 32000 }
+          - price_usd: 0.5
+            condition: { field: context_length, op: "<=", value: 128000 }
+          - price_usd: 0.8
+            condition: { field: context_length, op: "<=", value: 256000 }
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 1.5
+            condition: { field: context_length, op: "<=", value: 32000 }
+          - price_usd: 2.5
+            condition: { field: context_length, op: "<=", value: 128000 }
+          - price_usd: 4.0
+            condition: { field: context_length, op: "<=", value: 256000 }
+  - param: model
+    value: qwen3-coder-plus
+    description: "Qwen's large-context coding model with implicit caching."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 0.574
+            condition: { field: context_length, op: "<=", value: 32000 }
+          - price_usd: 0.861
+            condition: { field: context_length, op: "<=", value: 128000 }
+          - price_usd: 1.434
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 2.868
+            condition: { field: context_length, op: ">", value: 256000 }
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers:
+          - price_usd: 2.294
+            condition: { field: context_length, op: "<=", value: 32000 }
+          - price_usd: 3.441
+            condition: { field: context_length, op: "<=", value: 128000 }
+          - price_usd: 5.735
+            condition: { field: context_length, op: "<=", value: 256000 }
+          - price_usd: 28.671
+            condition: { field: context_length, op: ">", value: 256000 }
+  - param: model
+    value: default
+    description: "Conservative fallback for an unrecognized Model Studio model."
+    dimensions:
+      - direction: input
+        unit: tokens
+        scale: 1000000
+        tiers: [{ price_usd: 2.868 }]
+      - direction: output
+        unit: tokens
+        scale: 1000000
+        tiers: [{ price_usd: 28.671 }]
+
+endpoints:
+  # Claude Code and other OpenAI-chat clients are routed through this surface.
+  - method: POST
+    # The deployed Agent Gateway exposes Model Studio's OpenAI surface under
+    # its upstream-compatible prefix. Agent harnesses still use the standard
+    # `/v1/chat/completions`; the payer proxy maps that path to this one.
+    path: "compatible-mode/v1/chat/completions"
+    resource: "chat"
+    description: "OpenAI-compatible streaming chat completions for Qwen models."
+    routing:
+      type: proxy
+      url: https://dashscope-us.aliyuncs.com
+      auth: *dashscope_auth
+    metering:
+      schemes: [mpp-session]
+      variants: *qwen_model_pricing
+
+  # Codex uses the OpenAI Responses API wire format.
+  - method: POST
+    path: "v1/responses"
+    resource: "responses"
+    description: "OpenAI-compatible Responses API for Qwen agent models."
+    metering:
+      schemes: [mpp-session]
+      variants: *qwen_model_pricing
+
+  # Qoder and Claude-compatible clients can use Model Studio's native
+  # Anthropic-compatible endpoint without protocol translation.
+  - method: POST
+    path: "v1/messages"
+    resource: "messages"
+    description: "Anthropic-compatible messages API for Qoder and Claude clients."
+    routing:
+      type: proxy
+      url: https://dashscope-us.aliyuncs.com/apps/anthropic
+      auth: *dashscope_auth
+    metering:
+      schemes: [mpp-session]
+      variants: *qwen_model_pricing

--- a/web-ui/proxy/google-gemini.yml
+++ b/web-ui/proxy/google-gemini.yml
@@ -32,6 +32,8 @@ session:
   # Default channel cap offered to clients (USDC, human-readable).
   # Clients may request a lower cap; the server will not accept higher.
   cap_usdc: 10.0
+  # The gateway meters successful responses and signs cumulative vouchers.
+  settlement_authority: delegated
   # Minimum voucher increment (base units = µUSDC).
   # Official Gemini token prices can be sub-µUSDC per token. We settle in
   # 0.000001 USDC quanta (1 µUSDC) once usage has accumulated enough value.

--- a/web-ui/proxy/google-gemini.yml
+++ b/web-ui/proxy/google-gemini.yml
@@ -27,7 +27,7 @@ recipients:
 
 # Session channel parameters.
 # The middleware issues a 402 with intent="session" instead of intent="charge".
-# Clients send signed vouchers on each call; no on-chain tx per request.
+# The client opens one channel, then the gateway signs cumulative vouchers.
 session:
   # Default channel cap offered to clients (USDC, human-readable).
   # Clients may request a lower cap; the server will not accept higher.
@@ -41,10 +41,9 @@ session:
   # Idle delay before the operator closes and settles the channel.
   close_delay_ms: 15000
   settlement_interval_ms: 5000
-  # Pull follows charge semantics at the payment boundary: the operator opens
-  # and funds the payment-channel, then the client signs cumulative vouchers.
-  modes: [pull]
-  pull_voucher_strategy: client_voucher
+  # The agent payer opens the channel and reuses its authorization while the
+  # delegated gateway operator signs metered vouchers.
+  modes: [push]
   splits:
     - recipient: platform
       percent: 0.1

--- a/web-ui/proxy/google-gemini.yml
+++ b/web-ui/proxy/google-gemini.yml
@@ -38,6 +38,7 @@ session:
   min_voucher_delta: 1
   # Idle delay before the operator closes and settles the channel.
   close_delay_ms: 15000
+  settlement_interval_ms: 5000
   # Pull follows charge semantics at the payment boundary: the operator opens
   # and funds the payment-channel, then the client signs cumulative vouchers.
   modes: [pull]
@@ -203,6 +204,17 @@ endpoints:
       metered against official Gemini API paid-tier standard pricing, quantized
       to 0.000001 USDC settlement increments where sub-µUSDC token prices
       require batching.
+    metering:
+      schemes: [mpp-session]
+      variants: *official_gemini_generation_metering
+
+  # Agent harnesses such as Claude, Goose, and Qoder speak OpenAI Chat
+  # Completions. Google exposes the same Gemini models through this official
+  # compatibility surface, so they do not need a Gemini-native client.
+  - method: POST
+    path: "v1beta/openai/chat/completions"
+    resource: "chat"
+    description: "OpenAI-compatible chat completions for Gemini models."
     metering:
       schemes: [mpp-session]
       variants: *official_gemini_generation_metering


### PR DESCRIPTION
## Summary
- update PayKit with durable Redis-backed channel state and TLS support
- add paid Alibaba Model Studio and Gemini routing for Claude, Codex, Goose, and Qoder
- recover cached hosted sessions by rediscovering and opening a replacement channel
- make idle close omit vouchers whose watermark already landed, avoiding 0xEA duplicate settlement failures
- leave periodic durable watermark reconciliation to the singleton Agent Gateway job

## Test Plan
- cargo fmt --all -- --check
- payer proxy replacement-session regression test
- close watermark comparison regression test
- PayKit Redis store tests, including concurrent watermark CAS
- Agent Gateway settle-sessions check, clippy, test build, and Terraform validation