### PR TITLE
fix(core): rehydrate session operator state and lease capacity via Redis

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6424,6 +6424,7 @@ dependencies = [
  "pay-types",
  "percent-encoding 2.3.2",
  "rand 0.8.6",
+ "redis",
  "reqwest 0.12.28",
  "schemars 0.8.22",
  "serde",

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -47,14 +47,20 @@ fn default_bind() -> String {
     }
 }
 
-async fn session_channel_store() -> pay_core::Result<Arc<dyn pay_kit::mpp::store::ChannelStore>> {
+async fn session_channel_store() -> pay_core::Result<(
+    Arc<dyn pay_kit::mpp::store::ChannelStore>,
+    pay_core::server::session_capacity::CapacityLeaseCoordinator,
+)> {
     let redis_url = std::env::var("PAY_SESSION_REDIS_URL")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
     let Some(redis_url) = redis_url else {
-        return Ok(Arc::new(pay_kit::mpp::store::MemoryChannelStore::new()));
+        return Ok((
+            Arc::new(pay_kit::mpp::store::MemoryChannelStore::new()),
+            pay_core::server::session_capacity::CapacityLeaseCoordinator::local(),
+        ));
     };
 
     #[cfg(feature = "redis-session-store")]
@@ -64,13 +70,21 @@ async fn session_channel_store() -> pay_core::Result<Arc<dyn pay_kit::mpp::store
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "pay:session:v1:".to_string());
-        let store = pay_kit::mpp::store::RedisChannelStore::connect(&redis_url, prefix)
+        let store = pay_kit::mpp::store::RedisChannelStore::connect(&redis_url, prefix.clone())
             .await
             .map_err(|error| {
                 pay_core::Error::Config(format!("failed to connect session Redis store: {error}"))
             })?;
-        tracing::info!("using durable Redis channel store for MPP sessions");
-        return Ok(Arc::new(store));
+        let capacity =
+            pay_core::server::session_capacity::CapacityLeaseCoordinator::redis(&redis_url, prefix)
+                .await
+                .map_err(|error| {
+                    pay_core::Error::Config(format!(
+                        "failed to connect session capacity lease Redis: {error}"
+                    ))
+                })?;
+        tracing::info!("using durable Redis channel store and capacity leases for MPP sessions");
+        return Ok((Arc::new(store), capacity));
     }
 
     #[cfg(not(feature = "redis-session-store"))]
@@ -1073,7 +1087,7 @@ impl StartCommand {
                         .await?;
                 }
 
-                let session_channel_store = session_channel_store().await?;
+                let (session_channel_store, session_capacity) = session_channel_store().await?;
                 let mut session_mpps = Vec::with_capacity(currency_configs.len());
                 for (_currency, session_mpp_currency, session_decimals) in &currency_configs {
                     let cap_base =
@@ -1096,10 +1110,11 @@ impl StartCommand {
                         program_id: Some(channel_program_id),
                     };
 
-                    let mut smpp = SessionMpp::new_with_channel_store(
+                    let mut smpp = SessionMpp::new_with_stores(
                         config,
                         session_secret.clone(),
                         Arc::clone(&session_channel_store),
+                        session_capacity.clone(),
                     )
                         .with_realm(api.title.clone())
                         .with_pull_voucher_strategy(pull_voucher_strategy)
@@ -1111,6 +1126,7 @@ impl StartCommand {
                         smpp = smpp.with_payment_channel_payer_signer(channel_payer_signer);
                     }
 
+                    smpp.rehydrate_from_store().await?;
                     let smpp = Arc::new(smpp);
                     smpp.start_lifecycle_runloop_with_settlement(
                         Duration::from_millis(sess.close_delay_ms),

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -20,7 +20,8 @@ network_tests = []
 vendored-openssl = ["openssl-sys/vendored"]
 # Durable MPP session state backed by Redis. Runtime selection still requires
 # PAY_SESSION_REDIS_URL; without it the in-memory store remains the default.
-redis-session-store = ["pay-kit/redis-store"]
+# Also enables cross-replica capacity leases (SET NX) beside the channel store.
+redis-session-store = ["pay-kit/redis-store", "dep:redis"]
 
 [dependencies]
 axum = { workspace = true, optional = true }
@@ -61,6 +62,7 @@ blake3 = { workspace = true }
 reqwest = { workspace = true }
 pay-keystore = { workspace = true }
 pay-kit = { workspace = true }
+redis = { version = "0.32.5", optional = true, features = ["tokio-rustls-comp", "connection-manager"] }
 bincode = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-hash = { workspace = true }

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -119,7 +119,7 @@ pub struct SessionForward {
     /// Remaining channel capacity available to the metered delivery.
     pub available_base_units: u64,
     /// Releases the exclusive capacity reservation on every terminal path.
-    _reservation: Option<DelegatedCapacityLease>,
+    reservation: Option<DelegatedCapacityLease>,
 }
 
 impl SessionForward {
@@ -137,8 +137,14 @@ impl SessionForward {
             committed_base_units,
             settlement: Some(Box::new(settlement)),
             available_base_units,
-            _reservation: Some(reservation),
+            reservation: Some(reservation),
         }
+    }
+
+    /// The lease this forward is metering under, when it has one. Requests
+    /// without a reservation (non-delegated paths) are never gated on one.
+    pub fn capacity_lease(&self) -> Option<&DelegatedCapacityLease> {
+        self.reservation.as_ref()
     }
 }
 
@@ -1558,13 +1564,30 @@ async fn session_authorized(
                     .unwrap_or_default(),
                 ));
             }
-            let Some(reservation) =
-                handle.reserve_delegated_capacity(&state.channel_id, available_base_units)
-            else {
-                return GateDecision::Respond(GateResponse::json(
-                    StatusCode::PAYMENT_REQUIRED,
-                    Bytes::from_static(br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#),
-                ));
+            let reservation = match handle
+                .reserve_delegated_capacity(&state.channel_id, available_base_units)
+                .await
+            {
+                Ok(Some(reservation)) => reservation,
+                Ok(None) => {
+                    return GateDecision::Respond(GateResponse::json(
+                        StatusCode::PAYMENT_REQUIRED,
+                        Bytes::from_static(br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#),
+                    ));
+                }
+                // A lease backend outage is our failure, not the payer's: keep it
+                // out of the payment-required path so retries stay meaningful.
+                Err(error) => {
+                    tracing::error!(
+                        channel_id = %state.channel_id,
+                        error = %error,
+                        "session capacity lease backend unavailable"
+                    );
+                    return GateDecision::Respond(GateResponse::json(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        Bytes::from_static(br#"{"error":"session_capacity_unavailable","message":"Session capacity coordination is temporarily unavailable; retry shortly."}"#),
+                    ));
+                }
             };
             let props = metering::RequestProperties {
                 body_size: req.content_length,
@@ -1603,7 +1626,7 @@ async fn session_authorized(
                 committed_base_units: cumulative,
                 settlement: None,
                 available_base_units: 0,
-                _reservation: None,
+                reservation: None,
             }),
             receipt: None,
             upto: None,

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -233,11 +233,16 @@ pub async fn settle_delegated_session(
         return Ok(None);
     }
 
-    let cumulative = pending
+    let authorize = pending
         .handle
-        .authorize_delegated_usage(&pending.channel_id, actual.base_units)
-        .await
-        .map_err(|error| error.to_string())?;
+        .authorize_delegated_usage(&pending.channel_id, actual.base_units);
+    // Losing the lease means another replica owns the channel, so drop this
+    // charge instead of racing its voucher into the store.
+    let cumulative = match pending.capacity_lease() {
+        Some(lease) => lease.guard(authorize).await.map_err(|e| e.to_string())?,
+        None => authorize.await,
+    }
+    .map_err(|error| error.to_string())?;
     tracing::info!(
         channel = %pending.channel_id,
         amount = actual.base_units,

--- a/rust/crates/core/src/server/mod.rs
+++ b/rust/crates/core/src/server/mod.rs
@@ -25,6 +25,9 @@ pub mod proxy;
 pub mod session;
 
 #[cfg(feature = "server")]
+pub mod session_capacity;
+
+#[cfg(feature = "server")]
 pub mod session_metering;
 
 #[cfg(feature = "server")]

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 
+use crate::server::session_capacity::{CapacityLeaseCoordinator, CapacityLeaseToken};
 use crate::{Error, Result};
 
 const INTENT: &str = "session";
@@ -77,7 +78,7 @@ struct SessionOperatorRuntime {
     payment_channel_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     payment_channel_payer_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     committed_watermarks: Arc<Mutex<HashMap<String, u64>>>,
-    reserved_capacity: Arc<Mutex<HashMap<String, u64>>>,
+    capacity: CapacityLeaseCoordinator,
     delegated_voucher_lock: Arc<tokio::sync::Mutex<()>>,
     /// Channel id → on-chain settlement signature, recorded when the channel
     /// finalizes. Surfaced via the `/sessions/receipt/:channelId` poll so the
@@ -90,21 +91,14 @@ struct SessionOperatorRuntime {
 }
 
 impl SessionOperatorRuntime {
-    fn reserve_capacity(&self, channel_id: &str, amount: u64) -> bool {
-        let Ok(mut reservations) = self.reserved_capacity.lock() else {
-            return false;
-        };
-        if reservations.contains_key(channel_id) {
-            return false;
-        }
-        reservations.insert(channel_id.to_string(), amount);
-        true
+    async fn reserve_capacity(&self, channel_id: &str) -> Result<Option<CapacityLeaseToken>> {
+        self.capacity.try_acquire(channel_id).await
     }
-    fn release_capacity(&self, channel_id: &str) {
-        if let Ok(mut reservations) = self.reserved_capacity.lock() {
-            reservations.remove(channel_id);
-        }
+
+    fn release_capacity(&self, channel_id: &str, token: &CapacityLeaseToken) {
+        self.capacity.release(channel_id, token);
     }
+
     fn record_committed_watermark(&self, session_id: impl Into<String>, cumulative: u64) {
         if let Ok(mut watermarks) = self.committed_watermarks.lock() {
             let session_id = session_id.into();
@@ -455,11 +449,25 @@ fn close_voucher_required(onchain_settled: u64, latest_accepted: u64) -> bool {
 pub struct DelegatedCapacityLease {
     runtime: SessionOperatorRuntime,
     channel_id: String,
+    token: CapacityLeaseToken,
+}
+
+impl DelegatedCapacityLease {
+    /// False once the shared lease was lost (expired or taken over), so the
+    /// caller must stop the metered work this lease was protecting.
+    pub fn is_held(&self) -> bool {
+        self.token.is_held()
+    }
+
+    /// Resolves when the lease is lost; select on it to cancel in-flight work.
+    pub async fn lost(&self) {
+        self.token.lost().await;
+    }
 }
 
 impl Drop for DelegatedCapacityLease {
     fn drop(&mut self) {
-        self.runtime.release_capacity(&self.channel_id);
+        self.runtime.release_capacity(&self.channel_id, &self.token);
     }
 }
 
@@ -604,19 +612,31 @@ impl SessionLifecycleRunloop {
             // the reservation check atomic with the start of close: a request
             // already in flight defers close, while a close already in progress
             // prevents a new request from reserving stale capacity.
-            if !self.runtime.reserve_capacity(&channel_id, 0) {
-                self.last_activity.insert(channel_id, Instant::now());
-                continue;
-            }
+            let token = match self.runtime.reserve_capacity(&channel_id).await {
+                Ok(Some(token)) => token,
+                Ok(None) => {
+                    self.last_activity.insert(channel_id, Instant::now());
+                    continue;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        channel_id,
+                        error = %error,
+                        "capacity lease unavailable; deferring auto-close"
+                    );
+                    self.last_activity.insert(channel_id, Instant::now());
+                    continue;
+                }
+            };
             let runtime = self.runtime.clone();
             closing.push(async move {
                 let result = runtime.operator_close_channel(&channel_id).await;
+                runtime.release_capacity(&channel_id, &token);
                 (channel_id, result)
             });
         }
 
         for (channel_id, close_result) in futures_util::future::join_all(closing).await {
-            self.runtime.release_capacity(&channel_id);
             match close_result {
                 Ok(SessionCloseResult::Closed { settled }) => {
                     tracing::info!(channel_id, settled, "operator auto-closed payment channel");
@@ -651,17 +671,26 @@ impl SessionLifecycleRunloop {
         let channels = self.last_activity.keys().cloned().collect::<Vec<_>>();
         let mut settlements = Vec::with_capacity(channels.len());
         for channel_id in channels {
-            if !self.runtime.reserve_capacity(&channel_id, 0) {
-                continue;
-            }
+            let token = match self.runtime.reserve_capacity(&channel_id).await {
+                Ok(Some(token)) => token,
+                Ok(None) => continue,
+                Err(error) => {
+                    tracing::warn!(
+                        channel_id,
+                        error = %error,
+                        "capacity lease unavailable; skipping watermark push"
+                    );
+                    continue;
+                }
+            };
             let runtime = self.runtime.clone();
             settlements.push(async move {
                 let result = runtime.operator_push_watermark(&channel_id).await;
+                runtime.release_capacity(&channel_id, &token);
                 (channel_id, result)
             });
         }
         for (channel_id, result) in futures_util::future::join_all(settlements).await {
-            self.runtime.release_capacity(&channel_id);
             if let Err(error) = result {
                 tracing::warn!(
                     channel_id,
@@ -739,12 +768,26 @@ impl SessionMpp {
         challenge_binding_secret: impl Into<String>,
         channel_store: Arc<dyn ChannelStore>,
     ) -> Self {
+        Self::new_with_stores(
+            config,
+            challenge_binding_secret,
+            channel_store,
+            CapacityLeaseCoordinator::local(),
+        )
+    }
+
+    /// Create with an explicit channel store and capacity coordinator.
+    pub fn new_with_stores(
+        config: SessionConfig,
+        challenge_binding_secret: impl Into<String>,
+        channel_store: Arc<dyn ChannelStore>,
+        capacity: CapacityLeaseCoordinator,
+    ) -> Self {
         let session_config = config.clone();
         let server = Arc::new(SessionServer::new(config, Arc::clone(&channel_store)));
         let payment_channel_signer = Arc::new(Mutex::new(None));
         let payment_channel_payer_signer = Arc::new(Mutex::new(None));
         let committed_watermarks = Arc::new(Mutex::new(HashMap::new()));
-        let reserved_capacity = Arc::new(Mutex::new(HashMap::new()));
         let delegated_voucher_lock = Arc::new(tokio::sync::Mutex::new(()));
         let settlement_signatures = Arc::new(Mutex::new(HashMap::new()));
         let pull_sessions = Arc::new(Mutex::new(HashSet::new()));
@@ -755,7 +798,7 @@ impl SessionMpp {
             payment_channel_signer: Arc::clone(&payment_channel_signer),
             payment_channel_payer_signer: Arc::clone(&payment_channel_payer_signer),
             committed_watermarks: Arc::clone(&committed_watermarks),
-            reserved_capacity: Arc::clone(&reserved_capacity),
+            capacity,
             delegated_voucher_lock,
             settlement_signatures: Arc::clone(&settlement_signatures),
             settlement_worker: Arc::new(tokio::sync::OnceCell::new()),
@@ -943,17 +986,77 @@ impl SessionMpp {
         Ok(accepted.cumulative)
     }
 
-    pub fn reserve_delegated_capacity(
+    pub async fn reserve_delegated_capacity(
         &self,
         channel_id: &str,
-        amount: u64,
-    ) -> Option<DelegatedCapacityLease> {
-        self.operator_runtime
-            .reserve_capacity(channel_id, amount)
-            .then(|| DelegatedCapacityLease {
+        _amount: u64,
+    ) -> Result<Option<DelegatedCapacityLease>> {
+        Ok(self
+            .operator_runtime
+            .reserve_capacity(channel_id)
+            .await?
+            .map(|token| DelegatedCapacityLease {
                 runtime: self.operator_runtime.clone(),
                 channel_id: channel_id.to_string(),
-            })
+                token,
+            }))
+    }
+
+    /// Seed watermark cache + lifecycle timers from the durable store (call once at boot).
+    pub async fn rehydrate_from_store(&self) -> Result<usize> {
+        let channels = self
+            .operator_runtime
+            .channel_store
+            .list_channels()
+            .await
+            .map_err(|error| {
+                Error::Mpp(format!("failed to list durable session channels: {error}"))
+            })?;
+        let mut restored = 0usize;
+        for state in channels {
+            if state.sealed {
+                continue;
+            }
+            self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
+            self.touch_channel(state.channel_id);
+            restored += 1;
+        }
+        if restored > 0 {
+            tracing::info!(
+                restored,
+                "rehydrated open payment channels from durable session store"
+            );
+        }
+        Ok(restored)
+    }
+
+    /// Latest cumulative watermark from the local cache only.
+    pub fn committed_watermark(&self, session_id: &str) -> Option<u64> {
+        self.committed_watermarks
+            .lock()
+            .ok()
+            .and_then(|watermarks| watermarks.get(session_id).copied())
+    }
+
+    /// Always read the store and monotonically merge into the local watermark cache.
+    pub async fn refresh_committed_watermark(&self, session_id: &str) -> Option<u64> {
+        let state = self
+            .operator_runtime
+            .channel_store
+            .get_channel(session_id)
+            .await
+            .ok()
+            .flatten()?;
+        self.record_committed_watermark(session_id.to_string(), state.cumulative);
+        Some(state.cumulative)
+    }
+
+    /// Cache hit, else durable store (seeds the cache).
+    pub async fn load_committed_watermark(&self, session_id: &str) -> Option<u64> {
+        if let Some(cumulative) = self.committed_watermark(session_id) {
+            return Some(cumulative);
+        }
+        self.refresh_committed_watermark(session_id).await
     }
 
     /// Record channel activity so the lifecycle runloop can defer auto-close.
@@ -969,14 +1072,6 @@ impl SessionMpp {
         }
         self.lifecycle
             .send(SessionLifecycleCommand::Touch { channel_id });
-    }
-
-    /// Latest cumulative watermark accepted by this process for a session.
-    pub fn committed_watermark(&self, session_id: &str) -> Option<u64> {
-        self.committed_watermarks
-            .lock()
-            .ok()
-            .and_then(|watermarks| watermarks.get(session_id).copied())
     }
 
     /// On-chain settle signature for a finalized session channel, if recorded.
@@ -1153,6 +1248,7 @@ impl SessionMpp {
             SessionAction::Close(p) => {
                 let _lease = self
                     .reserve_delegated_capacity(&p.channel_id, 0)
+                    .await?
                     .ok_or_else(|| {
                         Error::Mpp(format!(
                             "Session channel {} is busy with another request",
@@ -1685,6 +1781,46 @@ mod tests {
         Box::new(MemorySigner::from_bytes(&kp).unwrap())
     }
 
+    #[tokio::test]
+    async fn rehydrate_restores_watermark_after_restart() {
+        let store: Arc<dyn ChannelStore> = Arc::new(MemoryChannelStore::new());
+        let first = SessionMpp::new_with_channel_store(
+            test_session_config(),
+            "test-secret",
+            Arc::clone(&store),
+        );
+        let challenge = first.challenge(CAP).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            test_session_signer(),
+            challenge,
+        );
+        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state: opened, .. } =
+            first.process(&open_header).await.unwrap()
+        else {
+            panic!("expected open");
+        };
+        let voucher_header = handle.voucher_header(75).await.unwrap();
+        first.process(&voucher_header).await.unwrap();
+        assert_eq!(first.committed_watermark(&opened.channel_id), Some(75));
+
+        // Simulate a gateway restart: new SessionMpp, same durable store.
+        let restarted = SessionMpp::new_with_channel_store(
+            test_session_config(),
+            "test-secret",
+            Arc::clone(&store),
+        );
+        assert_eq!(restarted.committed_watermark(&opened.channel_id), None);
+        let restored = restarted.rehydrate_from_store().await.unwrap();
+        assert_eq!(restored, 1);
+        assert_eq!(restarted.committed_watermark(&opened.channel_id), Some(75));
+        assert_eq!(
+            restarted.load_committed_watermark(&opened.channel_id).await,
+            Some(75)
+        );
+    }
+
     #[test]
     fn with_realm_updates_challenge_realm() {
         let session = test_session_mpp().with_realm("Custom Realm");
@@ -1827,6 +1963,8 @@ mod tests {
         let close_header = handle.close_header(Some(25)).await.unwrap();
         let competing_lease = session
             .reserve_delegated_capacity(&opened.channel_id, 0)
+            .await
+            .unwrap()
             .expect("test should reserve the channel");
         let error = session.process(&close_header).await.unwrap_err();
         assert!(
@@ -1972,21 +2110,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn delegated_capacity_lease_releases_on_drop() {
+    #[tokio::test]
+    async fn delegated_capacity_lease_releases_on_drop() {
         let session = test_session_mpp();
         let first = session
             .reserve_delegated_capacity("channel", CAP)
+            .await
+            .unwrap()
             .expect("first reservation should succeed");
         assert!(
-            session.reserve_delegated_capacity("channel", CAP).is_none(),
+            session
+                .reserve_delegated_capacity("channel", CAP)
+                .await
+                .unwrap()
+                .is_none(),
             "a live lease must exclude concurrent reservations"
         );
 
         drop(first);
 
         assert!(
-            session.reserve_delegated_capacity("channel", CAP).is_some(),
+            session
+                .reserve_delegated_capacity("channel", CAP)
+                .await
+                .unwrap()
+                .is_some(),
             "dropping the lease must release capacity"
         );
     }
@@ -2010,6 +2158,8 @@ mod tests {
         };
         let lease = session
             .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .await
+            .unwrap()
             .expect("request should reserve channel capacity");
 
         tokio::time::sleep(Duration::from_millis(60)).await;
@@ -2396,5 +2546,128 @@ mod tests {
         assert!(session_close_needs_reconciliation(&close_pending));
         assert!(session_close_needs_reconciliation(&sealed));
         assert!(!session_close_needs_reconciliation(&missing));
+    }
+}
+
+#[cfg(all(test, feature = "redis-session-store"))]
+mod redis_e2e_tests {
+    use super::*;
+    use crate::client::session::SessionHandle;
+    use crate::server::session_capacity::CapacityLeaseCoordinator;
+    use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
+    use pay_kit::mpp::store::RedisChannelStore;
+    use std::sync::Arc;
+
+    const CAP: u64 = 1_000_000;
+
+    fn redis_url() -> Option<String> {
+        std::env::var("PAY_SESSION_REDIS_URL")
+            .or_else(|_| std::env::var("PAY_KIT_TEST_REDIS_URL"))
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
+    fn config() -> SessionConfig {
+        SessionConfig {
+            operator: solana_pubkey::Pubkey::new_unique().to_string(),
+            recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+            max_cap: 5 * CAP,
+            currency: solana_pubkey::Pubkey::new_unique().to_string(),
+            network: "localnet".to_string(),
+            modes: vec![SessionMode::Push, SessionMode::Pull],
+            ..SessionConfig::default()
+        }
+    }
+
+    fn signer() -> Box<dyn SolanaSigner> {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let vk = sk.verifying_key();
+        let mut kp = [0u8; 64];
+        kp[..32].copy_from_slice(sk.as_bytes());
+        kp[32..].copy_from_slice(vk.as_bytes());
+        Box::new(MemorySigner::from_bytes(&kp).unwrap())
+    }
+
+    #[tokio::test]
+    async fn redis_rehydrate_and_lease_across_replicas() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:session:{}:", uuid::Uuid::new_v4().simple());
+        let store: Arc<dyn ChannelStore> = Arc::new(
+            RedisChannelStore::connect(&url, prefix.clone())
+                .await
+                .expect("redis store"),
+        );
+        let first = SessionMpp::new_with_stores(
+            config(),
+            "redis-e2e",
+            Arc::clone(&store),
+            CapacityLeaseCoordinator::redis(&url, &prefix)
+                .await
+                .unwrap(),
+        );
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            signer(),
+            first.challenge(CAP).unwrap(),
+        );
+        let open = handle.open_header(CAP, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state: opened, .. } = first.process(&open).await.unwrap()
+        else {
+            panic!("expected open");
+        };
+        first
+            .process(&handle.voucher_header(88).await.unwrap())
+            .await
+            .unwrap();
+
+        let lease = first
+            .reserve_delegated_capacity(&opened.channel_id, 0)
+            .await
+            .unwrap()
+            .expect("first lease");
+        assert!(
+            first
+                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let second = SessionMpp::new_with_stores(
+            config(),
+            "redis-e2e",
+            Arc::clone(&store),
+            CapacityLeaseCoordinator::redis(&url, &prefix)
+                .await
+                .unwrap(),
+        );
+        assert!(
+            second
+                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        drop(lease);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(second.rehydrate_from_store().await.unwrap() >= 1);
+        assert_eq!(
+            second.load_committed_watermark(&opened.channel_id).await,
+            Some(88)
+        );
+        assert!(
+            second
+                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -463,6 +463,11 @@ impl DelegatedCapacityLease {
     pub async fn lost(&self) {
         self.token.lost().await;
     }
+
+    /// Run `work` under this lease, abandoning it if the lease is lost first.
+    pub async fn guard<T>(&self, work: impl std::future::Future<Output = T>) -> Result<T> {
+        self.token.guard(work).await
+    }
 }
 
 impl Drop for DelegatedCapacityLease {
@@ -630,7 +635,10 @@ impl SessionLifecycleRunloop {
             };
             let runtime = self.runtime.clone();
             closing.push(async move {
-                let result = runtime.operator_close_channel(&channel_id).await;
+                let result = token
+                    .guard(runtime.operator_close_channel(&channel_id))
+                    .await
+                    .and_then(|closed| closed);
                 runtime.release_capacity(&channel_id, &token);
                 (channel_id, result)
             });
@@ -685,7 +693,10 @@ impl SessionLifecycleRunloop {
             };
             let runtime = self.runtime.clone();
             settlements.push(async move {
-                let result = runtime.operator_push_watermark(&channel_id).await;
+                let result = token
+                    .guard(runtime.operator_push_watermark(&channel_id))
+                    .await
+                    .and_then(|pushed| pushed);
                 runtime.release_capacity(&channel_id, &token);
                 (channel_id, result)
             });
@@ -1246,7 +1257,7 @@ impl SessionMpp {
             }
 
             SessionAction::Close(p) => {
-                let _lease = self
+                let lease = self
                     .reserve_delegated_capacity(&p.channel_id, 0)
                     .await?
                     .ok_or_else(|| {
@@ -1255,57 +1266,62 @@ impl SessionMpp {
                             p.channel_id
                         ))
                     })?;
-                let params = match self.server.process_close(p).await {
-                    Ok(params) => params,
-                    Err(error) if session_close_needs_reconciliation(&error) => self
-                        .server
-                        .seal_params(&p.channel_id)
-                        .await
-                        .map_err(|e| Error::Mpp(format!("Failed to get seal params: {e}")))?,
-                    Err(error) => {
-                        return Err(Error::Mpp(format!("Session close failed: {error}")));
-                    }
-                };
-                self.record_committed_watermark(params.channel_id.to_string(), params.settled);
-                let settlement = self.submit_payment_channel_settlement(&params).await;
-                let signature = match settlement {
-                    Ok(signature) => signature,
-                    Err(_error)
-                        if self
-                            .operator_runtime
-                            .channel_is_tombstoned_on_chain(&params.channel_id.to_string())
-                            .await =>
-                    {
-                        self.server
-                            .mark_sealed(&params.channel_id.to_string())
-                            .await
-                            .map_err(|e| {
-                                Error::Mpp(format!("Failed to mark session sealed: {e}"))
-                            })?;
-                        None
-                    }
-                    Err(error) => return Err(error),
-                };
-                if let Some(signature) = signature.as_ref() {
-                    self.server
-                        .mark_sealed(&params.channel_id.to_string())
-                        .await
-                        .map_err(|e| Error::Mpp(format!("Failed to mark session sealed: {e}")))?;
-                    self.operator_runtime.record_settlement_signature(
-                        params.channel_id.to_string(),
-                        signature.clone(),
-                    );
-                    tracing::info!(
-                        monotonic_counter.pay_payment_channels_closed_total = 1_u64,
-                        %signature,
-                        channel = %params.channel_id,
-                        "payment-channel settlement confirmed"
-                    );
-                }
-                self.unschedule_channel_close(params.channel_id.to_string());
-                Ok(SessionOutcome::Closed { params, signature })
+                lease.guard(self.close_session_channel(p)).await?
             }
         }
+    }
+
+    /// Settle, seal, and record a client-initiated close. Callers hold the
+    /// channel's capacity lease for the whole sequence.
+    async fn close_session_channel(
+        &self,
+        p: &pay_kit::mpp::ClosePayload,
+    ) -> Result<SessionOutcome> {
+        let params = match self.server.process_close(p).await {
+            Ok(params) => params,
+            Err(error) if session_close_needs_reconciliation(&error) => self
+                .server
+                .seal_params(&p.channel_id)
+                .await
+                .map_err(|e| Error::Mpp(format!("Failed to get seal params: {e}")))?,
+            Err(error) => {
+                return Err(Error::Mpp(format!("Session close failed: {error}")));
+            }
+        };
+        self.record_committed_watermark(params.channel_id.to_string(), params.settled);
+        let settlement = self.submit_payment_channel_settlement(&params).await;
+        let signature = match settlement {
+            Ok(signature) => signature,
+            Err(_error)
+                if self
+                    .operator_runtime
+                    .channel_is_tombstoned_on_chain(&params.channel_id.to_string())
+                    .await =>
+            {
+                self.server
+                    .mark_sealed(&params.channel_id.to_string())
+                    .await
+                    .map_err(|e| Error::Mpp(format!("Failed to mark session sealed: {e}")))?;
+                None
+            }
+            Err(error) => return Err(error),
+        };
+        if let Some(signature) = signature.as_ref() {
+            self.server
+                .mark_sealed(&params.channel_id.to_string())
+                .await
+                .map_err(|e| Error::Mpp(format!("Failed to mark session sealed: {e}")))?;
+            self.operator_runtime
+                .record_settlement_signature(params.channel_id.to_string(), signature.clone());
+            tracing::info!(
+                monotonic_counter.pay_payment_channels_closed_total = 1_u64,
+                %signature,
+                channel = %params.channel_id,
+                "payment-channel settlement confirmed"
+            );
+        }
+        self.unschedule_channel_close(params.channel_id.to_string());
+        Ok(SessionOutcome::Closed { params, signature })
     }
 
     /// Retrieve settle+seal parameters for an open channel.

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -1,0 +1,501 @@
+//! Exclusive capacity leases for delegated MPP sessions.
+//!
+//! Local: process-private `HashSet`. Redis: `SET key token NX EX` + Lua
+//! compare-and-delete so a late Drop cannot steal a newer holder's key.
+//!
+//! A Redis lease is renewed by a task owned by the returned
+//! [`CapacityLeaseToken`], so a lease stays exclusive for as long as the holder
+//! keeps the token — including streams that run far longer than the TTL. The
+//! TTL is the crash bound: when a replica dies the key expires within it.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::{Error, Result};
+
+/// How long a Redis lease survives without renewal (crash bound).
+pub const CAPACITY_LEASE_TTL: Duration = Duration::from_secs(60);
+
+/// Upper bound on any single lease command, connect included.
+#[cfg(feature = "redis-session-store")]
+const LEASE_IO_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Renew at a third of the TTL so a lease survives two failed renewals.
+#[cfg(feature = "redis-session-store")]
+fn renew_interval(ttl: Duration) -> Duration {
+    (ttl / 3).max(Duration::from_millis(100))
+}
+
+/// Keep the holder's Redis key alive; aborts when the token is dropped.
+#[cfg(feature = "redis-session-store")]
+struct RenewalTask(tokio::task::JoinHandle<()>);
+
+#[cfg(feature = "redis-session-store")]
+impl Drop for RenewalTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Proof of one acquisition. Must be passed back to
+/// [`CapacityLeaseCoordinator::release`]; dropping it stops Redis renewal.
+///
+/// Boxed so an in-flight request holds one pointer, not the whole hold.
+pub struct CapacityLeaseToken {
+    #[cfg(feature = "redis-session-store")]
+    redis: Option<Box<RedisLeaseHold>>,
+}
+
+/// Identity of a Redis lease plus the task keeping it alive.
+#[cfg(feature = "redis-session-store")]
+struct RedisLeaseHold {
+    id: String,
+    held: Arc<tokio::sync::watch::Sender<bool>>,
+    _renewal: Option<RenewalTask>,
+}
+
+impl CapacityLeaseToken {
+    /// The local backend needs no identity: the `HashSet` entry is the lease.
+    fn local() -> Self {
+        Self {
+            #[cfg(feature = "redis-session-store")]
+            redis: None,
+        }
+    }
+
+    /// False once renewal proves the lease was lost — the holder must stop the
+    /// work it was protecting, because a peer may already own the channel.
+    pub fn is_held(&self) -> bool {
+        #[cfg(feature = "redis-session-store")]
+        if let Some(hold) = &self.redis {
+            return *hold.held.borrow();
+        }
+        true
+    }
+
+    /// Resolves when the lease is lost, so callers can cancel work that is
+    /// already in flight instead of only checking before they start.
+    pub async fn lost(&self) {
+        #[cfg(feature = "redis-session-store")]
+        if let Some(hold) = &self.redis {
+            let mut held = hold.held.subscribe();
+            // A closed channel means the holder itself is going away.
+            let _ = held.wait_for(|held| !*held).await;
+            return;
+        }
+        // A local lease cannot be taken away while the holder keeps its token.
+        std::future::pending().await
+    }
+}
+
+/// Coordinates exclusive access to a session channel's remaining capacity.
+#[derive(Clone)]
+pub struct CapacityLeaseCoordinator {
+    inner: Arc<Inner>,
+}
+
+enum Inner {
+    Local(Mutex<HashSet<String>>),
+    #[cfg(feature = "redis-session-store")]
+    Redis(RedisLease),
+}
+
+#[cfg(feature = "redis-session-store")]
+#[derive(Clone)]
+struct RedisLease {
+    connection: redis::aio::ConnectionManager,
+    prefix: String,
+    ttl: Duration,
+}
+
+impl CapacityLeaseCoordinator {
+    pub fn local() -> Self {
+        Self {
+            inner: Arc::new(Inner::Local(Mutex::new(HashSet::new()))),
+        }
+    }
+
+    /// Shared Redis leases. `prefix` should match `PAY_SESSION_REDIS_PREFIX`.
+    #[cfg(feature = "redis-session-store")]
+    pub async fn redis(redis_url: &str, prefix: impl Into<String>) -> Result<Self> {
+        Self::redis_with_ttl(redis_url, prefix, CAPACITY_LEASE_TTL).await
+    }
+
+    #[cfg(feature = "redis-session-store")]
+    pub(crate) async fn redis_with_ttl(
+        redis_url: &str,
+        prefix: impl Into<String>,
+        ttl: Duration,
+    ) -> Result<Self> {
+        let client = redis::Client::open(redis_url).map_err(lease_error)?;
+        // Every lease call is on a request path, so bound the wait ourselves:
+        // redis-rs retries a rejected handshake for minutes on its own.
+        let config = redis::aio::ConnectionManagerConfig::new()
+            .set_number_of_retries(2)
+            .set_connection_timeout(LEASE_IO_TIMEOUT)
+            .set_response_timeout(LEASE_IO_TIMEOUT);
+        let connection =
+            with_lease_timeout("connect", client.get_connection_manager_with_config(config))
+                .await?
+                .map_err(lease_error)?;
+        Ok(Self {
+            inner: Arc::new(Inner::Redis(RedisLease {
+                connection,
+                prefix: normalize_prefix(prefix.into()),
+                ttl,
+            })),
+        })
+    }
+
+    /// `Ok(None)` means another holder owns the channel; `Err` means the lease
+    /// backend is unreachable, which callers must not report as contention.
+    pub async fn try_acquire(&self, channel_id: &str) -> Result<Option<CapacityLeaseToken>> {
+        match self.inner.as_ref() {
+            Inner::Local(slots) => {
+                let mut slots = slots.lock().map_err(|_| lease_poisoned())?;
+                Ok(slots
+                    .insert(channel_id.to_string())
+                    .then(CapacityLeaseToken::local))
+            }
+            #[cfg(feature = "redis-session-store")]
+            Inner::Redis(lease) => lease.try_acquire(channel_id).await,
+        }
+    }
+
+    pub fn release(&self, channel_id: &str, token: &CapacityLeaseToken) {
+        let _ = token;
+        match self.inner.as_ref() {
+            Inner::Local(slots) => {
+                if let Ok(mut slots) = slots.lock() {
+                    slots.remove(channel_id);
+                }
+            }
+            #[cfg(feature = "redis-session-store")]
+            Inner::Redis(lease) => {
+                if let Some(hold) = &token.redis {
+                    lease.release_spawn(channel_id, &hold.id);
+                }
+            }
+        }
+    }
+
+    pub async fn release_async(&self, channel_id: &str, token: &CapacityLeaseToken) {
+        let _ = token;
+        match self.inner.as_ref() {
+            Inner::Local(slots) => {
+                if let Ok(mut slots) = slots.lock() {
+                    slots.remove(channel_id);
+                }
+            }
+            #[cfg(feature = "redis-session-store")]
+            Inner::Redis(lease) => {
+                if let Some(hold) = &token.redis {
+                    lease.release_now(channel_id, &hold.id).await;
+                }
+            }
+        }
+    }
+}
+
+/// Bound a lease call so a stalled backend surfaces as an error, not a hang.
+#[cfg(feature = "redis-session-store")]
+async fn with_lease_timeout<T>(
+    what: &str,
+    operation: impl std::future::Future<Output = T>,
+) -> Result<T> {
+    tokio::time::timeout(LEASE_IO_TIMEOUT, operation)
+        .await
+        .map_err(|_| Error::Mpp(format!("capacity lease backend timed out during {what}")))
+}
+
+fn lease_poisoned() -> Error {
+    Error::Mpp("capacity lease registry lock poisoned".to_string())
+}
+
+#[cfg(feature = "redis-session-store")]
+fn lease_error(error: impl std::fmt::Display) -> Error {
+    Error::Mpp(format!("capacity lease backend unavailable: {error}"))
+}
+
+/// Both scripts act only while the key still holds the caller's token.
+#[cfg(feature = "redis-session-store")]
+const RENEW_SCRIPT: &str = r"
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+";
+
+#[cfg(feature = "redis-session-store")]
+const RELEASE_SCRIPT: &str = r"
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+return redis.call('DEL', KEYS[1])
+";
+
+#[cfg(feature = "redis-session-store")]
+impl RedisLease {
+    fn key(&self, channel_id: &str) -> String {
+        format!("{}lease:{}", self.prefix, channel_id)
+    }
+
+    async fn try_acquire(&self, channel_id: &str) -> Result<Option<CapacityLeaseToken>> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let key = self.key(channel_id);
+        let mut conn = self.connection.clone();
+        let acquired: Option<String> = with_lease_timeout(
+            "acquire",
+            redis::cmd("SET")
+                .arg(&key)
+                .arg(&id)
+                .arg("NX")
+                .arg("PX")
+                .arg(self.ttl.as_millis() as u64)
+                .query_async(&mut conn),
+        )
+        .await?
+        .map_err(lease_error)?;
+        if acquired.is_none() {
+            return Ok(None);
+        }
+        let held = Arc::new(tokio::sync::watch::Sender::new(true));
+        let renewal = self
+            .spawn_renewal(key, id.clone(), Arc::clone(&held))
+            .map(RenewalTask);
+        Ok(Some(CapacityLeaseToken {
+            redis: Some(Box::new(RedisLeaseHold {
+                id,
+                held,
+                _renewal: renewal,
+            })),
+        }))
+    }
+
+    /// Extend the TTL every interval so a long stream keeps its lease, and mark
+    /// the lease lost as soon as we can no longer prove we still hold it.
+    fn spawn_renewal(
+        &self,
+        key: String,
+        id: String,
+        held: Arc<tokio::sync::watch::Sender<bool>>,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        let handle = tokio::runtime::Handle::try_current().ok()?;
+        let mut conn = self.connection.clone();
+        let ttl = self.ttl;
+        Some(handle.spawn(async move {
+            let mut last_renewal = tokio::time::Instant::now();
+            loop {
+                tokio::time::sleep(renew_interval(ttl)).await;
+                let renewed: std::result::Result<i32, redis::RedisError> =
+                    redis::Script::new(RENEW_SCRIPT)
+                        .key(&key)
+                        .arg(&id)
+                        .arg(ttl.as_millis() as u64)
+                        .invoke_async(&mut conn)
+                        .await;
+                match renewed {
+                    Ok(0) => {
+                        tracing::warn!(key, "capacity lease lost; another holder may own it");
+                        let _ = held.send(false);
+                        return;
+                    }
+                    Ok(_) => last_renewal = tokio::time::Instant::now(),
+                    Err(error) => {
+                        // Past the TTL the key has expired regardless of why we
+                        // could not reach Redis, so stop vouching for the lease.
+                        if last_renewal.elapsed() >= ttl {
+                            tracing::warn!(key, error = %error, "capacity lease expired unrenewed");
+                            let _ = held.send(false);
+                            return;
+                        }
+                        tracing::warn!(key, error = %error, "capacity lease renewal failed");
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn release_now(&self, channel_id: &str, id: &str) {
+        let key = self.key(channel_id);
+        let mut conn = self.connection.clone();
+        let _: std::result::Result<i32, redis::RedisError> = redis::Script::new(RELEASE_SCRIPT)
+            .key(&key)
+            .arg(id)
+            .invoke_async(&mut conn)
+            .await;
+    }
+
+    fn release_spawn(&self, channel_id: &str, id: &str) {
+        let key = self.key(channel_id);
+        let id = id.to_string();
+        let mut conn = self.connection.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _: std::result::Result<i32, redis::RedisError> =
+                    redis::Script::new(RELEASE_SCRIPT)
+                        .key(&key)
+                        .arg(&id)
+                        .invoke_async(&mut conn)
+                        .await;
+            });
+        }
+    }
+}
+
+#[cfg(feature = "redis-session-store")]
+fn normalize_prefix(prefix: String) -> String {
+    if prefix.is_empty() || prefix.ends_with(':') {
+        prefix
+    } else {
+        format!("{prefix}:")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_lease_is_exclusive_until_released() {
+        let c = CapacityLeaseCoordinator::local();
+        let a = c.try_acquire("ch-a").await.unwrap().expect("a");
+        assert!(c.try_acquire("ch-a").await.unwrap().is_none());
+        assert!(c.try_acquire("ch-b").await.unwrap().is_some());
+        c.release_async("ch-a", &a).await;
+        assert!(c.try_acquire("ch-a").await.unwrap().is_some());
+    }
+}
+
+#[cfg(all(test, feature = "redis-session-store"))]
+mod redis_tests {
+    use super::*;
+
+    fn redis_url() -> Option<String> {
+        std::env::var("PAY_SESSION_REDIS_URL")
+            .or_else(|_| std::env::var("PAY_KIT_TEST_REDIS_URL"))
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
+    #[tokio::test]
+    async fn redis_lease_exclusive_and_stale_release_safe() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let a = CapacityLeaseCoordinator::redis(&url, &prefix)
+            .await
+            .unwrap();
+        let b = CapacityLeaseCoordinator::redis(&url, &prefix)
+            .await
+            .unwrap();
+
+        let token_a = a.try_acquire("ch").await.unwrap().expect("a");
+        assert!(b.try_acquire("ch").await.unwrap().is_none());
+
+        // Simulate TTL expiry, then B acquires; A's stale release must not win.
+        let key = format!("{prefix}lease:ch");
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut conn = client.get_connection_manager().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        let token_b = b.try_acquire("ch").await.unwrap().expect("b");
+        a.release_async("ch", &token_a).await;
+        let value: Option<String> = redis::cmd("GET")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        assert!(
+            value.is_some(),
+            "stale compare-and-delete must leave new holder"
+        );
+        b.release_async("ch", &token_b).await;
+    }
+
+    #[tokio::test]
+    async fn redis_lease_renews_past_its_ttl() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_millis(600);
+        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
+
+        // Outlive the TTL: only renewal can keep the key (and the exclusion) alive.
+        tokio::time::sleep(ttl * 3).await;
+
+        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        assert!(
+            peer.try_acquire("ch").await.unwrap().is_none(),
+            "renewed lease must stay exclusive past its TTL"
+        );
+
+        // Dropping the token stops renewal, so the lease lapses on its own.
+        drop(token);
+        tokio::time::sleep(ttl * 2).await;
+        assert!(peer.try_acquire("ch").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn redis_backend_failure_is_an_error_not_contention() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        // A rejected handshake stands in for any backend failure: it must never
+        // look like a channel that is merely busy.
+        let rejected = url.replacen("redis://", "redis://:wrong-password@", 1);
+        let acquired = match CapacityLeaseCoordinator::redis(&rejected, "pay:test:broken:").await {
+            Ok(coordinator) => coordinator.try_acquire("ch").await,
+            Err(error) => Err(error),
+        };
+        assert!(
+            acquired.is_err(),
+            "backend failure must surface as an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn lost_redis_lease_marks_the_token_unheld() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_millis(600);
+        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
+        assert!(token.is_held());
+
+        // Expire the key behind the holder's back and let a peer take over.
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut conn = client.get_connection_manager().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("{prefix}lease:ch"))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        let peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
+
+        tokio::time::timeout(ttl * 4, token.lost())
+            .await
+            .expect("losing the lease must wake work waiting on it");
+        assert!(
+            !token.is_held(),
+            "renewal must tell the holder its lease is gone"
+        );
+        assert!(peer.is_held());
+    }
+}

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -74,6 +74,22 @@ impl CapacityLeaseToken {
         true
     }
 
+    /// Run `work` under this lease, abandoning it if the lease is lost first.
+    ///
+    /// Cancelling beats finishing here: once a peer owns the channel, our
+    /// voucher or settlement would race theirs. Dropping `work` part-way is
+    /// safe because every step it performs is a store compare-and-set or an
+    /// idempotent on-chain settle that the new owner can redo.
+    pub async fn guard<T>(&self, work: impl std::future::Future<Output = T>) -> Result<T> {
+        tokio::select! {
+            biased;
+            () = self.lost() => Err(Error::Mpp(
+                "capacity lease was lost before the protected work finished".to_string(),
+            )),
+            done = work => Ok(done),
+        }
+    }
+
     /// Resolves when the lease is lost, so callers can cancel work that is
     /// already in flight instead of only checking before they start.
     pub async fn lost(&self) {
@@ -241,6 +257,9 @@ impl RedisLease {
         let id = uuid::Uuid::new_v4().to_string();
         let key = self.key(channel_id);
         let mut conn = self.connection.clone();
+        // Redis starts the clock when it runs the command, so date the deadline
+        // from before we send: erring early keeps us inside the real TTL.
+        let sent_at = tokio::time::Instant::now();
         let acquired: Option<String> = with_lease_timeout(
             "acquire",
             redis::cmd("SET")
@@ -258,7 +277,7 @@ impl RedisLease {
         }
         let held = Arc::new(tokio::sync::watch::Sender::new(true));
         let renewal = self
-            .spawn_renewal(key, id.clone(), Arc::clone(&held))
+            .spawn_renewal(key, id.clone(), Arc::clone(&held), sent_at + self.ttl)
             .map(RenewalTask);
         Ok(Some(CapacityLeaseToken {
             redis: Some(Box::new(RedisLeaseHold {
@@ -269,44 +288,64 @@ impl RedisLease {
         }))
     }
 
-    /// Extend the TTL every interval so a long stream keeps its lease, and mark
-    /// the lease lost as soon as we can no longer prove we still hold it.
+    /// Extend the TTL for as long as the holder keeps its token, and declare the
+    /// lease lost the moment we can no longer prove we still own the key.
+    ///
+    /// `expires_at` tracks when Redis will drop the key; every wait races it, so
+    /// an unreachable Redis invalidates the lease instead of silently outliving
+    /// it. Renewal is bounded by [`LEASE_IO_TIMEOUT`], so a stalled call cannot
+    /// carry us past the deadline either.
     fn spawn_renewal(
         &self,
         key: String,
         id: String,
         held: Arc<tokio::sync::watch::Sender<bool>>,
+        mut expires_at: tokio::time::Instant,
     ) -> Option<tokio::task::JoinHandle<()>> {
         let handle = tokio::runtime::Handle::try_current().ok()?;
         let mut conn = self.connection.clone();
         let ttl = self.ttl;
         Some(handle.spawn(async move {
-            let mut last_renewal = tokio::time::Instant::now();
             loop {
-                tokio::time::sleep(renew_interval(ttl)).await;
-                let renewed: std::result::Result<i32, redis::RedisError> =
-                    redis::Script::new(RENEW_SCRIPT)
-                        .key(&key)
-                        .arg(&id)
-                        .arg(ttl.as_millis() as u64)
-                        .invoke_async(&mut conn)
-                        .await;
-                match renewed {
-                    Ok(0) => {
+                let renewed = tokio::select! {
+                    biased;
+                    () = tokio::time::sleep_until(expires_at) => None,
+                    () = tokio::time::sleep(renew_interval(ttl)) => {
+                        let sent_at = tokio::time::Instant::now();
+                        let call = with_lease_timeout("renew", async {
+                            redis::Script::new(RENEW_SCRIPT)
+                                .key(&key)
+                                .arg(&id)
+                                .arg(ttl.as_millis() as u64)
+                                .invoke_async::<i32>(&mut conn)
+                                .await
+                        });
+                        tokio::select! {
+                            biased;
+                            () = tokio::time::sleep_until(expires_at) => None,
+                            outcome = call => Some((sent_at, outcome)),
+                        }
+                    }
+                };
+
+                let Some((sent_at, outcome)) = renewed else {
+                    tracing::warn!(key, "capacity lease expired before it could be renewed");
+                    let _ = held.send(false);
+                    return;
+                };
+                match outcome {
+                    Ok(Ok(0)) => {
                         tracing::warn!(key, "capacity lease lost; another holder may own it");
                         let _ = held.send(false);
                         return;
                     }
-                    Ok(_) => last_renewal = tokio::time::Instant::now(),
-                    Err(error) => {
-                        // Past the TTL the key has expired regardless of why we
-                        // could not reach Redis, so stop vouching for the lease.
-                        if last_renewal.elapsed() >= ttl {
-                            tracing::warn!(key, error = %error, "capacity lease expired unrenewed");
-                            let _ = held.send(false);
-                            return;
-                        }
+                    Ok(Ok(_)) => expires_at = sent_at + ttl,
+                    // Keep trying until the deadline arm above fires.
+                    Ok(Err(error)) => {
                         tracing::warn!(key, error = %error, "capacity lease renewal failed");
+                    }
+                    Err(error) => {
+                        tracing::warn!(key, error = %error, "capacity lease renewal timed out");
                     }
                 }
             }
@@ -316,11 +355,15 @@ impl RedisLease {
     async fn release_now(&self, channel_id: &str, id: &str) {
         let key = self.key(channel_id);
         let mut conn = self.connection.clone();
-        let _: std::result::Result<i32, redis::RedisError> = redis::Script::new(RELEASE_SCRIPT)
-            .key(&key)
-            .arg(id)
-            .invoke_async(&mut conn)
-            .await;
+        // The TTL cleans up after a failed release, so never block on one.
+        let _ = with_lease_timeout("release", async {
+            redis::Script::new(RELEASE_SCRIPT)
+                .key(&key)
+                .arg(id)
+                .invoke_async::<i32>(&mut conn)
+                .await
+        })
+        .await;
     }
 
     fn release_spawn(&self, channel_id: &str, id: &str) {
@@ -329,12 +372,14 @@ impl RedisLease {
         let mut conn = self.connection.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
-                let _: std::result::Result<i32, redis::RedisError> =
+                let _ = with_lease_timeout("release", async {
                     redis::Script::new(RELEASE_SCRIPT)
                         .key(&key)
                         .arg(&id)
-                        .invoke_async(&mut conn)
-                        .await;
+                        .invoke_async::<i32>(&mut conn)
+                        .await
+                })
+                .await;
             });
         }
     }
@@ -352,6 +397,13 @@ fn normalize_prefix(prefix: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn guard_runs_work_while_the_lease_is_held() {
+        let c = CapacityLeaseCoordinator::local();
+        let token = c.try_acquire("ch").await.unwrap().expect("lease");
+        assert_eq!(token.guard(async { 7 }).await.unwrap(), 7);
+    }
 
     #[tokio::test]
     async fn local_lease_is_exclusive_until_released() {
@@ -497,5 +549,46 @@ mod redis_tests {
             "renewal must tell the holder its lease is gone"
         );
         assert!(peer.is_held());
+    }
+
+    #[tokio::test]
+    async fn guard_abandons_in_flight_work_when_the_lease_is_lost() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_millis(600);
+        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
+
+        // Hand the channel to a peer while the guarded work is still running.
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut conn = client.get_connection_manager().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("{prefix}lease:ch"))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        let _peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
+
+        let work_finished = Arc::new(Mutex::new(false));
+        let flag = Arc::clone(&work_finished);
+        let guarded = token.guard(async move {
+            tokio::time::sleep(ttl * 10).await;
+            *flag.lock().unwrap() = true;
+        });
+
+        let error = tokio::time::timeout(ttl * 4, guarded)
+            .await
+            .expect("guard must return once the lease is lost")
+            .expect_err("a lost lease must abandon the work");
+        assert!(error.to_string().contains("capacity lease was lost"));
+        assert!(
+            !*work_finished.lock().unwrap(),
+            "guarded work must not run to completion after the lease is lost"
+        );
     }
 }

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -1,7 +1,7 @@
 //! Exclusive capacity leases for delegated MPP sessions.
 //!
-//! Local: process-private `HashSet`. Redis: `SET key token NX EX` + Lua
-//! compare-and-delete so a late Drop cannot steal a newer holder's key.
+//! Local: process-private `HashSet`. Redis: an expiring lease plus a slightly
+//! longer takeover barrier, both carrying the acquisition token.
 //!
 //! A Redis lease is renewed by a task owned by the returned
 //! [`CapacityLeaseToken`], so a lease stays exclusive for as long as the holder
@@ -25,6 +25,14 @@ const LEASE_IO_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(feature = "redis-session-store")]
 fn renew_interval(ttl: Duration) -> Duration {
     (ttl / 3).max(Duration::from_millis(100))
+}
+
+/// Keep a replacement holder out until the old holder's expiry watchdog has
+/// fired. This closes the takeover gap if the lease key alone is deleted,
+/// evicted, or replaced between renewal probes.
+#[cfg(feature = "redis-session-store")]
+fn barrier_ttl(ttl: Duration) -> Duration {
+    ttl + renew_interval(ttl)
 }
 
 /// Keep the holder's Redis key alive; aborts when the token is dropped.
@@ -51,8 +59,17 @@ pub struct CapacityLeaseToken {
 #[cfg(feature = "redis-session-store")]
 struct RedisLeaseHold {
     id: String,
-    held: Arc<tokio::sync::watch::Sender<bool>>,
+    state: Arc<tokio::sync::watch::Sender<LeaseState>>,
     _renewal: Option<RenewalTask>,
+}
+
+/// Local proof of the last Redis renewal. The deadline lets a paused replica
+/// reject its stale token immediately on resume, even before its watchdog runs.
+#[cfg(feature = "redis-session-store")]
+#[derive(Clone, Copy)]
+struct LeaseState {
+    held: bool,
+    expires_at: tokio::time::Instant,
 }
 
 impl CapacityLeaseToken {
@@ -69,7 +86,8 @@ impl CapacityLeaseToken {
     pub fn is_held(&self) -> bool {
         #[cfg(feature = "redis-session-store")]
         if let Some(hold) = &self.redis {
-            return *hold.held.borrow();
+            let state = *hold.state.borrow();
+            return state.held && tokio::time::Instant::now() < state.expires_at;
         }
         true
     }
@@ -95,10 +113,23 @@ impl CapacityLeaseToken {
     pub async fn lost(&self) {
         #[cfg(feature = "redis-session-store")]
         if let Some(hold) = &self.redis {
-            let mut held = hold.held.subscribe();
-            // A closed channel means the holder itself is going away.
-            let _ = held.wait_for(|held| !*held).await;
-            return;
+            let mut state = hold.state.subscribe();
+            loop {
+                let current = *state.borrow();
+                if !current.held || tokio::time::Instant::now() >= current.expires_at {
+                    return;
+                }
+                tokio::select! {
+                    biased;
+                    () = tokio::time::sleep_until(current.expires_at) => return,
+                    changed = state.changed() => {
+                        // A closed channel means the holder itself is going away.
+                        if changed.is_err() {
+                            return;
+                        }
+                    }
+                }
+            }
         }
         // A local lease cannot be taken away while the holder keeps its token.
         std::future::pending().await
@@ -234,17 +265,38 @@ fn lease_error(error: impl std::fmt::Display) -> Error {
     Error::Mpp(format!("capacity lease backend unavailable: {error}"))
 }
 
-/// Both scripts act only while the key still holds the caller's token.
+/// Acquire both keys atomically. A surviving barrier prevents takeover when
+/// the lease key alone disappears before its holder observes the loss.
+#[cfg(feature = "redis-session-store")]
+const ACQUIRE_SCRIPT: &str = r"
+if redis.call('EXISTS', KEYS[1]) == 1 or redis.call('EXISTS', KEYS[2]) == 1 then
+  return 0
+end
+redis.call('PSETEX', KEYS[1], ARGV[2], ARGV[1])
+redis.call('PSETEX', KEYS[2], ARGV[3], ARGV[1])
+return 1
+";
+
+/// Renew only while both keys still prove ownership.
 #[cfg(feature = "redis-session-store")]
 const RENEW_SCRIPT: &str = r"
 if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
-return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+if redis.call('GET', KEYS[2]) ~= ARGV[1] then return 0 end
+redis.call('PEXPIRE', KEYS[1], ARGV[2])
+redis.call('PEXPIRE', KEYS[2], ARGV[3])
+return 1
 ";
 
 #[cfg(feature = "redis-session-store")]
 const RELEASE_SCRIPT: &str = r"
-if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
-return redis.call('DEL', KEYS[1])
+local deleted = 0
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  deleted = deleted + redis.call('DEL', KEYS[1])
+end
+if redis.call('GET', KEYS[2]) == ARGV[1] then
+  deleted = deleted + redis.call('DEL', KEYS[2])
+end
+return deleted
 ";
 
 #[cfg(feature = "redis-session-store")]
@@ -253,36 +305,45 @@ impl RedisLease {
         format!("{}lease:{}", self.prefix, channel_id)
     }
 
+    fn barrier_key(&self, channel_id: &str) -> String {
+        format!("{}lease-barrier:{}", self.prefix, channel_id)
+    }
+
     async fn try_acquire(&self, channel_id: &str) -> Result<Option<CapacityLeaseToken>> {
         let id = uuid::Uuid::new_v4().to_string();
         let key = self.key(channel_id);
+        let barrier_key = self.barrier_key(channel_id);
         let mut conn = self.connection.clone();
         // Redis starts the clock when it runs the command, so date the deadline
         // from before we send: erring early keeps us inside the real TTL.
         let sent_at = tokio::time::Instant::now();
-        let acquired: Option<String> = with_lease_timeout(
+        let acquired: i32 = with_lease_timeout(
             "acquire",
-            redis::cmd("SET")
-                .arg(&key)
+            redis::Script::new(ACQUIRE_SCRIPT)
+                .key(&key)
+                .key(&barrier_key)
                 .arg(&id)
-                .arg("NX")
-                .arg("PX")
                 .arg(self.ttl.as_millis() as u64)
-                .query_async(&mut conn),
+                .arg(barrier_ttl(self.ttl).as_millis() as u64)
+                .invoke_async(&mut conn),
         )
         .await?
         .map_err(lease_error)?;
-        if acquired.is_none() {
+        if acquired == 0 {
             return Ok(None);
         }
-        let held = Arc::new(tokio::sync::watch::Sender::new(true));
+        let expires_at = sent_at + self.ttl;
+        let state = Arc::new(tokio::sync::watch::Sender::new(LeaseState {
+            held: true,
+            expires_at,
+        }));
         let renewal = self
-            .spawn_renewal(key, id.clone(), Arc::clone(&held), sent_at + self.ttl)
+            .spawn_renewal(key, barrier_key, id.clone(), Arc::clone(&state), expires_at)
             .map(RenewalTask);
         Ok(Some(CapacityLeaseToken {
             redis: Some(Box::new(RedisLeaseHold {
                 id,
-                held,
+                state,
                 _renewal: renewal,
             })),
         }))
@@ -298,8 +359,9 @@ impl RedisLease {
     fn spawn_renewal(
         &self,
         key: String,
+        barrier_key: String,
         id: String,
-        held: Arc<tokio::sync::watch::Sender<bool>>,
+        state: Arc<tokio::sync::watch::Sender<LeaseState>>,
         mut expires_at: tokio::time::Instant,
     ) -> Option<tokio::task::JoinHandle<()>> {
         let handle = tokio::runtime::Handle::try_current().ok()?;
@@ -315,8 +377,10 @@ impl RedisLease {
                         let call = with_lease_timeout("renew", async {
                             redis::Script::new(RENEW_SCRIPT)
                                 .key(&key)
+                                .key(&barrier_key)
                                 .arg(&id)
                                 .arg(ttl.as_millis() as u64)
+                                .arg(barrier_ttl(ttl).as_millis() as u64)
                                 .invoke_async::<i32>(&mut conn)
                                 .await
                         });
@@ -330,16 +394,28 @@ impl RedisLease {
 
                 let Some((sent_at, outcome)) = renewed else {
                     tracing::warn!(key, "capacity lease expired before it could be renewed");
-                    let _ = held.send(false);
+                    state.send_replace(LeaseState {
+                        held: false,
+                        expires_at,
+                    });
                     return;
                 };
                 match outcome {
                     Ok(Ok(0)) => {
                         tracing::warn!(key, "capacity lease lost; another holder may own it");
-                        let _ = held.send(false);
+                        state.send_replace(LeaseState {
+                            held: false,
+                            expires_at,
+                        });
                         return;
                     }
-                    Ok(Ok(_)) => expires_at = sent_at + ttl,
+                    Ok(Ok(_)) => {
+                        expires_at = sent_at + ttl;
+                        state.send_replace(LeaseState {
+                            held: true,
+                            expires_at,
+                        });
+                    }
                     // Keep trying until the deadline arm above fires.
                     Ok(Err(error)) => {
                         tracing::warn!(key, error = %error, "capacity lease renewal failed");
@@ -354,11 +430,13 @@ impl RedisLease {
 
     async fn release_now(&self, channel_id: &str, id: &str) {
         let key = self.key(channel_id);
+        let barrier_key = self.barrier_key(channel_id);
         let mut conn = self.connection.clone();
         // The TTL cleans up after a failed release, so never block on one.
         let _ = with_lease_timeout("release", async {
             redis::Script::new(RELEASE_SCRIPT)
                 .key(&key)
+                .key(&barrier_key)
                 .arg(id)
                 .invoke_async::<i32>(&mut conn)
                 .await
@@ -368,6 +446,7 @@ impl RedisLease {
 
     fn release_spawn(&self, channel_id: &str, id: &str) {
         let key = self.key(channel_id);
+        let barrier_key = self.barrier_key(channel_id);
         let id = id.to_string();
         let mut conn = self.connection.clone();
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -375,6 +454,7 @@ impl RedisLease {
                 let _ = with_lease_timeout("release", async {
                     redis::Script::new(RELEASE_SCRIPT)
                         .key(&key)
+                        .key(&barrier_key)
                         .arg(&id)
                         .invoke_async::<i32>(&mut conn)
                         .await
@@ -435,26 +515,29 @@ mod redis_tests {
             return;
         };
         let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
-        let a = CapacityLeaseCoordinator::redis(&url, &prefix)
+        let ttl = Duration::from_millis(600);
+        let a = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
             .unwrap();
-        let b = CapacityLeaseCoordinator::redis(&url, &prefix)
+        let b = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
             .unwrap();
 
-        let token_a = a.try_acquire("ch").await.unwrap().expect("a");
+        let mut token_a = a.try_acquire("ch").await.unwrap().expect("a");
         assert!(b.try_acquire("ch").await.unwrap().is_none());
 
-        // Simulate TTL expiry, then B acquires; A's stale release must not win.
+        // Stop A's watchdog and wait for both of its keys to expire naturally.
+        // Its local deadline is stale before B is allowed to acquire.
+        token_a.redis.as_mut().expect("redis hold")._renewal.take();
+        tokio::time::sleep(barrier_ttl(ttl) + Duration::from_millis(100)).await;
+        assert!(!token_a.is_held());
+
+        let token_b = b.try_acquire("ch").await.unwrap().expect("b");
         let key = format!("{prefix}lease:ch");
         let client = redis::Client::open(url.as_str()).unwrap();
         let mut conn = client.get_connection_manager().await.unwrap();
-        let _: () = redis::cmd("DEL")
-            .arg(&key)
-            .query_async(&mut conn)
-            .await
-            .unwrap();
-        let token_b = b.try_acquire("ch").await.unwrap().expect("b");
+
+        // A's late release must not delete B's token.
         a.release_async("ch", &token_a).await;
         let value: Option<String> = redis::cmd("GET")
             .arg(&key)
@@ -531,7 +614,8 @@ mod redis_tests {
         let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
         assert!(token.is_held());
 
-        // Expire the key behind the holder's back and let a peer take over.
+        // Delete only the lease key behind the holder's back. The barrier must
+        // keep a peer out until the original holder observes the loss.
         let client = redis::Client::open(url.as_str()).unwrap();
         let mut conn = client.get_connection_manager().await.unwrap();
         let _: () = redis::cmd("DEL")
@@ -539,7 +623,10 @@ mod redis_tests {
             .query_async(&mut conn)
             .await
             .unwrap();
-        let peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
+        assert!(
+            coordinator.try_acquire("ch").await.unwrap().is_none(),
+            "takeover barrier must block a peer after early lease deletion"
+        );
 
         tokio::time::timeout(ttl * 4, token.lost())
             .await
@@ -548,7 +635,115 @@ mod redis_tests {
             !token.is_held(),
             "renewal must tell the holder its lease is gone"
         );
+        coordinator.release_async("ch", &token).await;
+        let peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
         assert!(peer.is_held());
+    }
+
+    #[tokio::test]
+    async fn loss_is_persisted_without_an_active_waiter() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_millis(600);
+        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
+
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut conn = client.get_connection_manager().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("{prefix}lease:ch"))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+
+        // No receiver is active while the watchdog detects the loss.
+        tokio::time::sleep(renew_interval(ttl) * 2).await;
+        assert!(!token.is_held(), "loss must persist in the watch value");
+        assert!(
+            token.guard(async { 7 }).await.is_err(),
+            "work started after detection must fail immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_local_deadline_rejects_a_stale_token() {
+        let token = CapacityLeaseToken {
+            redis: Some(Box::new(RedisLeaseHold {
+                id: "stale".to_string(),
+                state: Arc::new(tokio::sync::watch::Sender::new(LeaseState {
+                    held: true,
+                    expires_at: tokio::time::Instant::now(),
+                })),
+                _renewal: None,
+            })),
+        };
+
+        assert!(!token.is_held());
+        assert!(
+            token.guard(async { 7 }).await.is_err(),
+            "a paused replica must reject an expired token on resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn early_deletion_after_renewal_cannot_overlap_holders() {
+        let Some(url) = redis_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_millis(600);
+        let owner = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let token = owner.try_acquire("ch").await.unwrap().expect("owner");
+
+        // Wait for proof that one renewal completed, then delete only the lease
+        // key just after it. Sleeping for one interval is not synchronization.
+        let initial_expiry = token
+            .redis
+            .as_ref()
+            .expect("redis hold")
+            .state
+            .borrow()
+            .expires_at;
+        let mut state = token.redis.as_ref().expect("redis hold").state.subscribe();
+        tokio::time::timeout(ttl, async {
+            loop {
+                if state.borrow().expires_at > initial_expiry {
+                    break;
+                }
+                state.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("renewal must complete");
+
+        let client = redis::Client::open(url.as_str()).unwrap();
+        let mut conn = client.get_connection_manager().await.unwrap();
+        let _: () = redis::cmd("DEL")
+            .arg(format!("{prefix}lease:ch"))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+
+        assert!(
+            peer.try_acquire("ch").await.unwrap().is_none(),
+            "the takeover barrier must prevent overlapping holders"
+        );
+        tokio::time::timeout(ttl, token.lost())
+            .await
+            .expect("owner must detect the loss before the barrier expires");
+        owner.release_async("ch", &token).await;
+        assert!(peer.try_acquire("ch").await.unwrap().is_some());
     }
 
     #[tokio::test]
@@ -564,7 +759,8 @@ mod redis_tests {
             .unwrap();
         let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
 
-        // Hand the channel to a peer while the guarded work is still running.
+        // Delete only the lease key while guarded work is still running. A peer
+        // remains blocked by the barrier until the holder cancels its work.
         let client = redis::Client::open(url.as_str()).unwrap();
         let mut conn = client.get_connection_manager().await.unwrap();
         let _: () = redis::cmd("DEL")
@@ -572,7 +768,7 @@ mod redis_tests {
             .query_async(&mut conn)
             .await
             .unwrap();
-        let _peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
+        assert!(coordinator.try_acquire("ch").await.unwrap().is_none());
 
         let work_finished = Arc::new(Mutex::new(false));
         let flag = Arc::clone(&work_finished);
@@ -589,6 +785,11 @@ mod redis_tests {
         assert!(
             !*work_finished.lock().unwrap(),
             "guarded work must not run to completion after the lease is lost"
+        );
+        coordinator.release_async("ch", &token).await;
+        assert!(
+            coordinator.try_acquire("ch").await.unwrap().is_some(),
+            "a peer may acquire only after the old holder has cancelled"
         );
     }
 }

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -296,18 +296,7 @@ impl DelegatedSessionStreamMeter {
         // Losing the lease mid-authorization means another replica now owns the
         // channel, so abandon this charge rather than race it to the store.
         let accepted = match self.forward.capacity_lease() {
-            Some(lease) => {
-                tokio::select! {
-                    biased;
-                    () = lease.lost() => {
-                        return Err(box_error(std::io::Error::other(format!(
-                            "delegated session {} lost its capacity lease",
-                            self.forward.channel_id
-                        ))));
-                    }
-                    accepted = authorize => accepted,
-                }
-            }
+            Some(lease) => lease.guard(authorize).await.map_err(box_error)?,
             None => authorize.await,
         }
         .map_err(box_error)?;

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -65,6 +65,14 @@ impl SessionStreamContext {
             .max(self.baseline_base_units)
     }
 
+    pub async fn refresh_committed_base_units(&self) -> u64 {
+        self.session_mpp
+            .refresh_committed_watermark(&self.session_id)
+            .await
+            .unwrap_or(self.baseline_base_units)
+            .max(self.baseline_base_units)
+    }
+
     pub fn settlement(&self) -> StablecoinSettlement {
         StablecoinSettlement::new(self.session_mpp.decimals())
     }
@@ -281,12 +289,28 @@ impl DelegatedSessionStreamMeter {
             self.authorization_exhausted |= exhausted_by_reprice;
             return Ok(());
         }
-        let accepted = self
+        let authorize = self
             .forward
             .handle
-            .authorize_delegated_usage(&self.forward.channel_id, amount)
-            .await
-            .map_err(box_error)?;
+            .authorize_delegated_usage(&self.forward.channel_id, amount);
+        // Losing the lease mid-authorization means another replica now owns the
+        // channel, so abandon this charge rather than race it to the store.
+        let accepted = match self.forward.capacity_lease() {
+            Some(lease) => {
+                tokio::select! {
+                    biased;
+                    () = lease.lost() => {
+                        return Err(box_error(std::io::Error::other(format!(
+                            "delegated session {} lost its capacity lease",
+                            self.forward.channel_id
+                        ))));
+                    }
+                    accepted = authorize => accepted,
+                }
+            }
+            None => authorize.await,
+        }
+        .map_err(box_error)?;
         self.gate.record_commit(accepted);
         self.authorization_exhausted |= exhausted_by_reprice;
         Ok(())
@@ -467,6 +491,13 @@ async fn wait_for_commit(context: &SessionStreamContext, target: u64) -> Result<
             let committed = context.committed_base_units();
             if committed >= target {
                 return Ok(committed);
+            }
+            // Another replica (or a restarted process) may have accepted the
+            // client voucher into the durable store without updating this
+            // process's cache — refresh before sleeping again.
+            let refreshed = context.refresh_committed_base_units().await;
+            if refreshed >= target {
+                return Ok(refreshed);
             }
             tokio::time::sleep(COMMIT_POLL_INTERVAL).await;
         }
@@ -1221,6 +1252,8 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
         };
         let reservation = session
             .reserve_delegated_capacity(&state.channel_id, 1_000)
+            .await
+            .unwrap()
             .expect("session capacity should be available");
         let forward = SessionForward::delegated(
             session.clone(),


### PR DESCRIPTION
## TL;DR

Stacked on #406: rehydrate operator watermark/lifecycle from Redis ChannelStore, and exclusive capacity leases (`SET NX PX` + compare-and-delete, self-renewing) across replicas.

## What / Why / How

| | |
|---|---|
| **What** | Boot rehydrate + Redis capacity leases |
| **Why** | #406 left watermarks/capacity/lifecycle process-local |
| **How** | `rehydrate_from_store` + store refresh; `CapacityLeaseCoordinator` |

```mermaid
flowchart TD
  subgraph before [Before — Redis vouchers only]
    R1[(Redis ChannelStore)]
    WM1[committed_watermarks local]
    Cap1[capacity HashSet local]
    Life1[lifecycle local]
    R1 -->|voucher CAS| Auth1[authorize]
    WM1 --> Auth1
    WM1 -->|poll| Stream1[wait_for_commit]
    Cap1 --> Gate1[gate reserve]
  end

  subgraph after [After — operator state shared]
    R2[(Redis ChannelStore)]
    WM2[watermark cache]
    Cap2[(Redis lease, renewed while held)]
    Life2[lifecycle rehydrated]
    R2 -->|get_channel refresh| WM2
    R2 -->|list_channels at boot| Life2
    WM2 --> Auth2[authorize + wait]
    Cap2 --> Gate2[gate reserve]
  end
```

## Lease safety

A lease lives as long as its holder: the token owns a renewal task, and a slightly longer token-bound takeover barrier prevents a peer from entering if the lease key is deleted, evicted, or replaced before loss detection. Acquire, renew, and release update both keys atomically. If ownership is lost or expires, `lost()` wakes and every lease-protected path (`guard`) abandons its work. Backend failures return `Err`, which the gate answers with 503 rather than 402.

## Read order

1. `session_capacity.rs`
2. `session.rs` — rehydrate / refresh / async reserve / guarded lifecycle + close
3. `session_stream.rs` → `gate.rs` → `start.rs`

## Test plan

```bash
cd rust
PAY_SESSION_REDIS_URL=redis://127.0.0.1:6379 \
  cargo test -p pay-core --features "server,redis-session-store" --lib
cargo clippy --workspace --all-targets -- -D warnings
```

## Reviewer note

The lease is an exclusion mechanism, not a fencing token: pay-kit's `ChannelStore` has no lease-aware compare-and-set, so correctness under a lost lease still rests on the store's monotonic cumulative CAS and idempotent on-chain settle. Guarding every path closes the window where we would knowingly race a new owner; a true fencing token needs a pay-kit API change and is out of scope here, as are lifecycle leader election and replica-shared `last_activity`.