### PR TITLE
test(core): Redis session CI harness and lease composition coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
         with:
           workspaces: rust
       - run: cargo fmt --check
-      - run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
+      - name: Clippy (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Clippy (server + redis-session-store)
+        run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
   # ── Rust tests + coverage ──
   rust-test:
     name: Rust tests + coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,24 @@ jobs:
         with:
           workspaces: rust
       - run: cargo fmt --check
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
   # ── Rust tests + coverage ──
   rust-test:
     name: Rust tests + coverage
     runs-on: ubuntu-latest
+    # Redis leases + durable session store tests require a live backend.
+    # Soft-skip locally; PAY_REQUIRE_REDIS_TESTS (set below) fails CI if the
+    # URL is missing so redis-session-store coverage cannot go vacuous.
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     defaults:
       run:
         working-directory: ./rust
@@ -86,7 +99,9 @@ jobs:
       - name: Run tests with coverage
         env:
           SURFPOOL_REPORT: "1"
-        run: cargo llvm-cov --workspace --features server --exclude pay --ignore-filename-regex 'crates/cli/' --json --output-path coverage.json
+          PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
+          PAY_REQUIRE_REDIS_TESTS: "1"
+        run: cargo llvm-cov --workspace --features "server,redis-session-store" --exclude pay --ignore-filename-regex 'crates/cli/' --json --output-path coverage.json
       - name: Upload Rust coverage
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -71,19 +71,11 @@ jobs:
         run: pnpm --filter @solana/pay test
 
   # ── Rust CLI (rust/) ──
+  # Fast default-feature gate for PRs. Redis-backed lease/session coverage
+  # lives in ci.yml (rust-check / rust-test) so PRs do not pay for it twice.
   cli-check:
     name: CLI check
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
     defaults:
       run:
         working-directory: ./rust
@@ -100,17 +92,8 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
-      - name: Lint (default features)
+      - name: Lint
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: Lint (server + redis-session-store)
-        run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
-
-      - name: Test (default features)
+      - name: Test
         run: cargo test --workspace
-
-      - name: Test (server + redis-session-store)
-        env:
-          PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
-          PAY_REQUIRE_REDIS_TESTS: "1"
-        run: cargo test --workspace --features "server,redis-session-store"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -100,10 +100,16 @@ jobs:
       - name: Format
         run: cargo fmt --check
 
-      - name: Lint
+      - name: Lint (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Lint (server + redis-session-store)
         run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
 
-      - name: Test
+      - name: Test (default features)
+        run: cargo test --workspace
+
+      - name: Test (server + redis-session-store)
         env:
           PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
           PAY_REQUIRE_REDIS_TESTS: "1"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -74,6 +74,16 @@ jobs:
   cli-check:
     name: CLI check
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     defaults:
       run:
         working-directory: ./rust
@@ -91,7 +101,10 @@ jobs:
         run: cargo fmt --check
 
       - name: Lint
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
 
       - name: Test
-        run: cargo test --workspace
+        env:
+          PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
+          PAY_REQUIRE_REDIS_TESTS: "1"
+        run: cargo test --workspace --features "server,redis-session-store"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,6 +27,16 @@ jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
@@ -85,9 +95,12 @@ jobs:
       - name: Format
         run: cargo fmt --check
       - name: Lint
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
       - name: Test
-        run: cargo test --workspace
+        env:
+          PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
+          PAY_REQUIRE_REDIS_TESTS: "1"
+        run: cargo test --workspace --features "server,redis-session-store"
 
       - name: Create tag
         if: github.event_name == 'workflow_dispatch' && inputs.dry-run == false

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -94,9 +94,13 @@ jobs:
 
       - name: Format
         run: cargo fmt --check
-      - name: Lint
+      - name: Lint (default features)
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Lint (server + redis-session-store)
         run: cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings
-      - name: Test
+      - name: Test (default features)
+        run: cargo test --workspace
+      - name: Test (server + redis-session-store)
         env:
           PAY_SESSION_REDIS_URL: redis://127.0.0.1:6379
           PAY_REQUIRE_REDIS_TESTS: "1"

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -84,7 +84,7 @@ async fn session_channel_store() -> pay_core::Result<(
                     ))
                 })?;
         tracing::info!("using durable Redis channel store and capacity leases for MPP sessions");
-        return Ok((Arc::new(store), capacity));
+        Ok((Arc::new(store), capacity))
     }
 
     #[cfg(not(feature = "redis-session-store"))]

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -1521,6 +1521,41 @@ fn session_receipt_annotation(network: &str, reference: String) -> ReceiptAnnota
     }
 }
 
+/// Map a capacity-reservation outcome onto gate responses.
+///
+/// Contention stays on the payment-required path (402). Backend failure must
+/// never look like "pay again" — it is our outage (503).
+#[allow(clippy::result_large_err)] // Err carries the existing GateDecision tree
+fn map_capacity_reservation(
+    channel_id: &str,
+    reservation: crate::Result<Option<DelegatedCapacityLease>>,
+) -> Result<DelegatedCapacityLease, GateDecision> {
+    match reservation {
+        Ok(Some(reservation)) => Ok(reservation),
+        Ok(None) => Err(GateDecision::Respond(GateResponse::json(
+            StatusCode::PAYMENT_REQUIRED,
+            Bytes::from_static(
+                br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#,
+            ),
+        ))),
+        // A lease backend outage is our failure, not the payer's: keep it out of
+        // the payment-required path so retries stay meaningful.
+        Err(error) => {
+            tracing::error!(
+                channel_id = %channel_id,
+                error = %error,
+                "session capacity lease backend unavailable"
+            );
+            Err(GateDecision::Respond(GateResponse::json(
+                StatusCode::SERVICE_UNAVAILABLE,
+                Bytes::from_static(
+                    br#"{"error":"session_capacity_unavailable","message":"Session capacity coordination is temporarily unavailable; retry shortly."}"#,
+                ),
+            )))
+        }
+    }
+}
+
 /// Process a session credential and map the outcome to a [`GateDecision`].
 async fn session_authorized(
     sm: &SessionMpp,
@@ -1569,30 +1604,14 @@ async fn session_authorized(
                     .unwrap_or_default(),
                 ));
             }
-            let reservation = match handle
-                .reserve_delegated_capacity(&state.channel_id, available_base_units)
-                .await
-            {
-                Ok(Some(reservation)) => reservation,
-                Ok(None) => {
-                    return GateDecision::Respond(GateResponse::json(
-                        StatusCode::PAYMENT_REQUIRED,
-                        Bytes::from_static(br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#),
-                    ));
-                }
-                // A lease backend outage is our failure, not the payer's: keep it
-                // out of the payment-required path so retries stay meaningful.
-                Err(error) => {
-                    tracing::error!(
-                        channel_id = %state.channel_id,
-                        error = %error,
-                        "session capacity lease backend unavailable"
-                    );
-                    return GateDecision::Respond(GateResponse::json(
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        Bytes::from_static(br#"{"error":"session_capacity_unavailable","message":"Session capacity coordination is temporarily unavailable; retry shortly."}"#),
-                    ));
-                }
+            let reservation = match map_capacity_reservation(
+                &state.channel_id,
+                handle
+                    .reserve_delegated_capacity(&state.channel_id, available_base_units)
+                    .await,
+            ) {
+                Ok(reservation) => reservation,
+                Err(decision) => return decision,
             };
             let props = metering::RequestProperties {
                 body_size: req.content_length,
@@ -1963,5 +1982,42 @@ mod tests {
             gate.evaluate(&req(&Method::GET, "v1/anything")).await,
             GateDecision::Passthrough
         ));
+    }
+
+    #[test]
+    fn gate_maps_lease_contention_to_402_not_503() {
+        let Err(decision) = map_capacity_reservation("ch", Ok(None)) else {
+            panic!("contention must map to a gate response");
+        };
+        let GateDecision::Respond(response) = decision else {
+            panic!("expected Respond");
+        };
+        assert_eq!(response.status, StatusCode::PAYMENT_REQUIRED);
+        let body = String::from_utf8_lossy(&response.body);
+        assert!(
+            body.contains("session_capacity_reserved"),
+            "contention must stay on the payment-required path: {body}"
+        );
+        assert!(!body.contains("session_capacity_unavailable"));
+    }
+
+    #[test]
+    fn gate_maps_lease_backend_error_to_503_not_402() {
+        let Err(decision) = map_capacity_reservation(
+            "ch",
+            Err(crate::Error::Mpp("capacity lease backend unavailable".into())),
+        ) else {
+            panic!("backend error must map to a gate response");
+        };
+        let GateDecision::Respond(response) = decision else {
+            panic!("expected Respond");
+        };
+        assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
+        let body = String::from_utf8_lossy(&response.body);
+        assert!(
+            body.contains("session_capacity_unavailable"),
+            "backend failure must not look like payment-required: {body}"
+        );
+        assert!(!body.contains("session_capacity_reserved"));
     }
 }

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -2005,7 +2005,9 @@ mod tests {
     fn gate_maps_lease_backend_error_to_503_not_402() {
         let Err(decision) = map_capacity_reservation(
             "ch",
-            Err(crate::Error::Mpp("capacity lease backend unavailable".into())),
+            Err(crate::Error::Mpp(
+                "capacity lease backend unavailable".into(),
+            )),
         ) else {
             panic!("backend error must map to a gate response");
         };

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -512,6 +512,21 @@ struct SessionLifecycleRunloop {
     last_activity: HashMap<String, Instant>,
 }
 
+/// Close one channel under an already-held lease. Extracted so composition
+/// tests can drive the same guard → release wiring as `close_due_channels`.
+async fn close_channel_under_lease(
+    runtime: SessionOperatorRuntime,
+    channel_id: String,
+    token: CapacityLeaseToken,
+) -> (String, Result<SessionCloseResult>) {
+    let result = token
+        .guard(runtime.operator_close_channel(&channel_id))
+        .await
+        .and_then(|closed| closed);
+    runtime.release_capacity(&channel_id, &token);
+    (channel_id, result)
+}
+
 impl SessionLifecycleRunloop {
     fn new(
         runtime: SessionOperatorRuntime,
@@ -634,14 +649,7 @@ impl SessionLifecycleRunloop {
                 }
             };
             let runtime = self.runtime.clone();
-            closing.push(async move {
-                let result = token
-                    .guard(runtime.operator_close_channel(&channel_id))
-                    .await
-                    .and_then(|closed| closed);
-                runtime.release_capacity(&channel_id, &token);
-                (channel_id, result)
-            });
+            closing.push(close_channel_under_lease(runtime, channel_id, token));
         }
 
         for (channel_id, close_result) in futures_util::future::join_all(closing).await {
@@ -2573,8 +2581,10 @@ mod redis_e2e_tests {
     use crate::server::metering::{RequestProperties, UptoSettlementPlan};
     use crate::server::session_capacity::CapacityLeaseCoordinator;
     use crate::server::session_capacity::redis_test_support::{
-        assert_no_overlapping_holders, del_lease_key, redis_test_url, unique_prefix,
+        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url,
+        unique_prefix,
     };
+    use crate::server::session_capacity::CAPACITY_LEASE_TTL;
     use http::HeaderMap;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
     use pay_kit::mpp::store::RedisChannelStore;
@@ -2646,16 +2656,16 @@ mod redis_e2e_tests {
         }
     }
 
-    async fn open_delegated_pair(
+    async fn open_delegated_pair_with_ttl(
         url: &str,
         prefix: &str,
+        ttl: Duration,
     ) -> (Arc<SessionMpp>, Arc<SessionMpp>, String, SessionHandle) {
         let store: Arc<dyn ChannelStore> = Arc::new(
             RedisChannelStore::connect(url, prefix.to_string())
                 .await
                 .expect("redis store"),
         );
-        let ttl = Duration::from_millis(600);
         let first = Arc::new(SessionMpp::new_with_stores(
             config(),
             "redis-e2e",
@@ -2683,6 +2693,14 @@ mod redis_e2e_tests {
             panic!("expected open");
         };
         (first, second, opened.channel_id, handle)
+    }
+
+    /// Default to the production TTL: only loss-injection tests want a short one.
+    async fn open_delegated_pair(
+        url: &str,
+        prefix: &str,
+    ) -> (Arc<SessionMpp>, Arc<SessionMpp>, String, SessionHandle) {
+        open_delegated_pair_with_ttl(url, prefix, CAPACITY_LEASE_TTL).await
     }
 
     #[tokio::test]
@@ -2719,7 +2737,7 @@ mod redis_e2e_tests {
         );
 
         drop(lease);
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        await_released(&url, &prefix, &channel_id, CAPACITY_LEASE_TTL).await;
 
         assert!(second.rehydrate_from_store().await.unwrap() >= 1);
         assert_eq!(
@@ -2764,14 +2782,25 @@ mod redis_e2e_tests {
         };
         let prefix = unique_prefix("rehydrate-sealed");
         let (first, second, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+        assert_eq!(
+            second.rehydrate_from_store().await.unwrap(),
+            1,
+            "open channel must be present before sealing"
+        );
         first
             .operator_runtime
             .channel_store
             .mark_sealed(&channel_id)
             .await
             .expect("seal");
-        assert_eq!(second.rehydrate_from_store().await.unwrap(), 0);
-        assert_eq!(second.committed_watermark(&channel_id), None);
+        let restarted = SessionMpp::new_with_stores(
+            config(),
+            "redis-e2e",
+            Arc::clone(&first.operator_runtime.channel_store),
+            CapacityLeaseCoordinator::redis(&url, &prefix).await.unwrap(),
+        );
+        assert_eq!(restarted.rehydrate_from_store().await.unwrap(), 0);
+        assert_eq!(restarted.committed_watermark(&channel_id), None);
     }
 
     #[tokio::test]
@@ -2781,29 +2810,21 @@ mod redis_e2e_tests {
             return;
         };
         let prefix = unique_prefix("settle-loss");
-        let ttl = Duration::from_millis(600);
-        let (first, second, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+        let ttl = Duration::from_secs(2);
+        let peer_coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        let (first, second, channel_id, _) =
+            open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
         let lease = first
             .reserve_delegated_capacity(&channel_id, CAP)
             .await
             .unwrap()
             .expect("lease");
-        assert_no_overlapping_holders(
-            &CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-                .await
-                .unwrap(),
-            &channel_id,
-        )
-        .await;
+        assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
 
         del_lease_key(&url, &prefix, &channel_id).await;
-        assert_no_overlapping_holders(
-            &CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-                .await
-                .unwrap(),
-            &channel_id,
-        )
-        .await;
+        assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
         tokio::time::timeout(ttl * 4, lease.lost())
             .await
             .expect("holder must observe lease loss");
@@ -2829,9 +2850,7 @@ mod redis_e2e_tests {
             error.contains("capacity lease was lost"),
             "unexpected settle error: {error}"
         );
-        // Peer remains blocked until the abandoned holder's Drop releases.
-        // After settle returns Err, forward (and lease) were dropped.
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        await_released(&url, &prefix, &channel_id, ttl).await;
         assert!(
             second
                 .reserve_delegated_capacity(&channel_id, 0)
@@ -2843,45 +2862,87 @@ mod redis_e2e_tests {
     }
 
     #[tokio::test]
+    async fn auto_close_defers_when_a_peer_holds_the_lease() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("lifecycle-contention");
+        let (session, peer, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+
+        let _peer_lease = peer
+            .reserve_delegated_capacity(&channel_id, 0)
+            .await
+            .unwrap()
+            .expect("peer lease");
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let mut runloop = SessionLifecycleRunloop::new(session.operator_runtime.clone(), rx);
+        runloop.close_delay = Some(Duration::ZERO);
+        runloop
+            .last_activity
+            .insert(channel_id.clone(), Instant::now() - Duration::from_secs(1));
+
+        runloop.close_due_channels().await;
+
+        assert!(
+            runloop.last_activity.contains_key(&channel_id),
+            "a channel held by a peer must be rescheduled, not dropped"
+        );
+        assert_eq!(
+            session.refresh_committed_watermark(&channel_id).await,
+            Some(0),
+            "a deferred close must not touch the durable channel state"
+        );
+    }
+
+    #[tokio::test]
     async fn lifecycle_auto_close_abandons_when_lease_lost() {
         let Some(url) = redis_test_url() else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
         let prefix = unique_prefix("lifecycle-loss");
-        let ttl = Duration::from_millis(600);
-        let (session, peer, channel_id, _) = open_delegated_pair(&url, &prefix).await;
-
-        // Mimic close_due_channels: reserve, then guard close-shaped work. Loss
-        // mid-guard must abandon before a peer can take over.
-        let lease = session
-            .reserve_delegated_capacity(&channel_id, 0)
-            .await
-            .unwrap()
-            .expect("lifecycle lease");
+        let ttl = Duration::from_secs(2);
         let peer_coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
             .unwrap();
+        let (session, peer, channel_id, _) =
+            open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
+
+        // Drive the extracted close_channel_under_lease path (same wiring as
+        // close_due_channels). Loss before the guarded close must abandon work
+        // and release so a peer can take over.
+        let token = session
+            .operator_runtime
+            .reserve_capacity(&channel_id)
+            .await
+            .unwrap()
+            .expect("lifecycle lease");
         assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
 
         del_lease_key(&url, &prefix, &channel_id).await;
         assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
-
-        let work_finished = Arc::new(std::sync::Mutex::new(false));
-        let flag = Arc::clone(&work_finished);
-        let guarded = lease.guard(async move {
-            tokio::time::sleep(ttl * 10).await;
-            *flag.lock().unwrap() = true;
-            Ok::<(), crate::Error>(())
-        });
-        let error = tokio::time::timeout(ttl * 4, guarded)
+        tokio::time::timeout(ttl * 4, token.lost())
             .await
-            .expect("guard must return on lease loss")
-            .expect_err("lost lease must abandon auto-close work");
-        assert!(error.to_string().contains("capacity lease was lost"));
-        assert!(!*work_finished.lock().unwrap());
-        drop(lease);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+            .expect("holder must observe lease loss");
+
+        let (closed_id, result) = close_channel_under_lease(
+            session.operator_runtime.clone(),
+            channel_id.clone(),
+            token,
+        )
+        .await;
+        assert_eq!(closed_id, channel_id);
+        let error = match result {
+            Ok(_) => panic!("lost lease must abandon auto-close"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("capacity lease was lost"),
+            "unexpected close error: {error}"
+        );
+        await_released(&url, &prefix, &channel_id, ttl).await;
         assert!(
             peer.reserve_delegated_capacity(&channel_id, 0)
                 .await

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -2579,18 +2579,15 @@ mod redis_e2e_tests {
     use crate::client::session::SessionHandle;
     use crate::server::gate::{SessionForward, settle_delegated_session};
     use crate::server::metering::{RequestProperties, UptoSettlementPlan};
+    use crate::server::session_capacity::CAPACITY_LEASE_TTL;
     use crate::server::session_capacity::CapacityLeaseCoordinator;
     use crate::server::session_capacity::redis_test_support::{
-        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url,
-        unique_prefix,
+        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url, unique_prefix,
     };
-    use crate::server::session_capacity::CAPACITY_LEASE_TTL;
     use http::HeaderMap;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
     use pay_kit::mpp::store::RedisChannelStore;
-    use pay_types::metering::{
-        BillingUnit, MeterDimension, MeterDirection, Metering, PriceTier,
-    };
+    use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering, PriceTier};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -2740,10 +2737,7 @@ mod redis_e2e_tests {
         await_released(&url, &prefix, &channel_id, CAPACITY_LEASE_TTL).await;
 
         assert!(second.rehydrate_from_store().await.unwrap() >= 1);
-        assert_eq!(
-            second.load_committed_watermark(&channel_id).await,
-            Some(88)
-        );
+        assert_eq!(second.load_committed_watermark(&channel_id).await, Some(88));
         assert!(
             second
                 .reserve_delegated_capacity(&channel_id, 0)
@@ -2797,7 +2791,9 @@ mod redis_e2e_tests {
             config(),
             "redis-e2e",
             Arc::clone(&first.operator_runtime.channel_store),
-            CapacityLeaseCoordinator::redis(&url, &prefix).await.unwrap(),
+            CapacityLeaseCoordinator::redis(&url, &prefix)
+                .await
+                .unwrap(),
         );
         assert_eq!(restarted.rehydrate_from_store().await.unwrap(), 0);
         assert_eq!(restarted.committed_watermark(&channel_id), None);
@@ -2814,8 +2810,7 @@ mod redis_e2e_tests {
         let peer_coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
             .unwrap();
-        let (first, second, channel_id, _) =
-            open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
+        let (first, second, channel_id, _) = open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
         let lease = first
             .reserve_delegated_capacity(&channel_id, CAP)
             .await
@@ -2907,8 +2902,7 @@ mod redis_e2e_tests {
         let peer_coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
             .unwrap();
-        let (session, peer, channel_id, _) =
-            open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
+        let (session, peer, channel_id, _) = open_delegated_pair_with_ttl(&url, &prefix, ttl).await;
 
         // Drive the extracted close_channel_under_lease path (same wiring as
         // close_due_channels). Loss before the guarded close must abandon work
@@ -2927,12 +2921,9 @@ mod redis_e2e_tests {
             .await
             .expect("holder must observe lease loss");
 
-        let (closed_id, result) = close_channel_under_lease(
-            session.operator_runtime.clone(),
-            channel_id.clone(),
-            token,
-        )
-        .await;
+        let (closed_id, result) =
+            close_channel_under_lease(session.operator_runtime.clone(), channel_id.clone(), token)
+                .await;
         assert_eq!(closed_id, channel_id);
         let error = match result {
             Ok(_) => panic!("lost lease must abandon auto-close"),

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -2569,20 +2569,22 @@ mod tests {
 mod redis_e2e_tests {
     use super::*;
     use crate::client::session::SessionHandle;
+    use crate::server::gate::{SessionForward, settle_delegated_session};
+    use crate::server::metering::{RequestProperties, UptoSettlementPlan};
     use crate::server::session_capacity::CapacityLeaseCoordinator;
+    use crate::server::session_capacity::redis_test_support::{
+        assert_no_overlapping_holders, del_lease_key, redis_test_url, unique_prefix,
+    };
+    use http::HeaderMap;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
     use pay_kit::mpp::store::RedisChannelStore;
+    use pay_types::metering::{
+        BillingUnit, MeterDimension, MeterDirection, Metering, PriceTier,
+    };
     use std::sync::Arc;
+    use std::time::Duration;
 
     const CAP: u64 = 1_000_000;
-
-    fn redis_url() -> Option<String> {
-        std::env::var("PAY_SESSION_REDIS_URL")
-            .or_else(|_| std::env::var("PAY_KIT_TEST_REDIS_URL"))
-            .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
-    }
 
     fn config() -> SessionConfig {
         SessionConfig {
@@ -2606,26 +2608,70 @@ mod redis_e2e_tests {
         Box::new(MemorySigner::from_bytes(&kp).unwrap())
     }
 
-    #[tokio::test]
-    async fn redis_rehydrate_and_lease_across_replicas() {
-        let Some(url) = redis_url() else {
-            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
-            return;
-        };
-        let prefix = format!("pay:test:session:{}:", uuid::Uuid::new_v4().simple());
+    fn output_bytes_plan() -> UptoSettlementPlan {
+        UptoSettlementPlan {
+            metering: Metering {
+                dimensions: vec![MeterDimension {
+                    direction: MeterDirection::Output,
+                    unit: BillingUnit::Tokens,
+                    scale: 1,
+                    period: None,
+                    tiers: vec![PriceTier {
+                        up_to: None,
+                        price_usd: 0.000001,
+                        condition: None,
+                        notes: None,
+                        splits: vec![],
+                    }],
+                    meter: None,
+                }],
+                variants: vec![],
+                sku_tiers: vec![],
+                splits: vec![],
+                schemes: None,
+                min_usd: None,
+                upto: None,
+            },
+            variant_hint: None,
+            request_properties: RequestProperties::default(),
+            ceiling_usd: 0.001,
+            inferred_usage: Some(crate::InferenceUsage {
+                model: None,
+                streamed: false,
+                ttft_ms: None,
+                tokens_prompt: None,
+                tokens_completion: Some(10),
+                tokens_per_sec: None,
+            }),
+        }
+    }
+
+    async fn open_delegated_pair(
+        url: &str,
+        prefix: &str,
+    ) -> (Arc<SessionMpp>, Arc<SessionMpp>, String, SessionHandle) {
         let store: Arc<dyn ChannelStore> = Arc::new(
-            RedisChannelStore::connect(&url, prefix.clone())
+            RedisChannelStore::connect(url, prefix.to_string())
                 .await
                 .expect("redis store"),
         );
-        let first = SessionMpp::new_with_stores(
+        let ttl = Duration::from_millis(600);
+        let first = Arc::new(SessionMpp::new_with_stores(
             config(),
             "redis-e2e",
             Arc::clone(&store),
-            CapacityLeaseCoordinator::redis(&url, &prefix)
+            CapacityLeaseCoordinator::redis_with_ttl(url, prefix, ttl)
                 .await
                 .unwrap(),
-        );
+        ));
+        let second = Arc::new(SessionMpp::new_with_stores(
+            config(),
+            "redis-e2e",
+            Arc::clone(&store),
+            CapacityLeaseCoordinator::redis_with_ttl(url, prefix, ttl)
+                .await
+                .unwrap(),
+        ));
         let handle = SessionHandle::new(
             solana_pubkey::Pubkey::new_unique(),
             signer(),
@@ -2636,35 +2682,37 @@ mod redis_e2e_tests {
         else {
             panic!("expected open");
         };
+        (first, second, opened.channel_id, handle)
+    }
+
+    #[tokio::test]
+    async fn redis_rehydrate_and_lease_across_replicas() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("session");
+        let (first, second, channel_id, handle) = open_delegated_pair(&url, &prefix).await;
         first
             .process(&handle.voucher_header(88).await.unwrap())
             .await
             .unwrap();
 
         let lease = first
-            .reserve_delegated_capacity(&opened.channel_id, 0)
+            .reserve_delegated_capacity(&channel_id, 0)
             .await
             .unwrap()
             .expect("first lease");
         assert!(
             first
-                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .reserve_delegated_capacity(&channel_id, 0)
                 .await
                 .unwrap()
                 .is_none()
         );
-
-        let second = SessionMpp::new_with_stores(
-            config(),
-            "redis-e2e",
-            Arc::clone(&store),
-            CapacityLeaseCoordinator::redis(&url, &prefix)
-                .await
-                .unwrap(),
-        );
         assert!(
             second
-                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .reserve_delegated_capacity(&channel_id, 0)
                 .await
                 .unwrap()
                 .is_none()
@@ -2675,12 +2723,167 @@ mod redis_e2e_tests {
 
         assert!(second.rehydrate_from_store().await.unwrap() >= 1);
         assert_eq!(
-            second.load_committed_watermark(&opened.channel_id).await,
+            second.load_committed_watermark(&channel_id).await,
             Some(88)
         );
         assert!(
             second
-                .reserve_delegated_capacity(&opened.channel_id, 0)
+                .reserve_delegated_capacity(&channel_id, 0)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn dual_replica_watermark_refresh_sees_peer_commit() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("watermark");
+        let (first, second, channel_id, handle) = open_delegated_pair(&url, &prefix).await;
+        first
+            .process(&handle.voucher_header(42).await.unwrap())
+            .await
+            .unwrap();
+        assert_eq!(first.committed_watermark(&channel_id), Some(42));
+        assert_eq!(second.committed_watermark(&channel_id), None);
+        assert_eq!(
+            second.refresh_committed_watermark(&channel_id).await,
+            Some(42)
+        );
+        assert_eq!(second.committed_watermark(&channel_id), Some(42));
+    }
+
+    #[tokio::test]
+    async fn rehydrate_skips_sealed_channels() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("rehydrate-sealed");
+        let (first, second, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+        first
+            .operator_runtime
+            .channel_store
+            .mark_sealed(&channel_id)
+            .await
+            .expect("seal");
+        assert_eq!(second.rehydrate_from_store().await.unwrap(), 0);
+        assert_eq!(second.committed_watermark(&channel_id), None);
+    }
+
+    #[tokio::test]
+    async fn settle_delegated_session_abandons_when_lease_lost() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("settle-loss");
+        let ttl = Duration::from_millis(600);
+        let (first, second, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+        let lease = first
+            .reserve_delegated_capacity(&channel_id, CAP)
+            .await
+            .unwrap()
+            .expect("lease");
+        assert_no_overlapping_holders(
+            &CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+                .await
+                .unwrap(),
+            &channel_id,
+        )
+        .await;
+
+        del_lease_key(&url, &prefix, &channel_id).await;
+        assert_no_overlapping_holders(
+            &CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+                .await
+                .unwrap(),
+            &channel_id,
+        )
+        .await;
+        tokio::time::timeout(ttl * 4, lease.lost())
+            .await
+            .expect("holder must observe lease loss");
+
+        let forward = SessionForward::delegated(
+            Arc::clone(&first),
+            channel_id.clone(),
+            0,
+            output_bytes_plan(),
+            CAP,
+            lease,
+        );
+        let error = match settle_delegated_session(forward, &HeaderMap::new(), Some(b"hello-world"))
+            .await
+        {
+            Ok(ok) => panic!(
+                "lost lease must abandon settlement, got Ok(is_some={})",
+                ok.is_some()
+            ),
+            Err(error) => error,
+        };
+        assert!(
+            error.contains("capacity lease was lost"),
+            "unexpected settle error: {error}"
+        );
+        // Peer remains blocked until the abandoned holder's Drop releases.
+        // After settle returns Err, forward (and lease) were dropped.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            second
+                .reserve_delegated_capacity(&channel_id, 0)
+                .await
+                .unwrap()
+                .is_some(),
+            "peer may acquire only after the abandoned holder released"
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_auto_close_abandons_when_lease_lost() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("lifecycle-loss");
+        let ttl = Duration::from_millis(600);
+        let (session, peer, channel_id, _) = open_delegated_pair(&url, &prefix).await;
+
+        // Mimic close_due_channels: reserve, then guard close-shaped work. Loss
+        // mid-guard must abandon before a peer can take over.
+        let lease = session
+            .reserve_delegated_capacity(&channel_id, 0)
+            .await
+            .unwrap()
+            .expect("lifecycle lease");
+        let peer_coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
+
+        del_lease_key(&url, &prefix, &channel_id).await;
+        assert_no_overlapping_holders(&peer_coordinator, &channel_id).await;
+
+        let work_finished = Arc::new(std::sync::Mutex::new(false));
+        let flag = Arc::clone(&work_finished);
+        let guarded = lease.guard(async move {
+            tokio::time::sleep(ttl * 10).await;
+            *flag.lock().unwrap() = true;
+            Ok::<(), crate::Error>(())
+        });
+        let error = tokio::time::timeout(ttl * 4, guarded)
+            .await
+            .expect("guard must return on lease loss")
+            .expect_err("lost lease must abandon auto-close work");
+        assert!(error.to_string().contains("capacity lease was lost"));
+        assert!(!*work_finished.lock().unwrap());
+        drop(lease);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            peer.reserve_delegated_capacity(&channel_id, 0)
                 .await
                 .unwrap()
                 .is_some()

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -496,20 +496,21 @@ mod tests {
     }
 }
 
-
 #[cfg(test)]
 mod required_coverage {
-    /// CI sets PAY_REQUIRE_REDIS_TESTS=1. If the feature is missing, the Redis
-    /// suite silently vanishes at compile time — fail loudly instead.
+    /// CI sets PAY_REQUIRE_REDIS_TESTS=1 on Redis-enabled jobs. If the feature
+    /// is missing, the Redis suite silently vanishes at compile time — fail
+    /// loudly instead. Keyed only on PAY_REQUIRE_REDIS_TESTS so default-feature
+    /// CI jobs can still run without Redis.
     #[test]
     fn redis_lease_suite_is_compiled_when_required() {
         let required = matches!(
             std::env::var("PAY_REQUIRE_REDIS_TESTS").as_deref(),
             Ok("1") | Ok("true")
-        ) || matches!(std::env::var("CI").as_deref(), Ok("true") | Ok("1"));
+        );
         assert!(
             !required || cfg!(feature = "redis-session-store"),
-            "PAY_REQUIRE_REDIS_TESTS/CI is set but this build has no \
+            "PAY_REQUIRE_REDIS_TESTS is set but this build has no \
              redis-session-store feature: the Redis lease tests did not run"
         );
     }
@@ -519,9 +520,8 @@ mod required_coverage {
 pub(crate) mod redis_test_support {
     //! Shared Redis lease-test helpers for pay-core.
     //!
-    //! Soft-skip when no URL is set locally. Under CI (`CI=true`) or
-    //! `PAY_REQUIRE_REDIS_TESTS=1`, a missing URL panics so coverage cannot go
-    //! vacuous.
+    //! Soft-skip when no URL is set locally. Under `PAY_REQUIRE_REDIS_TESTS=1`,
+    //! a missing URL panics so Redis-enabled CI jobs cannot go vacuous.
     //!
     //! Product ceilings intentionally out of scope for the harness:
     //! - no fencing token beyond the lease id / barrier pair
@@ -532,8 +532,10 @@ pub(crate) mod redis_test_support {
     use std::time::Duration;
 
     pub(crate) fn require_redis_tests() -> bool {
-        matches!(std::env::var("PAY_REQUIRE_REDIS_TESTS").as_deref(), Ok("1") | Ok("true"))
-            || matches!(std::env::var("CI").as_deref(), Ok("true") | Ok("1"))
+        matches!(
+            std::env::var("PAY_REQUIRE_REDIS_TESTS").as_deref(),
+            Ok("1") | Ok("true")
+        )
     }
 
     fn redis_url_optional() -> Option<String> {
@@ -551,7 +553,7 @@ pub(crate) mod redis_test_support {
             None if require_redis_tests() => {
                 panic!(
                     "PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL is required when \
-                     CI=true or PAY_REQUIRE_REDIS_TESTS=1"
+                     PAY_REQUIRE_REDIS_TESTS=1"
                 );
             }
             None => None,
@@ -564,7 +566,12 @@ pub(crate) mod redis_test_support {
 
     pub(crate) async fn dual_coordinators(
         ttl: Duration,
-    ) -> Option<(String, String, CapacityLeaseCoordinator, CapacityLeaseCoordinator)> {
+    ) -> Option<(
+        String,
+        String,
+        CapacityLeaseCoordinator,
+        CapacityLeaseCoordinator,
+    )> {
         let url = redis_test_url()?;
         let prefix = unique_prefix("lease");
         let a = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
@@ -593,7 +600,10 @@ pub(crate) mod redis_test_support {
         channel_id: &str,
     ) {
         assert!(
-            peer.try_acquire(channel_id).await.expect("peer acquire").is_none(),
+            peer.try_acquire(channel_id)
+                .await
+                .expect("peer acquire")
+                .is_none(),
             "the takeover barrier must prevent overlapping holders"
         );
     }
@@ -617,7 +627,8 @@ pub(crate) mod redis_test_support {
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "the abandoned holder did not release within half the barrier TTL;                  a later acquisition would only prove barrier expiry"
+                "the abandoned holder did not release within half the barrier TTL; \
+                 a later acquisition would only prove barrier expiry"
             );
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
@@ -626,11 +637,11 @@ pub(crate) mod redis_test_support {
 
 #[cfg(all(test, feature = "redis-session-store"))]
 mod redis_tests {
-    use super::*;
     use super::redis_test_support::{
         assert_no_overlapping_holders, del_lease_key, dual_coordinators, redis_test_url,
         unique_prefix,
     };
+    use super::*;
 
     #[tokio::test]
     async fn redis_lease_exclusive_and_stale_release_safe() {
@@ -790,8 +801,7 @@ mod redis_tests {
 
     #[tokio::test]
     async fn early_deletion_after_renewal_cannot_overlap_holders() {
-        let Some((url, prefix, owner, peer)) =
-            dual_coordinators(Duration::from_millis(600)).await
+        let Some((url, prefix, owner, peer)) = dual_coordinators(Duration::from_millis(600)).await
         else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -496,6 +496,25 @@ mod tests {
     }
 }
 
+
+#[cfg(test)]
+mod required_coverage {
+    /// CI sets PAY_REQUIRE_REDIS_TESTS=1. If the feature is missing, the Redis
+    /// suite silently vanishes at compile time — fail loudly instead.
+    #[test]
+    fn redis_lease_suite_is_compiled_when_required() {
+        let required = matches!(
+            std::env::var("PAY_REQUIRE_REDIS_TESTS").as_deref(),
+            Ok("1") | Ok("true")
+        ) || matches!(std::env::var("CI").as_deref(), Ok("true") | Ok("1"));
+        assert!(
+            !required || cfg!(feature = "redis-session-store"),
+            "PAY_REQUIRE_REDIS_TESTS/CI is set but this build has no \
+             redis-session-store feature: the Redis lease tests did not run"
+        );
+    }
+}
+
 #[cfg(all(test, feature = "redis-session-store"))]
 pub(crate) mod redis_test_support {
     //! Shared Redis lease-test helpers for pay-core.
@@ -577,6 +596,31 @@ pub(crate) mod redis_test_support {
             peer.try_acquire(channel_id).await.expect("peer acquire").is_none(),
             "the takeover barrier must prevent overlapping holders"
         );
+    }
+
+    /// Release is fire-and-forget; poll until both keys are gone, but require
+    /// that to happen inside half the barrier TTL so barrier expiry cannot
+    /// masquerade as a successful release.
+    pub(crate) async fn await_released(url: &str, prefix: &str, channel_id: &str, ttl: Duration) {
+        let deadline = tokio::time::Instant::now() + barrier_ttl(ttl) / 2;
+        let client = redis::Client::open(url).expect("redis client");
+        let mut conn = client.get_connection_manager().await.expect("redis conn");
+        loop {
+            let live: i64 = redis::cmd("EXISTS")
+                .arg(format!("{prefix}lease:{channel_id}"))
+                .arg(format!("{prefix}lease-barrier:{channel_id}"))
+                .query_async(&mut conn)
+                .await
+                .expect("EXISTS");
+            if live == 0 {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the abandoned holder did not release within half the barrier TTL;                  a later acquisition would only prove barrier expiry"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
     }
 }
 

--- a/rust/crates/core/src/server/session_capacity.rs
+++ b/rust/crates/core/src/server/session_capacity.rs
@@ -497,10 +497,27 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "redis-session-store"))]
-mod redis_tests {
-    use super::*;
+pub(crate) mod redis_test_support {
+    //! Shared Redis lease-test helpers for pay-core.
+    //!
+    //! Soft-skip when no URL is set locally. Under CI (`CI=true`) or
+    //! `PAY_REQUIRE_REDIS_TESTS=1`, a missing URL panics so coverage cannot go
+    //! vacuous.
+    //!
+    //! Product ceilings intentionally out of scope for the harness:
+    //! - no fencing token beyond the lease id / barrier pair
+    //! - `last_activity` is per-process (no shared idle clock across replicas)
+    //! - lifecycle is "whoever holds the lease", not a leader election
 
-    fn redis_url() -> Option<String> {
+    use super::*;
+    use std::time::Duration;
+
+    pub(crate) fn require_redis_tests() -> bool {
+        matches!(std::env::var("PAY_REQUIRE_REDIS_TESTS").as_deref(), Ok("1") | Ok("true"))
+            || matches!(std::env::var("CI").as_deref(), Ok("true") | Ok("1"))
+    }
+
+    fn redis_url_optional() -> Option<String> {
         std::env::var("PAY_SESSION_REDIS_URL")
             .or_else(|_| std::env::var("PAY_KIT_TEST_REDIS_URL"))
             .ok()
@@ -508,20 +525,75 @@ mod redis_tests {
             .filter(|v| !v.is_empty())
     }
 
+    /// Soft-skip locally; panic in CI / when Redis tests are required.
+    pub(crate) fn redis_test_url() -> Option<String> {
+        match redis_url_optional() {
+            Some(url) => Some(url),
+            None if require_redis_tests() => {
+                panic!(
+                    "PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL is required when \
+                     CI=true or PAY_REQUIRE_REDIS_TESTS=1"
+                );
+            }
+            None => None,
+        }
+    }
+
+    pub(crate) fn unique_prefix(kind: &str) -> String {
+        format!("pay:test:{kind}:{}:", uuid::Uuid::new_v4().simple())
+    }
+
+    pub(crate) async fn dual_coordinators(
+        ttl: Duration,
+    ) -> Option<(String, String, CapacityLeaseCoordinator, CapacityLeaseCoordinator)> {
+        let url = redis_test_url()?;
+        let prefix = unique_prefix("lease");
+        let a = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .expect("coordinator a");
+        let b = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .expect("coordinator b");
+        Some((url, prefix, a, b))
+    }
+
+    pub(crate) async fn del_lease_key(url: &str, prefix: &str, channel_id: &str) {
+        let client = redis::Client::open(url).expect("redis client");
+        let mut conn = client.get_connection_manager().await.expect("redis conn");
+        let _: () = redis::cmd("DEL")
+            .arg(format!("{prefix}lease:{channel_id}"))
+            .query_async(&mut conn)
+            .await
+            .expect("DEL lease key");
+    }
+
+    /// Peer must not acquire while the takeover barrier still proves the old hold.
+    /// Never assert success as "peer acquires while the original is still held".
+    pub(crate) async fn assert_no_overlapping_holders(
+        peer: &CapacityLeaseCoordinator,
+        channel_id: &str,
+    ) {
+        assert!(
+            peer.try_acquire(channel_id).await.expect("peer acquire").is_none(),
+            "the takeover barrier must prevent overlapping holders"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "redis-session-store"))]
+mod redis_tests {
+    use super::*;
+    use super::redis_test_support::{
+        assert_no_overlapping_holders, del_lease_key, dual_coordinators, redis_test_url,
+        unique_prefix,
+    };
+
     #[tokio::test]
     async fn redis_lease_exclusive_and_stale_release_safe() {
-        let Some(url) = redis_url() else {
+        let Some((url, prefix, a, b)) = dual_coordinators(Duration::from_millis(600)).await else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
-        let ttl = Duration::from_millis(600);
-        let a = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
-        let b = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
 
         let mut token_a = a.try_acquire("ch").await.unwrap().expect("a");
         assert!(b.try_acquire("ch").await.unwrap().is_none());
@@ -529,7 +601,8 @@ mod redis_tests {
         // Stop A's watchdog and wait for both of its keys to expire naturally.
         // Its local deadline is stale before B is allowed to acquire.
         token_a.redis.as_mut().expect("redis hold")._renewal.take();
-        tokio::time::sleep(barrier_ttl(ttl) + Duration::from_millis(100)).await;
+        tokio::time::sleep(barrier_ttl(Duration::from_millis(600)) + Duration::from_millis(100))
+            .await;
         assert!(!token_a.is_held());
 
         let token_b = b.try_acquire("ch").await.unwrap().expect("b");
@@ -553,11 +626,11 @@ mod redis_tests {
 
     #[tokio::test]
     async fn redis_lease_renews_past_its_ttl() {
-        let Some(url) = redis_url() else {
+        let Some(url) = redis_test_url() else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
+        let prefix = unique_prefix("lease");
         let ttl = Duration::from_millis(600);
         let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
             .await
@@ -583,7 +656,7 @@ mod redis_tests {
 
     #[tokio::test]
     async fn redis_backend_failure_is_an_error_not_contention() {
-        let Some(url) = redis_url() else {
+        let Some(url) = redis_test_url() else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
@@ -602,31 +675,20 @@ mod redis_tests {
 
     #[tokio::test]
     async fn lost_redis_lease_marks_the_token_unheld() {
-        let Some(url) = redis_url() else {
+        let Some((url, prefix, coordinator, peer)) =
+            dual_coordinators(Duration::from_millis(600)).await
+        else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
         let ttl = Duration::from_millis(600);
-        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
         let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
         assert!(token.is_held());
 
         // Delete only the lease key behind the holder's back. The barrier must
         // keep a peer out until the original holder observes the loss.
-        let client = redis::Client::open(url.as_str()).unwrap();
-        let mut conn = client.get_connection_manager().await.unwrap();
-        let _: () = redis::cmd("DEL")
-            .arg(format!("{prefix}lease:ch"))
-            .query_async(&mut conn)
-            .await
-            .unwrap();
-        assert!(
-            coordinator.try_acquire("ch").await.unwrap().is_none(),
-            "takeover barrier must block a peer after early lease deletion"
-        );
+        del_lease_key(&url, &prefix, "ch").await;
+        assert_no_overlapping_holders(&peer, "ch").await;
 
         tokio::time::timeout(ttl * 4, token.lost())
             .await
@@ -636,30 +698,22 @@ mod redis_tests {
             "renewal must tell the holder its lease is gone"
         );
         coordinator.release_async("ch", &token).await;
-        let peer = coordinator.try_acquire("ch").await.unwrap().expect("peer");
-        assert!(peer.is_held());
+        let peer_token = peer.try_acquire("ch").await.unwrap().expect("peer");
+        assert!(peer_token.is_held());
     }
 
     #[tokio::test]
     async fn loss_is_persisted_without_an_active_waiter() {
-        let Some(url) = redis_url() else {
+        let Some((url, prefix, coordinator, _)) =
+            dual_coordinators(Duration::from_millis(600)).await
+        else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
         let ttl = Duration::from_millis(600);
-        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
         let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
 
-        let client = redis::Client::open(url.as_str()).unwrap();
-        let mut conn = client.get_connection_manager().await.unwrap();
-        let _: () = redis::cmd("DEL")
-            .arg(format!("{prefix}lease:ch"))
-            .query_async(&mut conn)
-            .await
-            .unwrap();
+        del_lease_key(&url, &prefix, "ch").await;
 
         // No receiver is active while the watchdog detects the loss.
         tokio::time::sleep(renew_interval(ttl) * 2).await;
@@ -692,18 +746,13 @@ mod redis_tests {
 
     #[tokio::test]
     async fn early_deletion_after_renewal_cannot_overlap_holders() {
-        let Some(url) = redis_url() else {
+        let Some((url, prefix, owner, peer)) =
+            dual_coordinators(Duration::from_millis(600)).await
+        else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
         let ttl = Duration::from_millis(600);
-        let owner = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
-        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
         let token = owner.try_acquire("ch").await.unwrap().expect("owner");
 
         // Wait for proof that one renewal completed, then delete only the lease
@@ -727,18 +776,9 @@ mod redis_tests {
         .await
         .expect("renewal must complete");
 
-        let client = redis::Client::open(url.as_str()).unwrap();
-        let mut conn = client.get_connection_manager().await.unwrap();
-        let _: () = redis::cmd("DEL")
-            .arg(format!("{prefix}lease:ch"))
-            .query_async(&mut conn)
-            .await
-            .unwrap();
+        del_lease_key(&url, &prefix, "ch").await;
 
-        assert!(
-            peer.try_acquire("ch").await.unwrap().is_none(),
-            "the takeover barrier must prevent overlapping holders"
-        );
+        assert_no_overlapping_holders(&peer, "ch").await;
         tokio::time::timeout(ttl, token.lost())
             .await
             .expect("owner must detect the loss before the barrier expires");
@@ -748,27 +788,19 @@ mod redis_tests {
 
     #[tokio::test]
     async fn guard_abandons_in_flight_work_when_the_lease_is_lost() {
-        let Some(url) = redis_url() else {
+        let Some((url, prefix, coordinator, peer)) =
+            dual_coordinators(Duration::from_millis(600)).await
+        else {
             eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
             return;
         };
-        let prefix = format!("pay:test:lease:{}:", uuid::Uuid::new_v4().simple());
         let ttl = Duration::from_millis(600);
-        let coordinator = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
         let token = coordinator.try_acquire("ch").await.unwrap().expect("lease");
 
         // Delete only the lease key while guarded work is still running. A peer
         // remains blocked by the barrier until the holder cancels its work.
-        let client = redis::Client::open(url.as_str()).unwrap();
-        let mut conn = client.get_connection_manager().await.unwrap();
-        let _: () = redis::cmd("DEL")
-            .arg(format!("{prefix}lease:ch"))
-            .query_async(&mut conn)
-            .await
-            .unwrap();
-        assert!(coordinator.try_acquire("ch").await.unwrap().is_none());
+        del_lease_key(&url, &prefix, "ch").await;
+        assert_no_overlapping_holders(&peer, "ch").await;
 
         let work_finished = Arc::new(Mutex::new(false));
         let flag = Arc::clone(&work_finished);
@@ -788,8 +820,38 @@ mod redis_tests {
         );
         coordinator.release_async("ch", &token).await;
         assert!(
-            coordinator.try_acquire("ch").await.unwrap().is_some(),
+            peer.try_acquire("ch").await.unwrap().is_some(),
             "a peer may acquire only after the old holder has cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_stampede_yields_exactly_one_holder() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("stampede");
+        let ttl = Duration::from_millis(600);
+        let mut coordinators = Vec::new();
+        for _ in 0..8 {
+            coordinators.push(
+                CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+                    .await
+                    .unwrap(),
+            );
+        }
+        let mut tasks = Vec::new();
+        for coordinator in &coordinators {
+            let c = coordinator.clone();
+            tasks.push(async move { c.try_acquire("ch").await.unwrap() });
+        }
+        let results = futures_util::future::join_all(tasks).await;
+        let winners: Vec<_> = results.into_iter().flatten().collect();
+        assert_eq!(
+            winners.len(),
+            1,
+            "exactly one stampede participant may hold the lease"
         );
     }
 }

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -1343,3 +1343,159 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
         );
     }
 }
+
+#[cfg(all(test, feature = "redis-session-store"))]
+mod redis_stream_tests {
+    use super::*;
+    use crate::client::session::SessionHandle;
+    use crate::server::gate::SessionForward;
+    use crate::server::metering::{RequestProperties, UptoSettlementPlan};
+    use crate::server::session::SessionOutcome;
+    use crate::server::session_capacity::CapacityLeaseCoordinator;
+    use crate::server::session_capacity::redis_test_support::{
+        assert_no_overlapping_holders, del_lease_key, redis_test_url, unique_prefix,
+    };
+    use pay_kit::mpp::server::session::SessionConfig;
+    use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
+    use pay_kit::mpp::store::{ChannelStore, RedisChannelStore};
+    use pay_kit::mpp::{SessionMode, SessionSettlementAuthority};
+    use pay_types::metering::{BillingUnit, MeterDimension, MeterDirection, Metering, PriceTier};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn stream_metering() -> Metering {
+        Metering {
+            dimensions: vec![MeterDimension {
+                direction: MeterDirection::Output,
+                unit: BillingUnit::Tokens,
+                scale: 1,
+                period: None,
+                tiers: vec![PriceTier {
+                    up_to: None,
+                    price_usd: 0.000001,
+                    condition: None,
+                    notes: None,
+                    splits: vec![],
+                }],
+                meter: None,
+            }],
+            variants: vec![],
+            sku_tiers: vec![],
+            splits: vec![],
+            schemes: None,
+            min_usd: None,
+            upto: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn delegated_stream_authorize_cancels_when_lease_lost() {
+        let Some(url) = redis_test_url() else {
+            eprintln!("skipping: set PAY_SESSION_REDIS_URL or PAY_KIT_TEST_REDIS_URL");
+            return;
+        };
+        let prefix = unique_prefix("stream-loss");
+        let ttl = Duration::from_millis(600);
+        let store: Arc<dyn ChannelStore> = Arc::new(
+            RedisChannelStore::connect(&url, prefix.clone())
+                .await
+                .expect("redis store"),
+        );
+
+        use ed25519_dalek::SigningKey;
+        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        let verifying_key = signing_key.verifying_key();
+        let mut operator_keypair = [0_u8; 64];
+        operator_keypair[..32].copy_from_slice(signing_key.as_bytes());
+        operator_keypair[32..].copy_from_slice(verifying_key.as_bytes());
+        let operator: Arc<dyn SolanaSigner> =
+            Arc::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
+        let client_operator: Box<dyn SolanaSigner> =
+            Box::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
+
+        let mut config = SessionConfig {
+            operator: operator.pubkey().to_string(),
+            recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+            max_cap: 1_000,
+            currency: solana_pubkey::Pubkey::new_unique().to_string(),
+            network: "localnet".to_string(),
+            min_voucher_delta: 1,
+            modes: vec![SessionMode::Push],
+            ..SessionConfig::default()
+        };
+        config.settlement_authority = SessionSettlementAuthority::Delegated;
+
+        let session = Arc::new(
+            SessionMpp::new_with_stores(
+                config,
+                "delegated-stream-redis",
+                Arc::clone(&store),
+                CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+                    .await
+                    .unwrap(),
+            )
+            .with_payment_channel_signer(operator),
+        );
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            client_operator,
+            session.challenge(1_000).unwrap(),
+        );
+        let open_header = handle.open_header(1_000, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state, .. } = session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected an active delegated session");
+        };
+        let reservation = session
+            .reserve_delegated_capacity(&state.channel_id, 1_000)
+            .await
+            .unwrap()
+            .expect("session capacity should be available");
+
+        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
+        assert_no_overlapping_holders(&peer, &state.channel_id).await;
+
+        // Build the same SessionForward / meter path the proxy uses, then lose
+        // the lease before authorize — matching DelegatedSessionStreamMeter::settle.
+        let forward = SessionForward::delegated(
+            session.clone(),
+            state.channel_id.clone(),
+            0,
+            UptoSettlementPlan {
+                metering: stream_metering(),
+                variant_hint: None,
+                request_properties: RequestProperties::default(),
+                ceiling_usd: 0.001,
+                inferred_usage: None,
+            },
+            10,
+            reservation,
+        );
+        let meter = DelegatedSessionStreamMeter::from_forward(forward).unwrap();
+
+        del_lease_key(&url, &prefix, &state.channel_id).await;
+        assert_no_overlapping_holders(&peer, &state.channel_id).await;
+        let lease = meter.forward.capacity_lease().expect("lease");
+        tokio::time::timeout(ttl * 4, lease.lost())
+            .await
+            .expect("stream holder must observe lease loss");
+
+        let authorize = session.authorize_delegated_usage(&state.channel_id, 1);
+        let err = lease
+            .guard(authorize)
+            .await
+            .expect_err("lost lease must cancel stream authorize");
+        assert!(
+            err.to_string().contains("capacity lease was lost"),
+            "unexpected error: {err}"
+        );
+        drop(meter);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            peer.try_acquire(&state.channel_id).await.unwrap().is_some(),
+            "peer may acquire only after the abandoned stream meter released"
+        );
+    }
+}

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -1481,33 +1481,35 @@ mod redis_stream_tests {
 
         // Drive the real proxy path. settle runs before yield, so a lost lease
         // must fail the stream instead of releasing unpaid bytes.
-        let upstream = async_stream::stream! {
-            yield Ok::<_, std::io::Error>(Bytes::from_static(
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n",
-            ));
-        };
-        let metered = meter_delegated_response_stream(upstream, meter, true);
-        futures_util::pin_mut!(metered);
+        {
+            let upstream = async_stream::stream! {
+                yield Ok::<_, std::io::Error>(Bytes::from_static(
+                    b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n",
+                ));
+            };
+            let metered = meter_delegated_response_stream(upstream, meter, true);
+            futures_util::pin_mut!(metered);
 
-        let first = tokio::time::timeout(ttl * 4, metered.next())
-            .await
-            .expect("a lost lease must terminate the stream, not hang")
-            .expect("the stream must surface the loss as an item");
-        let err = first.expect_err("a lost lease must not release chargeable bytes");
-        assert!(
-            err.to_string().contains("capacity lease was lost"),
-            "unexpected stream error: {err}"
-        );
-        assert!(
-            metered.next().await.is_none(),
-            "the metered stream must end after abandoning the charge"
-        );
-        assert_eq!(
-            session.refresh_committed_watermark(&state.channel_id).await,
-            Some(0),
-            "an abandoned stream must not advance the durable watermark"
-        );
-        drop(metered);
+            let first = tokio::time::timeout(ttl * 4, metered.next())
+                .await
+                .expect("a lost lease must terminate the stream, not hang")
+                .expect("the stream must surface the loss as an item");
+            let err = first.expect_err("a lost lease must not release chargeable bytes");
+            assert!(
+                err.to_string().contains("capacity lease was lost"),
+                "unexpected stream error: {err}"
+            );
+            assert!(
+                metered.next().await.is_none(),
+                "the metered stream must end after abandoning the charge"
+            );
+            assert_eq!(
+                session.refresh_committed_watermark(&state.channel_id).await,
+                Some(0),
+                "an abandoned stream must not advance the durable watermark"
+            );
+        }
+        // Ending the stream scope drops the owned meter and releases its lease.
         await_released(&url, &prefix, &state.channel_id, ttl).await;
         assert!(
             peer.try_acquire(&state.channel_id).await.unwrap().is_some(),

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -1353,8 +1353,7 @@ mod redis_stream_tests {
     use crate::server::session::SessionOutcome;
     use crate::server::session_capacity::CapacityLeaseCoordinator;
     use crate::server::session_capacity::redis_test_support::{
-        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url,
-        unique_prefix,
+        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url, unique_prefix,
     };
     use pay_kit::mpp::server::session::SessionConfig;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
@@ -1475,9 +1474,12 @@ mod redis_stream_tests {
 
         del_lease_key(&url, &prefix, &state.channel_id).await;
         assert_no_overlapping_holders(&peer, &state.channel_id).await;
-        tokio::time::timeout(ttl * 4, meter.forward.capacity_lease().expect("lease").lost())
-            .await
-            .expect("stream holder must observe lease loss");
+        tokio::time::timeout(
+            ttl * 4,
+            meter.forward.capacity_lease().expect("lease").lost(),
+        )
+        .await
+        .expect("stream holder must observe lease loss");
 
         // Drive the real proxy path. settle runs before yield, so a lost lease
         // must fail the stream instead of releasing unpaid bytes.

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -1353,7 +1353,8 @@ mod redis_stream_tests {
     use crate::server::session::SessionOutcome;
     use crate::server::session_capacity::CapacityLeaseCoordinator;
     use crate::server::session_capacity::redis_test_support::{
-        assert_no_overlapping_holders, del_lease_key, redis_test_url, unique_prefix,
+        assert_no_overlapping_holders, await_released, del_lease_key, redis_test_url,
+        unique_prefix,
     };
     use pay_kit::mpp::server::session::SessionConfig;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
@@ -1395,7 +1396,10 @@ mod redis_stream_tests {
             return;
         };
         let prefix = unique_prefix("stream-loss");
-        let ttl = Duration::from_millis(600);
+        let ttl = Duration::from_secs(2);
+        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
+            .await
+            .unwrap();
         let store: Arc<dyn ChannelStore> = Arc::new(
             RedisChannelStore::connect(&url, prefix.clone())
                 .await
@@ -1451,14 +1455,8 @@ mod redis_stream_tests {
             .await
             .unwrap()
             .expect("session capacity should be available");
-
-        let peer = CapacityLeaseCoordinator::redis_with_ttl(&url, &prefix, ttl)
-            .await
-            .unwrap();
         assert_no_overlapping_holders(&peer, &state.channel_id).await;
 
-        // Build the same SessionForward / meter path the proxy uses, then lose
-        // the lease before authorize — matching DelegatedSessionStreamMeter::settle.
         let forward = SessionForward::delegated(
             session.clone(),
             state.channel_id.clone(),
@@ -1477,22 +1475,40 @@ mod redis_stream_tests {
 
         del_lease_key(&url, &prefix, &state.channel_id).await;
         assert_no_overlapping_holders(&peer, &state.channel_id).await;
-        let lease = meter.forward.capacity_lease().expect("lease");
-        tokio::time::timeout(ttl * 4, lease.lost())
+        tokio::time::timeout(ttl * 4, meter.forward.capacity_lease().expect("lease").lost())
             .await
             .expect("stream holder must observe lease loss");
 
-        let authorize = session.authorize_delegated_usage(&state.channel_id, 1);
-        let err = lease
-            .guard(authorize)
+        // Drive the real proxy path. settle runs before yield, so a lost lease
+        // must fail the stream instead of releasing unpaid bytes.
+        let upstream = async_stream::stream! {
+            yield Ok::<_, std::io::Error>(Bytes::from_static(
+                b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n",
+            ));
+        };
+        let metered = meter_delegated_response_stream(upstream, meter, true);
+        futures_util::pin_mut!(metered);
+
+        let first = tokio::time::timeout(ttl * 4, metered.next())
             .await
-            .expect_err("lost lease must cancel stream authorize");
+            .expect("a lost lease must terminate the stream, not hang")
+            .expect("the stream must surface the loss as an item");
+        let err = first.expect_err("a lost lease must not release chargeable bytes");
         assert!(
             err.to_string().contains("capacity lease was lost"),
-            "unexpected error: {err}"
+            "unexpected stream error: {err}"
         );
-        drop(meter);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            metered.next().await.is_none(),
+            "the metered stream must end after abandoning the charge"
+        );
+        assert_eq!(
+            session.refresh_committed_watermark(&state.channel_id).await,
+            Some(0),
+            "an abandoned stream must not advance the durable watermark"
+        );
+        drop(metered);
+        await_released(&url, &prefix, &state.channel_id, ttl).await;
         assert!(
             peer.try_acquire(&state.channel_id).await.unwrap().is_some(),
             "peer may acquire only after the abandoned stream meter released"


### PR DESCRIPTION
## What

Hard Redis session CI coverage plus lease composition regressions for `pay-core`, stacked on #407.

- Live `redis:7-alpine` in Rust CI (`ci.yml`) with `server,redis-session-store` clippy/test lanes **alongside** default-feature lanes
- Hard-require Redis under `PAY_REQUIRE_REDIS_TESTS=1` (soft-skip locally) plus anti-vacuity so coverage cannot silently vanish
- Shared `redis_test_support` helpers and composition tests (gate 402/503, stream authorize cancel-on-loss, lifecycle defer/abandon, dual-replica watermark, acquire stampede, sealed rehydrate)
- Intentional workflow split (`bc0ee7e`): Redis once on PRs via `ci.yml`; release preflight keeps Redis; `pull-requests.yml` stays the fast default-feature gate (no duplicate Redis suite)

## Why

Without a live Redis service and a hard-require path, Redis lease tests soft-skip and CI stays green while lease regressions (including #407 operator-state behavior) go unexercised. Duplicating Redis on both `ci.yml` and `pull-requests.yml` would charge every PR twice without extra signal.

Keep #407 as the product-fix PR; this PR is the harness/coverage stack on top.

## How

```mermaid
flowchart TB
  subgraph before [Before]
    B1[Local / CI without Redis URL]
    B2[Redis lease tests soft-skip]
    B3[CI stays green]
    B4[pull-requests.yml + ci.yml lack hard Redis gate]
    B1 --> B2 --> B3
    B4 --> B3
  end

  subgraph after [After]
    A1[ci.yml: redis:7-alpine + PAY_REQUIRE_REDIS_TESTS=1]
    A2[Default-feature clippy/test lanes]
    A3[Redis-enabled clippy/test/coverage]
    A4[pull-requests.yml: fast default-feature only]
    A5[release-preflight: still runs Redis]
    A1 --> A3
    A2 --- A3
    A4 -.->|dedupe: no second Redis suite| A1
    A5 --> A3
  end

  before -->|this PR| after
```

- Wire Redis service + env into Rust jobs in `ci.yml`; enable `server,redis-session-store` for Redis-enabled clippy/test while restoring default lanes
- Fail loud when Redis is required but URL/feature missing; soft-skip only when not required
- Extract helpers; drive real stream/lifecycle paths (`meter_delegated_response_stream`, `close_channel_under_lease`) and loss-injection regressions
- Drop duplicate Redis suite from `pull-requests.yml` so PR Redis runs once via `ci.yml`

## Summary

- Live Redis in Rust CI with Redis-enabled **and** default-feature lanes
- Hard-require + anti-vacuity so lease coverage cannot soft-skip green in CI
- Composition regressions for gate/stream/lifecycle lease loss and related oracles
- Stacked on #407; after #407 merges, retarget this PR to `main` (or merge the stack in order)

## Test plan

- [x] CI green on this PR (default clippy/test + Redis-enabled clippy/test/coverage)
- [ ] Local: `PAY_SESSION_REDIS_URL=redis://127.0.0.1:6379 PAY_REQUIRE_REDIS_TESTS=1 cargo test -p pay-core --features "server,redis-session-store" --lib -- redis_`
- [ ] Local: `cargo clippy --workspace --all-targets --features "server,redis-session-store" -- -D warnings`
- [ ] Confirm Redis tests fail loudly if `PAY_REQUIRE_REDIS_TESTS=1` without URL or without the feature
- [ ] Confirm `pull-requests.yml` no longer starts a Redis service / Redis-enabled suite (dedupe)
- [ ] After #407 merges, retarget this PR to `main` (or merge the stack in order)