### PR TITLE
fix(pay): restore builds, auth gates, and telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,31 @@ jobs:
           workspaces: rust
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # ── Windows Rust check ──
+  rust-windows-check:
+    name: Rust check (Windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ./rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Build PDB frontend
+        run: cd ../web-ui && pnpm install --frozen-lockfile && pnpm build
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          key: check-windows
+      - run: cargo check -p pay
+
   # ── Rust tests + coverage ──
   rust-test:
     name: Rust tests + coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode
 .DS_Store
+.worktrees/
 
 # TypeScript
 node_modules

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=c68e5548f01f0edeb90de6f39f6fdecedb39496c#c68e5548f01f0edeb90de6f39f6fdecedb39496c"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=2d7f605c08c1b32abad99b2e13c0960112d929b9#2d7f605c08c1b32abad99b2e13c0960112d929b9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=a05c1d0cf29002c6f41c5afdbdf01c162ac64529#a05c1d0cf29002c6f41c5afdbdf01c162ac64529"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=1140b152c88ae2ea6587b42bc2dae14cebaf23dd#1140b152c88ae2ea6587b42bc2dae14cebaf23dd"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7239,7 +7239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=1140b152c88ae2ea6587b42bc2dae14cebaf23dd#1140b152c88ae2ea6587b42bc2dae14cebaf23dd"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=c68e5548f01f0edeb90de6f39f6fdecedb39496c#c68e5548f01f0edeb90de6f39f6fdecedb39496c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15390,7 +15390,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6406,6 +6406,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "blake3",
+ "borsh 1.7.0",
  "bs58",
  "bytes 1.12.0",
  "chrono",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6343,7 +6343,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pay"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "pay-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6456,7 +6456,7 @@ dependencies = [
 
 [[package]]
 name = "pay-integration"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.22.1",
  "pay-core",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "pay-keystore"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bs58",
  "secret-service",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "pay-mcp"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -6509,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "pay-pdb"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "pay-proxy"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "pay-types"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6363,6 +6363,7 @@ dependencies = [
  "opentelemetry-semantic-conventions 0.31.0",
  "opentelemetry_sdk 0.31.0",
  "owo-colors",
+ "pay-acp",
  "pay-core",
  "pay-keystore",
  "pay-mcp",
@@ -6395,6 +6396,15 @@ dependencies = [
  "urlencoding",
  "uuid",
  "webbrowser",
+]
+
+[[package]]
+name = "pay-acp"
+version = "0.25.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=cb02b5afcbba8147c4483a9d800a3eff93ed6592#cb02b5afcbba8147c4483a9d800a3eff93ed6592"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=a05c1d0cf29002c6f41c5afdbdf01c162ac64529#a05c1d0cf29002c6f41c5afdbdf01c162ac64529"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "a05c1d0cf29002c6f41c5afdbdf01c162ac64529", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "1140b152c88ae2ea6587b42bc2dae14cebaf23dd", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "cb02b5afcbba8147c4483a9d800a3eff93ed6592", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "a05c1d0cf29002c6f41c5afdbdf01c162ac64529", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.24.0"
+version = "0.25.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -110,7 +110,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "1140b152c88ae2ea6587b42bc2dae14cebaf23dd", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "c68e5548f01f0edeb90de6f39f6fdecedb39496c", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "c68e5548f01f0edeb90de6f39f6fdecedb39496c", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "2d7f605c08c1b32abad99b2e13c0960112d929b9", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 [workspace.dependencies]
 # Internal crates
 pay-core = { path = "crates/core" }
+pay-acp = { path = "crates/acp" }
 pay-types = { path = "crates/types" }
 pay-keystore = { path = "crates/keystore" }
 pay-mcp = { path = "crates/mcp" }

--- a/rust/crates/acp/Cargo.toml
+++ b/rust/crates/acp/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pay-acp"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+name = "pay_acp"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/rust/crates/acp/src/lib.rs
+++ b/rust/crates/acp/src/lib.rs
@@ -1,0 +1,490 @@
+//! ACP middleware primitives for Pay.
+//!
+//! The crate observes the stable ACP frames needed for delivery decisions while
+//! callers continue forwarding the original bytes. Unknown and vendor-specific
+//! messages therefore remain transparent.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+/// A final ACP assistant response that should be published into Buzz.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BuzzDelivery {
+    /// Destination channel UUID.
+    pub channel: String,
+    /// Optional event ID to reply to.
+    pub reply_to: Option<String>,
+    /// Final assistant text collected from ACP message chunks.
+    pub content: String,
+}
+
+/// Tracks ACP prompt turns and identifies assistant text that was not already
+/// published with `buzz messages send`.
+#[derive(Default)]
+pub struct BuzzDeliveryTracker {
+    prompt_sessions: HashMap<RequestId, String>,
+    turns: HashMap<String, TurnState>,
+}
+
+#[derive(Default)]
+struct TurnState {
+    destination: Option<BuzzDestination>,
+    assistant_text: String,
+    publish_tool_calls: HashSet<String>,
+    published: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BuzzDestination {
+    channel: String,
+    reply_to: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[serde(untagged)]
+enum RequestId {
+    Number(i64),
+    String(String),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PromptRequest {
+    session_id: String,
+    prompt: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize)]
+struct ContentBlock {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    text: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionNotification {
+    session_id: String,
+    update: SessionUpdate,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "sessionUpdate", rename_all = "snake_case")]
+enum SessionUpdate {
+    AgentMessageChunk {
+        content: ContentBlock,
+    },
+    ToolCall(ToolCall),
+    ToolCallUpdate(ToolCall),
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ToolCall {
+    tool_call_id: String,
+    status: Option<ToolCallStatus>,
+    raw_input: Option<Value>,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ToolCallStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+    #[serde(other)]
+    Other,
+}
+
+impl BuzzDeliveryTracker {
+    /// Observe one client-to-agent ACP NDJSON frame.
+    ///
+    /// Malformed, non-JSON, and unrecognized frames are ignored so callers can
+    /// still forward them unchanged.
+    pub fn observe_client_frame(&mut self, frame: &[u8]) {
+        let Ok(message) = serde_json::from_slice::<Value>(frame) else {
+            return;
+        };
+        self.observe_client_message(&message);
+    }
+
+    /// Observe one agent-to-client ACP NDJSON frame.
+    ///
+    /// Returns a fallback delivery only when a successful prompt response ends
+    /// a turn containing assistant text and no completed Buzz publish tool.
+    pub fn observe_agent_frame(&mut self, frame: &[u8]) -> Option<BuzzDelivery> {
+        let message = serde_json::from_slice::<Value>(frame).ok()?;
+        self.observe_agent_message(&message)
+    }
+
+    fn observe_client_message(&mut self, message: &Value) {
+        if message.get("method").and_then(Value::as_str) != Some("session/prompt") {
+            return;
+        }
+        let Some(request_id) = parse_request_id(message.get("id")) else {
+            return;
+        };
+        let Some(prompt) = message
+            .get("params")
+            .cloned()
+            .and_then(|params| serde_json::from_value::<PromptRequest>(params).ok())
+        else {
+            return;
+        };
+        let session_id = prompt.session_id;
+        let prompt_text = prompt
+            .prompt
+            .iter()
+            .filter_map(|block| {
+                (block.kind.as_deref() == Some("text"))
+                    .then_some(block.text.as_deref())
+                    .flatten()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        self.prompt_sessions.insert(request_id, session_id.clone());
+        self.turns.insert(
+            session_id,
+            TurnState {
+                destination: parse_buzz_destination(&prompt_text),
+                ..TurnState::default()
+            },
+        );
+    }
+
+    fn observe_agent_message(&mut self, message: &Value) -> Option<BuzzDelivery> {
+        if message.get("method").and_then(Value::as_str) == Some("session/update") {
+            self.observe_session_update(message);
+            return None;
+        }
+
+        let request_id = parse_request_id(message.get("id"))?;
+        let session_id = self.prompt_sessions.remove(&request_id)?;
+        let turn = self.turns.remove(&session_id)?;
+        if message.get("error").is_some() || turn.published {
+            return None;
+        }
+        let destination = turn.destination?;
+        let content = turn.assistant_text.trim().to_string();
+        if content.is_empty() {
+            return None;
+        }
+        Some(BuzzDelivery {
+            channel: destination.channel,
+            reply_to: destination.reply_to,
+            content,
+        })
+    }
+
+    fn observe_session_update(&mut self, message: &Value) {
+        let Some(notification) = message
+            .get("params")
+            .cloned()
+            .and_then(|params| serde_json::from_value::<SessionNotification>(params).ok())
+        else {
+            return;
+        };
+        let Some(turn) = self.turns.get_mut(&notification.session_id) else {
+            return;
+        };
+        match notification.update {
+            SessionUpdate::AgentMessageChunk { content } => {
+                if content.kind.as_deref() == Some("text")
+                    && let Some(text) = content.text
+                {
+                    turn.assistant_text.push_str(&text);
+                }
+            }
+            SessionUpdate::ToolCall(tool_call) => turn.observe_tool_call(tool_call),
+            SessionUpdate::ToolCallUpdate(update) => turn.observe_tool_call(update),
+            SessionUpdate::Other => {}
+        }
+    }
+}
+
+impl TurnState {
+    fn observe_tool_call(&mut self, tool_call: ToolCall) {
+        let tool_call_id = tool_call.tool_call_id;
+        let is_publish = tool_call
+            .raw_input
+            .as_ref()
+            .is_some_and(value_contains_buzz_message_send);
+        if is_publish {
+            self.publish_tool_calls.insert(tool_call_id.clone());
+        }
+        if matches!(tool_call.status, Some(ToolCallStatus::Completed))
+            && (is_publish || self.publish_tool_calls.contains(&tool_call_id))
+        {
+            self.published = true;
+        } else if matches!(tool_call.status, Some(ToolCallStatus::Failed)) {
+            self.publish_tool_calls.remove(&tool_call_id);
+        }
+    }
+}
+
+fn parse_request_id(value: Option<&Value>) -> Option<RequestId> {
+    serde_json::from_value(value?.clone()).ok()
+}
+
+fn parse_buzz_destination(prompt: &str) -> Option<BuzzDestination> {
+    let context = prompt.split_once("[Context]\n")?.1;
+    let context = context.find("\n[").map_or(context, |end| &context[..end]);
+    let channel_line = context
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Channel: "))?;
+    let channel = parse_channel_uuid(channel_line)?;
+    Some(BuzzDestination {
+        channel,
+        reply_to: parse_reply_target(context),
+    })
+}
+
+fn parse_channel_uuid(value: &str) -> Option<String> {
+    let candidate = if let Some(start) = value.find("(#") {
+        let rest = &value[start + 2..];
+        &rest[..rest.find(')')?]
+    } else {
+        value.trim().trim_start_matches('#')
+    };
+    Uuid::parse_str(candidate.trim())
+        .ok()
+        .map(|uuid| uuid.to_string())
+}
+
+fn parse_reply_target(context: &str) -> Option<String> {
+    const MARKER: &str = "--reply-to ";
+    let mut remaining = context;
+    while let Some(start) = remaining.find(MARKER) {
+        let candidate = remaining[start + MARKER.len()..]
+            .trim_start_matches(['`', '\'', '"'])
+            .chars()
+            .take_while(char::is_ascii_hexdigit)
+            .collect::<String>();
+        if candidate.len() == 64 {
+            return Some(candidate);
+        }
+        remaining = &remaining[start + MARKER.len()..];
+    }
+    None
+}
+
+fn value_contains_buzz_message_send(value: &Value) -> bool {
+    match value {
+        Value::String(text) => command_contains_buzz_message_send(text),
+        Value::Array(values) => values.iter().any(value_contains_buzz_message_send),
+        Value::Object(values) => values.values().any(value_contains_buzz_message_send),
+        _ => false,
+    }
+}
+
+fn command_contains_buzz_message_send(command: &str) -> bool {
+    let tokens = command
+        .split_whitespace()
+        .map(|token| {
+            token.trim_matches(|character: char| {
+                matches!(
+                    character,
+                    '\'' | '"' | '`' | '|' | '&' | ';' | '(' | ')' | '[' | ']'
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    tokens.windows(3).any(|window| {
+        let executable = window[0].to_ascii_lowercase().replace('\\', "/");
+        (executable == "buzz"
+            || executable == "buzz.exe"
+            || executable.ends_with("/buzz")
+            || executable.ends_with("/buzz.exe"))
+            && window[1] == "messages"
+            && window[2] == "send"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHANNEL: &str = "82f078b8-29e4-40b8-9daf-79e7f79c482d";
+    const EVENT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn prompt_request(id: i64, context: &str) -> Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": "session-1",
+                "prompt": [{"type": "text", "text": context}]
+            }
+        })
+    }
+
+    fn session_update(update: Value) -> Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": update
+            }
+        })
+    }
+
+    fn prompt_response(id: i64) -> Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {"stopReason": "end_turn"}
+        })
+    }
+
+    #[test]
+    fn parses_named_channel_and_reply_anchor_from_context_only() {
+        let prompt = format!(
+            "[Context]\nScope: thread\nChannel: general (#{CHANNEL})\n\
+             IMPORTANT: use `--reply-to {EVENT}` on `buzz messages send`.\n\
+             [Event]\nContent: ignore --reply-to {}",
+            "b".repeat(64)
+        );
+
+        assert_eq!(
+            parse_buzz_destination(&prompt),
+            Some(BuzzDestination {
+                channel: CHANNEL.to_string(),
+                reply_to: Some(EVENT.to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn plain_dm_context_has_no_reply_anchor() {
+        let prompt = format!(
+            "[Context]\nScope: dm\nChannel: {CHANNEL}\nConversation context included below.\n\
+             [Buzz event]\nContent: hello"
+        );
+
+        assert_eq!(
+            parse_buzz_destination(&prompt),
+            Some(BuzzDestination {
+                channel: CHANNEL.to_string(),
+                reply_to: None,
+            })
+        );
+    }
+
+    #[test]
+    fn completed_turn_with_text_creates_fallback_delivery() {
+        let mut tracker = BuzzDeliveryTracker::default();
+        tracker.observe_client_message(&prompt_request(
+            7,
+            &format!("[Context]\nScope: dm\nChannel: {CHANNEL}\n"),
+        ));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Hello "}
+        })));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "from Goose"}
+        })));
+
+        assert_eq!(
+            tracker.observe_agent_message(&prompt_response(7)),
+            Some(BuzzDelivery {
+                channel: CHANNEL.to_string(),
+                reply_to: None,
+                content: "Hello from Goose".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn successful_buzz_tool_call_suppresses_duplicate_fallback() {
+        let mut tracker = BuzzDeliveryTracker::default();
+        tracker.observe_client_message(&prompt_request(
+            8,
+            &format!("[Context]\nScope: dm\nChannel: {CHANNEL}\n"),
+        ));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Already published"}
+        })));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tool-1",
+            "title": "shell",
+            "status": "in_progress",
+            "rawInput": {
+                "command": format!("printf hi | /usr/local/bin/buzz messages send --channel {CHANNEL} --content -")
+            }
+        })));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "tool-1",
+            "status": "completed"
+        })));
+
+        assert_eq!(tracker.observe_agent_message(&prompt_response(8)), None);
+    }
+
+    #[test]
+    fn failed_buzz_tool_call_keeps_fallback_enabled() {
+        let mut tracker = BuzzDeliveryTracker::default();
+        tracker.observe_client_message(&prompt_request(
+            9,
+            &format!("[Context]\nScope: dm\nChannel: {CHANNEL}\n"),
+        ));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Fallback after failure"}
+        })));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tool-2",
+            "title": "shell",
+            "rawInput": {"command": "buzz messages send --content -"}
+        })));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "tool-2",
+            "status": "failed"
+        })));
+
+        assert!(tracker.observe_agent_message(&prompt_response(9)).is_some());
+    }
+
+    #[test]
+    fn errors_and_non_buzz_prompts_never_publish() {
+        let mut tracker = BuzzDeliveryTracker::default();
+        tracker.observe_client_message(&prompt_request(10, "ordinary ACP prompt"));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "not for Buzz"}
+        })));
+        assert_eq!(tracker.observe_agent_message(&prompt_response(10)), None);
+
+        tracker.observe_client_message(&prompt_request(
+            11,
+            &format!("[Context]\nScope: dm\nChannel: {CHANNEL}\n"),
+        ));
+        tracker.observe_agent_message(&session_update(serde_json::json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "partial"}
+        })));
+        assert_eq!(
+            tracker.observe_agent_message(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 11,
+                "error": {"code": -32000, "message": "failed"}
+            })),
+            None
+        );
+    }
+}

--- a/rust/crates/cli/Cargo.toml
+++ b/rust/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ redis-session-store = ["pay-core/redis-session-store", "pay-kit/redis-store"]
 async-trait = "0.1"
 axum = { workspace = true }
 pay-core = { workspace = true, features = ["server", "otel"] }
+pay-acp = { workspace = true }
 pay-proxy = { path = "../proxy" }
 pay-keystore = { workspace = true }
 pay-types = { workspace = true }

--- a/rust/crates/cli/src/commands/acp.rs
+++ b/rust/crates/cli/src/commands/acp.rs
@@ -1,0 +1,348 @@
+//! `pay acp <harness>` — run an ACP adapter through Pay's payer proxy.
+//!
+//! ACP uses stdin/stdout for JSON-RPC. Launches are transparent outside Buzz;
+//! Buzz-managed launches add a stream middleware that publishes final assistant
+//! text when the model did not invoke `buzz messages send` itself. Provider
+//! selection uses the existing stderr-backed TUI when interactive, while
+//! `--provider`/`--model` (or their environment equivalents) make managed,
+//! headless launches deterministic.
+
+use std::process::{Command, Stdio};
+
+use clap::{Args, ValueEnum};
+
+use super::claude::{
+    AlternateClient, AlternateProvider, claude_env, prepare_alternate_provider_for,
+};
+use super::codex::write_model_catalog_file;
+use super::goose::goose_provider_env;
+
+const ACP_PROVIDER_ENV: &str = "PAY_ACP_PROVIDER";
+const ACP_MODEL_ENV: &str = "PAY_ACP_MODEL";
+const CODEX_PROVIDER_ID: &str = "pay_acp";
+
+/// Run an ACP-compatible agent harness with paid inference routing.
+#[derive(Args)]
+pub struct AcpCommand {
+    /// ACP harness to launch.
+    #[arg(value_enum)]
+    pub harness: AcpHarness,
+
+    /// Pay inference-provider slug. Required for headless launches when more
+    /// than one compatible provider is available.
+    #[arg(long, value_name = "SLUG")]
+    pub provider: Option<String>,
+
+    /// Model exposed by the selected provider.
+    #[arg(short, long, value_name = "MODEL")]
+    pub model: Option<String>,
+
+    /// Arguments forwarded to the ACP adapter. Place them after `--`.
+    #[arg(last = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
+}
+
+/// ACP runtimes whose inference configuration Pay knows how to override.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum AcpHarness {
+    Goose,
+    Claude,
+    Codex,
+}
+
+impl AcpHarness {
+    fn alternate_client(self) -> AlternateClient {
+        match self {
+            Self::Goose => AlternateClient::Goose,
+            Self::Claude => AlternateClient::Claude,
+            Self::Codex => AlternateClient::Codex,
+        }
+    }
+
+    fn adapter_program(self) -> &'static str {
+        match self {
+            Self::Goose => "goose",
+            Self::Claude => "claude-agent-acp",
+            Self::Codex => "codex-acp",
+        }
+    }
+
+    fn install_hint(self) -> &'static str {
+        match self {
+            Self::Goose => {
+                "Install Goose: https://block.github.io/goose/docs/getting-started/installation"
+            }
+            Self::Claude => {
+                "Install the adapter: npm install -g @agentclientprotocol/claude-agent-acp"
+            }
+            Self::Codex => "Install the adapter: npm install -g @agentclientprotocol/codex-acp",
+        }
+    }
+}
+
+impl AcpCommand {
+    pub fn run(
+        self,
+        active_account_name: Option<&str>,
+        network_override: Option<&str>,
+    ) -> pay_core::Result<i32> {
+        let provider =
+            effective_override(self.provider.as_deref(), std::env::var(ACP_PROVIDER_ENV));
+        let model = effective_override(self.model.as_deref(), std::env::var(ACP_MODEL_ENV));
+        let selection_args = model
+            .as_ref()
+            .map(|model| vec!["--model".to_string(), model.clone()])
+            .unwrap_or_default();
+
+        let alternate = prepare_alternate_provider_for(
+            self.harness.alternate_client(),
+            &selection_args,
+            network_override,
+            active_account_name,
+            provider.as_deref(),
+        )?;
+        let launch = AcpLaunch::new(self.harness, alternate, self.args)?;
+        launch.run(active_account_name)
+    }
+}
+
+fn effective_override(
+    cli: Option<&str>,
+    env: Result<String, std::env::VarError>,
+) -> Option<String> {
+    cli.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            env.ok()
+                .map(|value| value.trim().to_string())
+                .filter(|v| !v.is_empty())
+        })
+}
+
+#[derive(Debug)]
+struct AcpLaunch {
+    harness: AcpHarness,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    // Codex reads this file throughout the adapter process lifetime.
+    _model_catalog_file: Option<tempfile::NamedTempFile>,
+}
+
+impl AcpLaunch {
+    fn new(
+        harness: AcpHarness,
+        alternate: AlternateProvider,
+        extra_args: Vec<String>,
+    ) -> pay_core::Result<Self> {
+        let model = alternate.model.as_deref().ok_or_else(|| {
+            pay_core::Error::Config(format!(
+                "{} ACP routing requires a model; pass `--model <MODEL>` or set {ACP_MODEL_ENV}",
+                harness.adapter_program()
+            ))
+        })?;
+
+        let mut model_catalog_file = None;
+        let (args, env) = match harness {
+            AcpHarness::Goose => {
+                let mut args = vec!["acp".to_string()];
+                args.extend(extra_args);
+                let mut env = goose_provider_env(&alternate, model);
+                env.push(("GOOSE_MODE".to_string(), "auto".to_string()));
+                (args, env)
+            }
+            AcpHarness::Claude => {
+                let mut env = claude_env(&alternate.base_url, Some(model));
+                // The ACP adapter does not receive Claude's `--model` flag.
+                // These variables both select the model and make arbitrary
+                // gateway model IDs visible in its ACP model options.
+                env.extend([
+                    ("ANTHROPIC_MODEL".to_string(), model.to_string()),
+                    (
+                        "ANTHROPIC_CUSTOM_MODEL_OPTION".to_string(),
+                        model.to_string(),
+                    ),
+                ]);
+                (extra_args, env)
+            }
+            AcpHarness::Codex => {
+                let catalog = write_model_catalog_file(model)?;
+                let env = codex_acp_env(&alternate, model, catalog.path())?;
+                model_catalog_file = Some(catalog);
+                (extra_args, env)
+            }
+        };
+
+        Ok(Self {
+            harness,
+            args,
+            env,
+            _model_catalog_file: model_catalog_file,
+        })
+    }
+
+    fn run(self, active_account_name: Option<&str>) -> pay_core::Result<i32> {
+        let mut command = adapter_command(self.harness);
+        command.args(&self.args).envs(self.env);
+
+        if let Some(account) = active_account_name {
+            command.env("PAY_ACTIVE_ACCOUNT", account);
+        }
+
+        let result = if super::acp_middleware::buzz_delivery_available() {
+            super::acp_middleware::run(command)
+        } else {
+            command
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .map(|status| status.code().unwrap_or(1))
+        };
+        result.map_err(|error| {
+            pay_core::Error::Config(format!(
+                "Failed to launch `{}`: {error}. {}",
+                self.harness.adapter_program(),
+                self.harness.install_hint()
+            ))
+        })
+    }
+}
+
+fn codex_acp_env(
+    alternate: &AlternateProvider,
+    model: &str,
+    model_catalog_path: &std::path::Path,
+) -> pay_core::Result<Vec<(String, String)>> {
+    let config = serde_json::json!({
+        "model": model,
+        "model_provider": CODEX_PROVIDER_ID,
+        "model_reasoning_effort": "none",
+        "model_catalog_json": model_catalog_path,
+        "model_providers": {
+            CODEX_PROVIDER_ID: {
+                "name": "Pay ACP provider",
+                "base_url": alternate.base_url,
+                "wire_api": "responses",
+                "env_key": "OPENAI_API_KEY",
+                "requires_openai_auth": false
+            }
+        }
+    });
+
+    Ok(vec![
+        ("CODEX_CONFIG".to_string(), serde_json::to_string(&config)?),
+        ("MODEL_PROVIDER".to_string(), CODEX_PROVIDER_ID.to_string()),
+        ("OPENAI_API_KEY".to_string(), "pay".to_string()),
+        ("CODEX_API_KEY".to_string(), "pay".to_string()),
+        ("NO_BROWSER".to_string(), "1".to_string()),
+    ])
+}
+
+#[cfg(not(windows))]
+fn adapter_command(harness: AcpHarness) -> Command {
+    Command::new(harness.adapter_program())
+}
+
+// npm-installed ACP adapters are `.cmd` shims on Windows. Run those through
+// cmd.exe while keeping stdin/stdout inherited so ACP JSON-RPC remains
+// transparent. Goose is a native executable and does not need the shell.
+#[cfg(windows)]
+fn adapter_command(harness: AcpHarness) -> Command {
+    if harness == AcpHarness::Goose {
+        return Command::new(harness.adapter_program());
+    }
+    let mut command = Command::new("cmd.exe");
+    command.args(["/D", "/S", "/C", harness.adapter_program()]);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alternate(model: Option<&str>) -> AlternateProvider {
+        AlternateProvider {
+            base_url: "http://127.0.0.1:54321/v1".to_string(),
+            model: model.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn cli_override_wins_over_environment() {
+        assert_eq!(
+            effective_override(Some(" modelstudio "), Ok("other".to_string())),
+            Some("modelstudio".to_string())
+        );
+        assert_eq!(
+            effective_override(None, Ok(" qwen3.7-plus ".to_string())),
+            Some("qwen3.7-plus".to_string())
+        );
+    }
+
+    #[test]
+    fn goose_launches_its_native_acp_subcommand() {
+        let launch =
+            AcpLaunch::new(AcpHarness::Goose, alternate(Some("qwen3.7-plus")), vec![]).unwrap();
+
+        assert_eq!(launch.args, ["acp"]);
+        assert!(
+            launch
+                .env
+                .contains(&("GOOSE_PROVIDER".to_string(), "openai".to_string()))
+        );
+        assert!(
+            launch
+                .env
+                .contains(&("GOOSE_MODEL".to_string(), "qwen3.7-plus".to_string()))
+        );
+    }
+
+    #[test]
+    fn claude_acp_receives_gateway_and_custom_model_environment() {
+        let launch =
+            AcpLaunch::new(AcpHarness::Claude, alternate(Some("qwen3.7-plus")), vec![]).unwrap();
+
+        assert!(launch.env.contains(&(
+            "ANTHROPIC_BASE_URL".to_string(),
+            "http://127.0.0.1:54321/v1".to_string()
+        )));
+        assert!(
+            launch
+                .env
+                .contains(&("ANTHROPIC_MODEL".to_string(), "qwen3.7-plus".to_string()))
+        );
+    }
+
+    #[test]
+    fn codex_acp_receives_pay_model_provider_config() {
+        let launch = AcpLaunch::new(AcpHarness::Codex, alternate(Some("gpt-5.4")), vec![]).unwrap();
+        let config = launch
+            .env
+            .iter()
+            .find(|(key, _)| key == "CODEX_CONFIG")
+            .map(|(_, value)| value)
+            .unwrap();
+        let config: serde_json::Value = serde_json::from_str(config).unwrap();
+
+        assert_eq!(config["model"], "gpt-5.4");
+        assert_eq!(config["model_provider"], CODEX_PROVIDER_ID);
+        let catalog_path = config["model_catalog_json"].as_str().unwrap();
+        assert!(std::path::Path::new(catalog_path).is_file());
+        assert_eq!(
+            config["model_providers"][CODEX_PROVIDER_ID]["base_url"],
+            "http://127.0.0.1:54321/v1"
+        );
+        assert_eq!(
+            config["model_providers"][CODEX_PROVIDER_ID]["wire_api"],
+            "responses"
+        );
+    }
+
+    #[test]
+    fn headless_gateway_fallback_requires_a_model() {
+        let error = AcpLaunch::new(AcpHarness::Goose, alternate(None), vec![]).unwrap_err();
+
+        assert!(error.to_string().contains(ACP_MODEL_ENV));
+    }
+}

--- a/rust/crates/cli/src/commands/acp_middleware.rs
+++ b/rust/crates/cli/src/commands/acp_middleware.rs
@@ -1,0 +1,151 @@
+//! CLI transport and Buzz publisher for the reusable `pay-acp` tracker.
+
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread;
+
+use pay_acp::{BuzzDelivery, BuzzDeliveryTracker};
+
+const BUZZ_RELAY_URL_ENV: &str = "BUZZ_RELAY_URL";
+const BUZZ_PRIVATE_KEY_ENV: &str = "BUZZ_PRIVATE_KEY";
+
+/// Whether this ACP launch has the credentials needed to publish as a
+/// Buzz-managed agent.
+pub(super) fn buzz_delivery_available() -> bool {
+    nonempty_env(BUZZ_RELAY_URL_ENV) && nonempty_env(BUZZ_PRIVATE_KEY_ENV)
+}
+
+fn nonempty_env(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| !value.trim().is_empty())
+}
+
+/// Run an ACP child with stdin/stdout relayed byte-for-byte while observing
+/// complete NDJSON frames for Buzz delivery state.
+pub(super) fn run(mut command: Command) -> io::Result<i32> {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+    let child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| io::Error::other("ACP child stdin was not piped"))?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("ACP child stdout was not piped"))?;
+
+    let tracker = Arc::new(Mutex::new(BuzzDeliveryTracker::default()));
+    let input_tracker = Arc::clone(&tracker);
+    thread::spawn(move || relay_client_input(io::stdin(), child_stdin, input_tracker));
+
+    relay_agent_output(child_stdout, io::stdout(), tracker)?;
+    let status = child.wait()?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn relay_client_input<R: Read, W: Write>(
+    input: R,
+    mut child_stdin: W,
+    tracker: Arc<Mutex<BuzzDeliveryTracker>>,
+) {
+    let mut reader = BufReader::new(input);
+    let mut frame = Vec::new();
+    loop {
+        frame.clear();
+        match reader.read_until(b'\n', &mut frame) {
+            Ok(0) => break,
+            Ok(_) => {
+                lock_tracker(&tracker).observe_client_frame(&frame);
+                if child_stdin.write_all(&frame).is_err() || child_stdin.flush().is_err() {
+                    break;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Pay ACP middleware could not read client input");
+                break;
+            }
+        }
+    }
+}
+
+fn relay_agent_output<R: Read, W: Write>(
+    output: R,
+    destination: W,
+    tracker: Arc<Mutex<BuzzDeliveryTracker>>,
+) -> io::Result<()> {
+    let mut reader = BufReader::new(output);
+    let mut destination = BufWriter::new(destination);
+    let mut frame = Vec::new();
+    loop {
+        frame.clear();
+        if reader.read_until(b'\n', &mut frame)? == 0 {
+            break;
+        }
+
+        let delivery = lock_tracker(&tracker).observe_agent_frame(&frame);
+        if let Some(delivery) = delivery {
+            publish_fallback(&delivery);
+        }
+
+        destination.write_all(&frame)?;
+        destination.flush()?;
+    }
+    Ok(())
+}
+
+fn lock_tracker(tracker: &Arc<Mutex<BuzzDeliveryTracker>>) -> MutexGuard<'_, BuzzDeliveryTracker> {
+    tracker
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn publish_fallback(delivery: &BuzzDelivery) {
+    let mut command = Command::new("buzz");
+    command
+        .args(["messages", "send", "--channel", &delivery.channel])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(reply_to) = delivery.reply_to.as_deref() {
+        command.args(["--reply-to", reply_to]);
+    }
+    command.args(["--content", "-"]);
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            tracing::warn!(%error, "Pay ACP fallback could not launch `buzz messages send`");
+            return;
+        }
+    };
+    let write_error = child
+        .stdin
+        .take()
+        .and_then(|mut stdin| stdin.write_all(delivery.content.as_bytes()).err());
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(error) => {
+            tracing::warn!(%error, "Pay ACP fallback could not wait for `buzz messages send`");
+            return;
+        }
+    };
+    if let Some(error) = write_error {
+        tracing::warn!(%error, "Pay ACP fallback could not write message content");
+    } else if output.status.success() {
+        tracing::info!(
+            channel = %delivery.channel,
+            reply_to = ?delivery.reply_to,
+            "Pay ACP published assistant text to Buzz"
+        );
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::warn!(
+            status = ?output.status.code(),
+            error = %stderr.trim(),
+            "Pay ACP fallback `buzz messages send` failed"
+        );
+    }
+}

--- a/rust/crates/cli/src/commands/buzz_setup.rs
+++ b/rust/crates/cli/src/commands/buzz_setup.rs
@@ -1,0 +1,445 @@
+//! Setup-time registration of Pay as a Buzz custom ACP harness.
+
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
+use owo_colors::OwoColorize;
+use serde::{Deserialize, Serialize};
+
+use super::claude::{AlternateClient, AlternateProviderOption, discover_acp_provider_options};
+
+const BUZZ_APP_ID: &str = "xyz.block.buzz.app";
+const HARNESS_ID: &str = "pay-acp";
+const HARNESS_FILE: &str = "pay-acp.json";
+const PROVIDER_ENV: &str = "PAY_ACP_PROVIDER";
+const MODEL_ENV: &str = "PAY_ACP_MODEL";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AcpRuntime {
+    Goose,
+    Claude,
+    Codex,
+}
+
+impl AcpRuntime {
+    const ALL: [Self; 3] = [Self::Goose, Self::Claude, Self::Codex];
+
+    fn slug(self) -> &'static str {
+        match self {
+            Self::Goose => "goose",
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Goose => "Goose",
+            Self::Claude => "Claude Code",
+            Self::Codex => "Codex",
+        }
+    }
+
+    fn command(self) -> &'static str {
+        match self {
+            Self::Goose => "goose",
+            Self::Claude => "claude-agent-acp",
+            Self::Codex => "codex-acp",
+        }
+    }
+
+    fn alternate_client(self) -> AlternateClient {
+        match self {
+            Self::Goose => AlternateClient::Goose,
+            Self::Claude => AlternateClient::Claude,
+            Self::Codex => AlternateClient::Codex,
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|runtime| runtime.slug() == value)
+    }
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BuzzHarnessDefinition {
+    id: String,
+    label: String,
+    command: String,
+    args: Vec<String>,
+    env: BTreeMap<String, String>,
+    install_instructions_url: String,
+    install_hint: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HarnessWriteResult {
+    Added,
+    AlreadyPresent,
+    Updated,
+}
+
+/// Detect Buzz Desktop and offer to register a deterministic Pay-backed ACP
+/// harness. Setup remains successful when this optional integration is skipped
+/// or cannot be configured.
+pub(crate) fn maybe_configure() {
+    let Some(app_data_dir) = detect_buzz_app_data_dir() else {
+        return;
+    };
+
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        eprintln!(
+            "  {} Buzz detected; run `pay setup --update` in a terminal to configure its Pay ACP harness.",
+            "!".yellow()
+        );
+        return;
+    }
+
+    if let Err(error) = configure_interactively(&app_data_dir) {
+        eprintln!("  {} Failed to configure Buzz: {error}", "!".yellow());
+    }
+}
+
+fn configure_interactively(app_data_dir: &Path) -> Result<(), String> {
+    eprintln!();
+    let theme = ColorfulTheme::default();
+    let configure = Confirm::with_theme(&theme)
+        .with_prompt("Configure Pay as a custom ACP harness in Buzz?")
+        .default(true)
+        .interact()
+        .map_err(|error| format!("Buzz setup prompt: {error}"))?;
+    if !configure {
+        return Ok(());
+    }
+
+    let harness_path = app_data_dir.join("custom_harnesses").join(HARNESS_FILE);
+    let existing = read_harness(&harness_path);
+    let runtimes = installed_runtimes();
+    if runtimes.is_empty() {
+        return Err(
+            "no supported ACP runtime found; install Goose, claude-agent-acp, or codex-acp first"
+                .to_string(),
+        );
+    }
+
+    let previous_runtime = existing
+        .as_ref()
+        .and_then(|definition| definition.args.get(1))
+        .and_then(|slug| AcpRuntime::parse(slug));
+    let runtime_default = previous_runtime
+        .and_then(|selected| runtimes.iter().position(|runtime| *runtime == selected))
+        .unwrap_or_default();
+    let runtime_labels = runtimes
+        .iter()
+        .map(|runtime| runtime.label())
+        .collect::<Vec<_>>();
+    let runtime_index = Select::with_theme(&theme)
+        .with_prompt("ACP runtime for Buzz")
+        .items(&runtime_labels)
+        .default(runtime_default)
+        .interact()
+        .map_err(|error| format!("runtime selection: {error}"))?;
+    let runtime = runtimes[runtime_index];
+
+    eprintln!("  {}", "Discovering compatible Pay providers…".dimmed());
+    let providers = discover_acp_provider_options(runtime.alternate_client())
+        .map_err(|error| format!("provider discovery: {error}"))?;
+    if providers.is_empty() {
+        return Err(format!(
+            "no compatible Pay provider is currently available for {}",
+            runtime.label()
+        ));
+    }
+
+    let previous_provider = existing
+        .as_ref()
+        .and_then(|definition| definition.env.get(PROVIDER_ENV));
+    let provider_default = previous_provider
+        .and_then(|slug| {
+            providers
+                .iter()
+                .position(|provider| provider.slug.eq_ignore_ascii_case(slug))
+        })
+        .unwrap_or_default();
+    let provider_labels = providers
+        .iter()
+        .map(|provider| format!("{} ({})", provider.title, provider.slug))
+        .collect::<Vec<_>>();
+    let provider_index = Select::with_theme(&theme)
+        .with_prompt("Pay provider")
+        .items(&provider_labels)
+        .default(provider_default)
+        .interact()
+        .map_err(|error| format!("provider selection: {error}"))?;
+    let provider = &providers[provider_index];
+
+    let previous_model = existing
+        .as_ref()
+        .and_then(|definition| definition.env.get(MODEL_ENV))
+        .map(String::as_str);
+    let model = select_model(&theme, provider, previous_model)?;
+    let pay_bin = std::env::current_exe()
+        .map_err(|error| format!("resolve current pay executable: {error}"))?
+        .to_string_lossy()
+        .to_string();
+    let definition = harness_definition(runtime, &provider.slug, &model, &pay_bin);
+
+    let result = write_harness(&harness_path, &definition)?;
+    let status = match result {
+        HarnessWriteResult::Added => "added to",
+        HarnessWriteResult::AlreadyPresent => "already configured in",
+        HarnessWriteResult::Updated => "updated in",
+    };
+    eprintln!("  {} Pay + {} {status} Buzz", "✔".green(), runtime.label());
+    eprintln!(
+        "  {}",
+        "Open Buzz Settings → Harnesses to select the new runtime.".dimmed()
+    );
+    eprintln!();
+    Ok(())
+}
+
+fn select_model(
+    theme: &ColorfulTheme,
+    provider: &AlternateProviderOption,
+    previous_model: Option<&str>,
+) -> Result<String, String> {
+    if provider.models.is_empty() {
+        return Input::<String>::with_theme(theme)
+            .with_prompt("Model")
+            .with_initial_text(previous_model.unwrap_or_default())
+            .validate_with(|value: &String| -> Result<(), &str> {
+                if value.trim().is_empty() {
+                    Err("model must not be empty")
+                } else {
+                    Ok(())
+                }
+            })
+            .interact_text()
+            .map(|value| value.trim().to_string())
+            .map_err(|error| format!("model input: {error}"));
+    }
+
+    let default = previous_model
+        .and_then(|model| {
+            provider
+                .models
+                .iter()
+                .position(|candidate| candidate == model)
+        })
+        .unwrap_or_default();
+    let index = Select::with_theme(theme)
+        .with_prompt("Model")
+        .items(&provider.models)
+        .default(default)
+        .interact()
+        .map_err(|error| format!("model selection: {error}"))?;
+    Ok(provider.models[index].clone())
+}
+
+fn harness_definition(
+    runtime: AcpRuntime,
+    provider: &str,
+    model: &str,
+    pay_bin: &str,
+) -> BuzzHarnessDefinition {
+    BuzzHarnessDefinition {
+        id: HARNESS_ID.to_string(),
+        label: format!("Pay + {}", runtime.label()),
+        command: pay_bin.to_string(),
+        args: vec!["acp".to_string(), runtime.slug().to_string()],
+        env: BTreeMap::from([
+            (PROVIDER_ENV.to_string(), provider.to_string()),
+            (MODEL_ENV.to_string(), model.to_string()),
+        ]),
+        install_instructions_url: "https://github.com/solana-foundation/pay".to_string(),
+        install_hint: "Run `pay setup --update` to reconfigure this harness.".to_string(),
+    }
+}
+
+fn read_harness(path: &Path) -> Option<BuzzHarnessDefinition> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_harness(
+    path: &Path,
+    definition: &BuzzHarnessDefinition,
+) -> Result<HarnessWriteResult, String> {
+    if read_harness(path).as_ref() == Some(definition) {
+        return Ok(HarnessWriteResult::AlreadyPresent);
+    }
+    let existed = path.exists();
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("create {}: {error}", parent.display()))?;
+    let json = serde_json::to_string_pretty(definition)
+        .map_err(|error| format!("serialize Buzz harness: {error}"))?;
+    std::fs::write(path, json + "\n")
+        .map_err(|error| format!("write {}: {error}", path.display()))?;
+    Ok(if existed {
+        HarnessWriteResult::Updated
+    } else {
+        HarnessWriteResult::Added
+    })
+}
+
+fn installed_runtimes() -> Vec<AcpRuntime> {
+    AcpRuntime::ALL
+        .into_iter()
+        .filter(|runtime| command_on_path(runtime.command()))
+        .collect()
+}
+
+fn command_on_path(command: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    let extensions: &[&str] = if cfg!(windows) {
+        &["", ".exe", ".cmd", ".bat"]
+    } else {
+        &[""]
+    };
+    std::env::split_paths(&path).any(|directory| {
+        extensions
+            .iter()
+            .any(|extension| directory.join(format!("{command}{extension}")).is_file())
+    })
+}
+
+fn detect_buzz_app_data_dir() -> Option<PathBuf> {
+    let app_data_dir = buzz_app_data_dir()?;
+    if app_data_dir.exists() || buzz_install_markers().iter().any(|path| path.exists()) {
+        Some(app_data_dir)
+    } else {
+        None
+    }
+}
+
+fn buzz_app_data_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        home_dir().map(|home| {
+            home.join("Library")
+                .join("Application Support")
+                .join(BUZZ_APP_ID)
+        })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var_os("APPDATA")
+            .map(PathBuf::from)
+            .map(|path| path.join(BUZZ_APP_ID))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home_dir().map(|home| home.join(".local").join("share")))
+            .map(|path| path.join(BUZZ_APP_ID))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+fn buzz_install_markers() -> Vec<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut markers = vec![PathBuf::from("/Applications/Buzz.app")];
+        if let Some(home) = home_dir() {
+            markers.push(home.join("Applications").join("Buzz.app"));
+        }
+        markers
+    }
+    #[cfg(target_os = "windows")]
+    {
+        ["ProgramFiles", "LOCALAPPDATA"]
+            .into_iter()
+            .filter_map(std::env::var_os)
+            .map(PathBuf::from)
+            .map(|path| path.join("Buzz").join("Buzz.exe"))
+            .collect()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        vec![
+            PathBuf::from("/usr/bin/buzz"),
+            PathBuf::from("/usr/local/bin/buzz"),
+            PathBuf::from("/opt/Buzz/buzz"),
+        ]
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buzz_harness_matches_custom_harness_schema() {
+        let definition = harness_definition(
+            AcpRuntime::Goose,
+            "modelstudio",
+            "qwen3.7-plus",
+            "/usr/local/bin/pay",
+        );
+        let json = serde_json::to_value(&definition).unwrap();
+
+        assert_eq!(json["id"], "pay-acp");
+        assert_eq!(json["label"], "Pay + Goose");
+        assert_eq!(json["command"], "/usr/local/bin/pay");
+        assert_eq!(json["args"], serde_json::json!(["acp", "goose"]));
+        assert_eq!(json["env"][PROVIDER_ENV], "modelstudio");
+        assert_eq!(json["env"][MODEL_ENV], "qwen3.7-plus");
+        assert!(json.get("installInstructionsUrl").is_some());
+        assert!(json.get("installHint").is_some());
+    }
+
+    #[test]
+    fn harness_write_adds_updates_and_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("custom_harnesses").join(HARNESS_FILE);
+        let first = harness_definition(AcpRuntime::Goose, "modelstudio", "qwen", "/bin/pay");
+        let second = harness_definition(AcpRuntime::Codex, "openai", "gpt-5", "/new/pay");
+
+        assert_eq!(
+            write_harness(&path, &first).unwrap(),
+            HarnessWriteResult::Added
+        );
+        assert_eq!(
+            write_harness(&path, &first).unwrap(),
+            HarnessWriteResult::AlreadyPresent
+        );
+        assert_eq!(
+            write_harness(&path, &second).unwrap(),
+            HarnessWriteResult::Updated
+        );
+        assert_eq!(read_harness(&path), Some(second));
+    }
+
+    #[test]
+    fn runtime_parser_accepts_only_supported_acp_runtime_slugs() {
+        assert_eq!(AcpRuntime::parse("goose"), Some(AcpRuntime::Goose));
+        assert_eq!(AcpRuntime::parse("claude"), Some(AcpRuntime::Claude));
+        assert_eq!(AcpRuntime::parse("codex"), Some(AcpRuntime::Codex));
+        assert_eq!(AcpRuntime::parse("unknown"), None);
+    }
+}

--- a/rust/crates/cli/src/commands/claude/mod.rs
+++ b/rust/crates/cli/src/commands/claude/mod.rs
@@ -233,6 +233,15 @@ pub(crate) struct AlternateProvider {
     pub model: Option<String>,
 }
 
+/// Provider metadata used by setup-time integrations that need a deterministic,
+/// headless `pay --alt` route without starting the payer proxy yet.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AlternateProviderOption {
+    pub slug: String,
+    pub title: String,
+    pub models: Vec<String>,
+}
+
 #[derive(Clone, Copy)]
 enum AlternateRouteKind {
     Hosted,
@@ -248,20 +257,19 @@ pub(crate) fn prepare_alternate_provider(
     network_override: Option<&str>,
     account_override: Option<&str>,
 ) -> pay_core::Result<AlternateProvider> {
+    prepare_alternate_provider_for(client, args, network_override, account_override, None)
+}
+
+pub(crate) fn prepare_alternate_provider_for(
+    client: AlternateClient,
+    args: &[String],
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    requested_provider: Option<&str>,
+) -> pay_core::Result<AlternateProvider> {
     let agent = client.name();
     let requested_model = model_arg(args);
-    let gateway_up = gateway_listening();
-    let mut providers = discover_local_providers()?;
-    if gateway_up {
-        let gateway_providers = gateway_provider_summaries();
-        if !gateway_providers.is_empty() {
-            apply_gateway_provider_summaries(&mut providers, &gateway_providers);
-        } else {
-            apply_gateway_proxy_fallback(&mut providers);
-        }
-    }
-    providers.extend(discover_catalog_providers());
-    providers.retain(|provider| client.provider_supported(provider));
+    let (providers, gateway_up) = discover_compatible_providers(client)?;
 
     let choice = if providers.is_empty() {
         None
@@ -270,6 +278,7 @@ pub(crate) fn prepare_alternate_provider(
             agent,
             providers,
             requested_model.as_deref(),
+            requested_provider,
         )?)
     };
 
@@ -349,6 +358,41 @@ pub(crate) fn prepare_alternate_provider(
         base_url: client.payer_base_url(&payer.base_url),
         model,
     })
+}
+
+/// Discover providers that can back an ACP runtime without launching a payer
+/// proxy. Buzz setup uses this to persist a provider and model for its
+/// headless custom-harness process.
+pub(crate) fn discover_acp_provider_options(
+    client: AlternateClient,
+) -> pay_core::Result<Vec<AlternateProviderOption>> {
+    let (providers, _) = discover_compatible_providers(client)?;
+    Ok(providers
+        .into_iter()
+        .map(|provider| AlternateProviderOption {
+            slug: provider.slug().to_string(),
+            title: provider.title().to_string(),
+            models: provider.models,
+        })
+        .collect())
+}
+
+fn discover_compatible_providers(
+    client: AlternateClient,
+) -> pay_core::Result<(Vec<DiscoveredProvider>, bool)> {
+    let gateway_up = gateway_listening();
+    let mut providers = discover_local_providers()?;
+    if gateway_up {
+        let gateway_providers = gateway_provider_summaries();
+        if !gateway_providers.is_empty() {
+            apply_gateway_provider_summaries(&mut providers, &gateway_providers);
+        } else {
+            apply_gateway_proxy_fallback(&mut providers);
+        }
+    }
+    providers.extend(discover_catalog_providers());
+    providers.retain(|provider| client.provider_supported(provider));
+    Ok((providers, gateway_up))
 }
 
 fn print_alternate_route(
@@ -531,7 +575,37 @@ fn select_provider_choice(
     agent: &str,
     providers: Vec<DiscoveredProvider>,
     requested_model: Option<&str>,
+    requested_provider: Option<&str>,
 ) -> pay_core::Result<crate::tui::ProviderChoice> {
+    if let Some(requested_provider) = requested_provider {
+        let available = providers
+            .iter()
+            .map(DiscoveredProvider::slug)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let provider = providers
+            .into_iter()
+            .find(|provider| {
+                provider.slug().eq_ignore_ascii_case(requested_provider)
+                    || provider.title().eq_ignore_ascii_case(requested_provider)
+            })
+            .ok_or_else(|| {
+                pay_core::Error::Config(format!(
+                    "provider `{requested_provider}` is not available for {agent}; available providers: {available}"
+                ))
+            })?;
+        let model = requested_model
+            .map(str::to_string)
+            .or_else(|| provider.models.first().cloned())
+            .ok_or_else(|| {
+                pay_core::Error::Config(format!(
+                    "provider `{}` did not report any models; pass `--model <MODEL>`",
+                    provider.slug()
+                ))
+            })?;
+        return Ok(crate::tui::ProviderChoice { provider, model });
+    }
+
     match select_provider(agent, providers, requested_model)
         .map_err(|e| pay_core::Error::Config(format!("Provider selection failed: {e}")))?
     {
@@ -737,7 +811,7 @@ fn claude_args_with_model(args: &[String], model: Option<&str>) -> Vec<String> {
     out
 }
 
-fn claude_env(base_url: &str, model: Option<&str>) -> Vec<(String, String)> {
+pub(crate) fn claude_env(base_url: &str, model: Option<&str>) -> Vec<(String, String)> {
     let mut env = vec![
         (ANTHROPIC_BASE_URL_ENV.to_string(), base_url.to_string()),
         (ANTHROPIC_API_KEY_ENV.to_string(), String::new()),

--- a/rust/crates/cli/src/commands/codex.rs
+++ b/rust/crates/cli/src/commands/codex.rs
@@ -179,7 +179,7 @@ fn build_codex_args(
     args
 }
 
-fn write_model_catalog_file(model: &str) -> pay_core::Result<tempfile::NamedTempFile> {
+pub(crate) fn write_model_catalog_file(model: &str) -> pay_core::Result<tempfile::NamedTempFile> {
     use std::io::Write;
 
     let mut file = tempfile::Builder::new()

--- a/rust/crates/cli/src/commands/codex.rs
+++ b/rust/crates/cli/src/commands/codex.rs
@@ -1,5 +1,5 @@
 #[cfg(windows)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use clap::Args;

--- a/rust/crates/cli/src/commands/goose.rs
+++ b/rust/crates/cli/src/commands/goose.rs
@@ -88,7 +88,10 @@ fn launch_goose(
     Ok(status.code().unwrap_or(1))
 }
 
-fn goose_provider_env(alternate: &AlternateProvider, model: &str) -> Vec<(String, String)> {
+pub(crate) fn goose_provider_env(
+    alternate: &AlternateProvider,
+    model: &str,
+) -> Vec<(String, String)> {
     vec![
         (GOOSE_PROVIDER_ENV.to_string(), "openai".to_string()),
         (GOOSE_MODEL_ENV.to_string(), model.to_string()),

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -243,7 +243,9 @@ impl Command {
             }
             Command::Setup(cmd) => return cmd.run(),
             Command::Topup(cmd) => return cmd.run(),
-            Command::Server { command } => return command.run(keypair_override, sandbox),
+            Command::Server { command } => {
+                return command.run(keypair_override, account_override, sandbox);
+            }
             Command::Mcp => {
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -572,6 +574,7 @@ fn handle_outcome(
                 return pay_session_and_retry(
                     &challenge,
                     req.as_ref(),
+                    &resource_url,
                     tool,
                     output_fmt,
                     fetch_headers,
@@ -1672,6 +1675,7 @@ fn pay_x402_siwx_and_retry(
 fn pay_session_and_retry(
     challenge: &mpp::Challenge,
     req: Option<&SessionRequest>,
+    resource_url: &str,
     tool: &Tool,
     output_fmt: Option<OutputFormat>,
     fetch_headers: Option<Vec<(String, String)>>,
@@ -1742,6 +1746,7 @@ fn pay_session_and_retry(
                         account_override,
                         deposit,
                         SessionMode::Pull,
+                        resource_url,
                         sandbox,
                     )?;
                 header
@@ -1769,6 +1774,7 @@ fn pay_session_and_retry(
                 network_override,
                 account_override,
                 deposit,
+                resource_url,
                 sandbox,
             )?;
             header

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -1,5 +1,8 @@
 pub mod account;
+pub mod acp;
+mod acp_middleware;
 pub(crate) mod agent_args;
+mod buzz_setup;
 pub mod catalog;
 pub mod claude;
 pub mod codex;
@@ -46,6 +49,8 @@ pub enum Command {
     Http(http::HttpCommand),
     /// Fetch a URL using the built-in HTTP client (no external tool required).
     Fetch(fetch::FetchCommand),
+    /// Run an ACP agent harness with 402 payment support.
+    Acp(acp::AcpCommand),
     /// Run Claude Code with 402 payment support.
     Claude(claude::ClaudeCommand),
     /// Run Codex with 402 payment support.
@@ -115,6 +120,7 @@ pub enum ToolKind {
     Wget,
     Http,
     Fetch,
+    Acp,
     Claude,
     Codex,
     Goose,
@@ -145,6 +151,7 @@ impl Command {
             | Command::Wget(_)
             | Command::Http(_)
             | Command::Fetch(_)
+            | Command::Acp(_)
             | Command::Claude(_)
             | Command::Codex(_)
             | Command::Goose(_)
@@ -172,6 +179,7 @@ impl Command {
             Command::Wget(_) => ToolKind::Wget,
             Command::Http(_) => ToolKind::Http,
             Command::Fetch(_) => ToolKind::Fetch,
+            Command::Acp(_) => ToolKind::Acp,
             Command::Claude(_) => ToolKind::Claude,
             Command::Codex(_) => ToolKind::Codex,
             Command::Goose(_) => ToolKind::Goose,
@@ -281,6 +289,7 @@ impl Command {
                 network_override,
                 alternate_provider,
             )?),
+            Command::Acp(cmd) => std::process::exit(cmd.run(account_override, network_override)?),
             Command::Docs { command } => return command.run(),
             _ => {}
         }

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -113,6 +113,8 @@ pub struct PayerUpstream {
 struct PayerState {
     /// Upstream base URL without a trailing slash.
     upstream: String,
+    /// Logical provider URL shown in session spending authorization.
+    authorization_url: String,
     host_header: Option<HeaderValue>,
     dialect: Dialect,
     /// Chat-completions path without a leading slash (translation target).
@@ -152,6 +154,12 @@ impl PayerState {
             .map(HeaderValue::from_str)
             .transpose()
             .map_err(|e| pay_core::Error::Config(format!("payer proxy Host header: {e}")))?;
+        let parsed_upstream = reqwest::Url::parse(&upstream.base_url)
+            .map_err(|e| pay_core::Error::Config(format!("payer proxy upstream URL: {e}")))?;
+        let authorization_url = match upstream.host_header.as_deref() {
+            Some(host) => format!("{}://{host}", parsed_upstream.scheme()),
+            None => upstream.base_url.clone(),
+        };
         // Do not impose a total request timeout: streamed completions may stay
         // open for minutes. Bound connection setup and silent read stalls so a
         // hung provider cannot retain the session mutex forever.
@@ -164,6 +172,7 @@ impl PayerState {
             .map_err(|e| pay_core::Error::Config(format!("payer proxy HTTP client: {e}")))?;
         Ok(Self {
             upstream: upstream.base_url.trim_end_matches('/').to_string(),
+            authorization_url,
             host_header,
             dialect: upstream.dialect,
             chat_path: upstream.chat_path.trim_start_matches('/').to_string(),
@@ -830,6 +839,7 @@ fn build_session_authorization(
         state.network_override.as_deref(),
         state.account_override.as_deref(),
         deposit,
+        &state.authorization_url,
         sandbox,
     )?;
 

--- a/rust/crates/cli/src/commands/server/demo.rs
+++ b/rust/crates/cli/src/commands/server/demo.rs
@@ -32,7 +32,12 @@ pub struct DemoCommand {
 }
 
 impl DemoCommand {
-    pub fn run(self, active_account_name: Option<&str>, _sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        _sandbox: bool,
+    ) -> pay_core::Result<()> {
         // Extract embedded spec to ./pay-demo.yaml in the current directory
         let spec_path = std::path::PathBuf::from("pay-demo.yaml");
         std::fs::write(&spec_path, DEMO_SPEC)
@@ -59,6 +64,6 @@ impl DemoCommand {
             no_register: false,
             scaffolded_spec: Some("./pay-demo.yaml".to_string()),
         };
-        cmd.run(active_account_name, true)
+        cmd.run(legacy_signer_source, account_override, true)
     }
 }

--- a/rust/crates/cli/src/commands/server/inference/mod.rs
+++ b/rust/crates/cli/src/commands/server/inference/mod.rs
@@ -366,7 +366,8 @@ fn usage_to_info(usage: &pay_core::InferenceUsage) -> InferenceInfo {
 impl InferenceCommand {
     pub fn run(
         self,
-        active_account_name: Option<&str>,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
         global_sandbox: bool,
     ) -> pay_core::Result<()> {
         let sandbox = self.sandbox || global_sandbox;
@@ -408,17 +409,23 @@ impl InferenceCommand {
             let signer = if let Some(signer) = state.fee_payer_signer.clone() {
                 signer
             } else {
-                let source = active_account_name.ok_or_else(|| {
+                let intent = pay_core::keystore::AuthIntent::from_reason(
+                    "register your inference service in the pay provider registry",
+                );
+                let network = if sandbox { "localnet" } else { "mainnet" };
+                let signer = super::load_account_or_legacy_signer(
+                    network,
+                    account_override,
+                    legacy_signer_source,
+                    &intent,
+                )?
+                .ok_or_else(|| {
                     pay_core::Error::Config(
                         "provider registration requires an active account; pass --no-register to serve without publishing"
                             .to_string(),
                     )
                 })?;
-                let intent = pay_core::keystore::AuthIntent::from_reason(
-                    "register your inference service in the pay provider registry",
-                );
-                Arc::new(pay_core::signer::load_signer_with_intent(source, &intent)?)
-                    as Arc<dyn SolanaSigner>
+                Arc::new(signer) as Arc<dyn SolanaSigner>
             };
             let registration = super::provider_registration::ServiceRegistration::new(
                 "inference",

--- a/rust/crates/cli/src/commands/server/mod.rs
+++ b/rust/crates/cli/src/commands/server/mod.rs
@@ -46,15 +46,55 @@ impl ServerCommand {
         }
     }
 
-    pub fn run(self, active_account_name: Option<&str>, sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        sandbox: bool,
+    ) -> pay_core::Result<()> {
         match self {
-            Self::Demo(cmd) => cmd.run(active_account_name, sandbox),
-            Self::Start(cmd) => cmd.run(active_account_name, sandbox),
-            Self::Inference(cmd) => cmd.run(active_account_name, sandbox),
+            Self::Demo(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
+            Self::Start(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
+            Self::Inference(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
             Self::Scaffold(cmd) => cmd.run(),
             Self::Plans { command } => match command {
                 PlansCommand::Publish(cmd) => cmd.run(),
             },
         }
     }
+}
+
+/// Load the account selected for `network` without flattening its auth policy.
+///
+/// Named accounts (`--account`, then `PAY_ACTIVE_ACCOUNT`) and the network's
+/// active account go through the existing account-aware loader. A raw
+/// `pay.toml`/legacy keystore source is used only when no account is selected.
+pub(crate) fn load_account_or_legacy_signer(
+    network: &str,
+    cli_account: Option<&str>,
+    legacy_source: Option<&str>,
+    intent: &pay_core::keystore::AuthIntent,
+) -> pay_core::Result<Option<pay_kit::mpp::solana_keychain::MemorySigner>> {
+    let env_account = std::env::var("PAY_ACTIVE_ACCOUNT")
+        .ok()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty());
+    let account_override = cli_account.or(env_account.as_deref());
+    let accounts = pay_core::accounts::AccountsFile::load()?;
+    let has_network_account = accounts.account_for_network(network).is_some();
+
+    if account_override.is_some() || has_network_account {
+        let store = pay_core::accounts::FileAccountsStore::default_path();
+        let (signer, _) = pay_core::signer::load_signer_for_network_with_intent(
+            network,
+            &store,
+            account_override,
+            intent,
+        )?;
+        return Ok(Some(signer));
+    }
+
+    legacy_source
+        .map(|source| pay_core::signer::load_signer_with_intent(source, intent))
+        .transpose()
 }

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -578,7 +578,12 @@ fn x402_upto_beneficiary_pubkey(
 }
 
 impl StartCommand {
-    pub fn run(self, active_account_name: Option<&str>, sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        sandbox: bool,
+    ) -> pay_core::Result<()> {
         let debugger = self.debugger || sandbox;
         let expanded = shellexpand::tilde(&self.spec);
         let contents = std::fs::read_to_string(expanded.as_ref())
@@ -715,7 +720,8 @@ impl StartCommand {
 
         let fee_payer = op.map(|o| o.fee_payer).unwrap_or(false);
         let signer_cfg = op.and_then(|o| o.signer.clone());
-        let active_account_name_owned = active_account_name.map(|s| s.to_string());
+        let legacy_signer_source = legacy_signer_source.map(str::to_string);
+        let account_override = account_override.map(str::to_string);
 
         // Create the runtime first — everything async runs inside it so
         // background tasks (like GCP auth token refresh) stay alive. Worker
@@ -769,7 +775,12 @@ impl StartCommand {
                 Some(signer)
             } else if let Some(ref cfg) = signer_cfg {
                 Some(resolve_signer(cfg).await?)
-            } else if let Some(ref source) = active_account_name_owned {
+            } else if let Some(signer) = super::load_account_or_legacy_signer(
+                network.slug(),
+                account_override.as_deref(),
+                legacy_signer_source.as_deref(),
+                &pay_core::keystore::AuthIntent::use_gateway_fee_payer(),
+            )? {
                 // Mainnet (or unknown network) with no `operator.signer`
                 // block but a default keypair from `pay setup` —
                 // typically `keychain:default`. Load it once at startup
@@ -777,8 +788,6 @@ impl StartCommand {
                 // tells the user *why* it's being asked. The same
                 // signer is then used as both the fee-payer and the
                 // recipient-pubkey source (no second load).
-                let intent = pay_core::keystore::AuthIntent::use_gateway_fee_payer();
-                let signer = pay_core::signer::load_signer_with_intent(source, &intent)?;
                 Some(Arc::new(signer) as Arc<dyn SolanaSigner>)
             } else {
                 None
@@ -792,7 +801,7 @@ impl StartCommand {
             //   3. PAY_PAYMENT_RECIPIENT env var
             //   4. fee_payer_signer's pubkey — covers sandbox, throwaway-
             //      network smart default, explicit operator.signer block,
-            //      and the active_account_name fallback (all four set
+            //      and the resolved signer fallback (all four set
             //      fee_payer_signer above).
             let recipient = if let Some(r) = op.and_then(|o| o.recipient.as_ref()) {
                 r.clone()

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -9,7 +9,7 @@ use axum::routing::{any, get, post};
 use owo_colors::OwoColorize;
 use pay_core::PaymentState;
 use pay_core::accounts::AccountsStore;
-use pay_core::server::session::SessionMpp;
+use pay_core::server::session::{SessionLifecycleReconciliation, SessionMpp};
 use pay_core::server::telemetry::FeePayerWallet;
 use pay_kit::mpp::server::Mpp;
 use pay_kit::mpp::solana_keychain::SolanaSigner;
@@ -47,14 +47,18 @@ fn default_bind() -> String {
     }
 }
 
-async fn session_channel_store() -> pay_core::Result<Arc<dyn pay_kit::mpp::store::ChannelStore>> {
+async fn session_channel_store()
+-> pay_core::Result<(Arc<dyn pay_kit::mpp::store::ChannelStore>, bool)> {
     let redis_url = std::env::var("PAY_SESSION_REDIS_URL")
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
     let Some(redis_url) = redis_url else {
-        return Ok(Arc::new(pay_kit::mpp::store::MemoryChannelStore::new()));
+        return Ok((
+            Arc::new(pay_kit::mpp::store::MemoryChannelStore::new()),
+            false,
+        ));
     };
 
     #[cfg(feature = "redis-session-store")]
@@ -70,7 +74,7 @@ async fn session_channel_store() -> pay_core::Result<Arc<dyn pay_kit::mpp::store
                 pay_core::Error::Config(format!("failed to connect session Redis store: {error}"))
             })?;
         tracing::info!("using durable Redis channel store for MPP sessions");
-        return Ok(Arc::new(store));
+        return Ok((Arc::new(store), true));
     }
 
     #[cfg(not(feature = "redis-session-store"))]
@@ -1082,7 +1086,8 @@ impl StartCommand {
                         .await?;
                 }
 
-                let session_channel_store = session_channel_store().await?;
+                let (session_channel_store, durable_session_store) =
+                    session_channel_store().await?;
                 let mut session_mpps = Vec::with_capacity(currency_configs.len());
                 for (_currency, session_mpp_currency, session_decimals) in &currency_configs {
                     let cap_base =
@@ -1121,9 +1126,15 @@ impl StartCommand {
                     }
 
                     let smpp = Arc::new(smpp);
-                    smpp.start_lifecycle_runloop_with_settlement(
+                    smpp.start_lifecycle_runloop_with_settlement_and_batching(
                         Duration::from_millis(sess.close_delay_ms),
+                        Duration::from_millis(sess.close_batch_interval_ms),
                         Duration::from_millis(sess.settlement_interval_ms),
+                        if durable_session_store {
+                            SessionLifecycleReconciliation::External
+                        } else {
+                            SessionLifecycleReconciliation::Embedded
+                        },
                     );
                     session_mpps.push(smpp);
                 }

--- a/rust/crates/cli/src/commands/setup.rs
+++ b/rust/crates/cli/src/commands/setup.rs
@@ -28,7 +28,7 @@ pub struct SetupCommand {
     #[arg(long, hide = true)]
     pub vault: Option<String>,
 
-    /// Re-install MCP configs and agent skill without creating a new account.
+    /// Re-install integrations, including MCP configs, agent skill, and Buzz.
     #[arg(long)]
     pub update: bool,
 
@@ -86,6 +86,7 @@ impl SetupCommand {
                 ),
             );
             eprintln!();
+            super::buzz_setup::maybe_configure();
             return Ok(());
         }
 
@@ -105,6 +106,7 @@ impl SetupCommand {
             self.vault.as_deref(),
             self.force,
         )?;
+        super::buzz_setup::maybe_configure();
 
         let config = pay_core::Config::load().unwrap_or_default();
         let rpc_url = config
@@ -158,6 +160,7 @@ impl SetupCommand {
             )?;
             (pk, false)
         };
+        super::buzz_setup::maybe_configure();
 
         // 2. POST to pay-api's `/v1/redeem`. Honors `PAY_API_URL` via
         //    the same helper the `/v1/send` client uses, so override
@@ -401,11 +404,12 @@ fn shorten_pubkey(pk: &str) -> String {
     format!("{}…{}", &pk[..4], &pk[pk.len() - 4..])
 }
 
-/// `pay setup --update`: re-install MCP configs and agent skill.
+/// `pay setup --update`: refresh agent integrations without creating an account.
 fn run_update() -> pay_core::Result<()> {
     eprintln!();
     maybe_install_skill();
     install_mcp_configs();
+    super::buzz_setup::maybe_configure();
     eprintln!("  {}", "Update complete.".dimmed());
     eprintln!();
     Ok(())

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -259,6 +259,7 @@ fn main() {
                 | Command::Wget(_)
                 | Command::Http(_)
                 | Command::Fetch(_)
+                | Command::Acp(_)
                 | Command::Mcp
         ) {
         None
@@ -292,6 +293,14 @@ fn main() {
     // cryptic "no account configured" error mid-flight. Sandbox flows
     // generate ephemeral wallets on first use, so they're exempt.
     if command.requires_account() && !sandbox_mode && !has_any_account() {
+        if matches!(command, Command::Acp(_)) {
+            eprintln!(
+                "{}",
+                "No pay account configured. Run `pay setup` in a terminal before starting an ACP client."
+                    .dimmed()
+            );
+            std::process::exit(1);
+        }
         eprintln!(
             "{}",
             "No pay account configured — running `pay setup` first…".dimmed()
@@ -655,6 +664,32 @@ mod tests {
                 assert_eq!(cmd.args, ["--model", "qwen3.7-plus"]);
             }
             _ => panic!("expected goose command"),
+        }
+    }
+
+    #[test]
+    fn acp_parses_headless_provider_and_model_without_adapter_leakage() {
+        let opts = Opts::try_parse_from([
+            "pay",
+            "acp",
+            "goose",
+            "--provider",
+            "modelstudio",
+            "--model",
+            "qwen3.7-plus",
+            "--",
+            "--debug",
+        ])
+        .unwrap();
+
+        match opts.command {
+            Some(Command::Acp(cmd)) => {
+                assert_eq!(cmd.harness, commands::acp::AcpHarness::Goose);
+                assert_eq!(cmd.provider.as_deref(), Some("modelstudio"));
+                assert_eq!(cmd.model.as_deref(), Some("qwen3.7-plus"));
+                assert_eq!(cmd.args, ["--debug"]);
+            }
+            _ => panic!("expected acp command"),
         }
     }
 

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -227,10 +227,10 @@ fn main() {
         unsafe { std::env::set_var("PAY_PROTOCOL_ENFORCED", "mpp") };
     }
 
-    // ── Legacy keypair source for non-payment commands ─────────────────────
+    // ── Legacy signer fallback for non-payment commands ────────────────────
     //
-    // `pay topup` and server commands still use the original
-    // keystore-source-string flow.
+    // Server commands resolve accounts after reading the spec's network; this
+    // value is only their raw pay.toml/platform-keystore fallback.
     // Launcher commands (`pay claude`/`pay codex`) pass only an explicit
     // `--account` through to the MCP server and must not resolve an account
     // before the first-run setup hook below.
@@ -262,7 +262,9 @@ fn main() {
                 | Command::Mcp
         ) {
         None
-    } else if matches!(command, Command::Server { .. } | Command::Topup(_)) {
+    } else if matches!(command, Command::Server { .. }) {
+        config.legacy_keypair_source()
+    } else if matches!(command, Command::Topup(_)) {
         config.default_active_account_name()
     } else {
         resolve_keypair(&config)

--- a/rust/crates/cli/src/observability.rs
+++ b/rust/crates/cli/src/observability.rs
@@ -56,6 +56,11 @@ pub(crate) fn init_otlp(sidecar: &str, filter: EnvFilter) -> Result<OtelGuard, S
         .with(OpenTelemetryLayer::new(tracer))
         .init();
 
+    pay_core::server::telemetry::record_metric_baselines();
+    meter_provider
+        .force_flush()
+        .map_err(|error| format!("failed to export initial metric baselines: {error:?}"))?;
+
     Ok(OtelGuard {
         tracer_provider,
         meter_provider,
@@ -123,6 +128,8 @@ fn init_meter_provider(endpoints: &OtlpEndpoints) -> Result<SdkMeterProvider, St
 
 fn resource() -> Resource {
     let service_name = std::env::var("K_SERVICE").unwrap_or_else(|_| "pay-server".to_string());
+    let revision = std::env::var("K_REVISION").unwrap_or_else(|_| "local".to_string());
+    let instance_id = format!("{revision}:{}", uuid::Uuid::new_v4());
     let deployment = std::env::var("PAY_ENV").unwrap_or_else(|_| {
         std::env::var("K_REVISION")
             .map(|_| "cloud-run".to_string())
@@ -134,6 +141,7 @@ fn resource() -> Resource {
         .with_schema_url(
             [
                 KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+                KeyValue::new("service.instance.id", instance_id),
                 KeyValue::new("deployment.environment", deployment),
             ],
             SCHEMA_URL,

--- a/rust/crates/cli/src/tui/session.rs
+++ b/rust/crates/cli/src/tui/session.rs
@@ -403,6 +403,7 @@ fn render_card_panel(
                 ToolKind::Wget => "wget",
                 ToolKind::Http => "http",
                 ToolKind::Fetch => "fetch",
+                ToolKind::Acp => "acp",
                 ToolKind::Goose => "goose",
                 ToolKind::Mcp => "mcp",
                 ToolKind::Claude | ToolKind::Codex | ToolKind::Qodercli => unreachable!(),

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -84,6 +84,7 @@ five8_core = { version = "=0.1.2", features = ["std"] }
 libc = "0.2"
 
 [dev-dependencies]
+borsh = "1"
 serde_yml = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -490,7 +490,7 @@ fn session_spend_limit(deposit: u64, request: &SessionRequest) -> SessionSpendLi
         };
         let usd_amount = format!("${usd}");
         SessionSpendLimit {
-            display: format!("{usd_amount} USD ({amount} {})", stablecoin.symbol()),
+            display: usd_amount.clone(),
             usd_amount: Some(usd_amount),
         }
     } else {
@@ -609,12 +609,12 @@ mod tests {
     }
 
     #[test]
-    fn spend_limit_names_usd_amount_and_stablecoin() {
+    fn spend_limit_displays_usd_amount() {
         let mut request = test_request();
         request.currency = "USDC".to_string();
         request.decimals = Some(6);
         let limit = session_spend_limit(1_000_000, &request);
-        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.display, "$1.00");
         assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
     }
 
@@ -626,7 +626,7 @@ mod tests {
 
         let limit = session_spend_limit(1_000_000, &request);
 
-        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.display, "$1.00");
         assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
     }
 

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -319,12 +319,13 @@ pub fn open_payment_channel_session_header_with_mode(
             .clone()
             .unwrap_or_else(|| "mainnet".to_string())
     });
-    let authorization_origin = canonical_session_origin(resource_url)?;
+    canonical_session_origin(resource_url)?;
+    let prompt_context = crate::client::prompt::payment_prompt_context(None, &[Some(resource_url)]);
     let limit = session_spend_limit(deposit, request);
     let intent = crate::keystore::AuthIntent::authorize_spend_up_to(
         limit.usd_amount.as_deref(),
         &limit.display,
-        &authorization_origin,
+        &prompt_context.operator,
     );
     let (signer, ephemeral_notice) = crate::signer::load_signer_for_network_with_intent(
         &network,

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -265,6 +265,7 @@ pub fn open_session_header(
 ///
 /// The transaction is signed by the payer and fee-payer/cosigned by the server
 /// when it processes the `open` action.
+#[allow(clippy::too_many_arguments)]
 pub fn open_payment_channel_session_header(
     challenge: &PaymentChallenge,
     request: &pay_kit::mpp::SessionRequest,
@@ -272,6 +273,7 @@ pub fn open_payment_channel_session_header(
     network_override: Option<&str>,
     account_override: Option<&str>,
     deposit: u64,
+    resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
     open_payment_channel_session_header_with_mode(
@@ -282,11 +284,12 @@ pub fn open_payment_channel_session_header(
         account_override,
         deposit,
         pay_kit::mpp::SessionMode::Push,
+        resource_url,
         sandbox,
     )
 }
 
-/// Open a payment-channel session with an explicit submission mode.
+/// Open a payment-channel session in `submission_mode`.
 #[allow(clippy::too_many_arguments)]
 pub fn open_payment_channel_session_header_with_mode(
     challenge: &PaymentChallenge,
@@ -296,6 +299,7 @@ pub fn open_payment_channel_session_header_with_mode(
     account_override: Option<&str>,
     deposit: u64,
     submission_mode: pay_kit::mpp::SessionMode,
+    resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
     use pay_kit::mpp::client::{
@@ -315,7 +319,13 @@ pub fn open_payment_channel_session_header_with_mode(
             .clone()
             .unwrap_or_else(|| "mainnet".to_string())
     });
-    let intent = crate::keystore::AuthIntent::open_session();
+    let authorization_origin = canonical_session_origin(resource_url)?;
+    let limit = session_spend_limit(deposit, request);
+    let intent = crate::keystore::AuthIntent::authorize_spend_up_to(
+        limit.usd_amount.as_deref(),
+        &limit.display,
+        &authorization_origin,
+    );
     let (signer, ephemeral_notice) = crate::signer::load_signer_for_network_with_intent(
         &network,
         store,
@@ -440,6 +450,56 @@ pub fn voucher_header_sync(handle: &SessionHandle, amount: u64) -> Result<String
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+pub(crate) fn canonical_session_origin(resource_url: &str) -> Result<String> {
+    let url = reqwest::Url::parse(resource_url)
+        .map_err(|e| Error::Mpp(format!("invalid session authorization URL: {e}")))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(Error::Mpp(
+            "session authorization URL must be an absolute HTTP(S) URL".to_string(),
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(Error::Mpp(
+            "session authorization URL must not contain credentials".to_string(),
+        ));
+    }
+    Ok(url.origin().ascii_serialization())
+}
+
+struct SessionSpendLimit {
+    display: String,
+    usd_amount: Option<String>,
+}
+
+fn session_spend_limit(deposit: u64, request: &SessionRequest) -> SessionSpendLimit {
+    let stablecoin = pay_types::Stablecoin::from_mint(&request.currency)
+        .or_else(|| pay_types::Stablecoin::parse_symbol(&request.currency));
+
+    if let Some(stablecoin) = stablecoin {
+        let amount = crate::client::send::format_token_amount(deposit, stablecoin.decimals());
+        let usd = if !amount.contains('.') {
+            format!("{amount}.00")
+        } else if amount
+            .split_once('.')
+            .is_some_and(|(_, fraction)| fraction.len() == 1)
+        {
+            format!("{amount}0")
+        } else {
+            amount.clone()
+        };
+        let usd_amount = format!("${usd}");
+        SessionSpendLimit {
+            display: format!("{usd_amount} USD ({amount} {})", stablecoin.symbol()),
+            usd_amount: Some(usd_amount),
+        }
+    } else {
+        SessionSpendLimit {
+            display: format!("{deposit} base units of {}", request.currency),
+            usd_amount: None,
+        }
+    }
+}
+
 fn build_header(challenge: &PaymentChallenge, action: &SessionAction) -> Result<String> {
     let credential = PaymentCredential::new(challenge.to_echo(), action);
     format_authorization(&credential)
@@ -519,6 +579,68 @@ mod tests {
         let non_session = test_challenge("charge").to_header().unwrap();
         assert!(SessionHandle::parse_challenge(&non_session).is_none());
         assert!(SessionHandle::parse_challenge("not a challenge").is_none());
+    }
+
+    #[test]
+    fn canonical_origin_normalizes_paths_case_and_default_ports() {
+        assert_eq!(
+            canonical_session_origin("HTTPS://Example.COM:443/v1/chat?model=test").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            canonical_session_origin("http://localhost:1402/v1/chat").unwrap(),
+            "http://localhost:1402"
+        );
+    }
+
+    #[test]
+    fn canonical_origin_rejects_relative_non_http_and_credential_urls() {
+        for invalid in [
+            "/v1/chat",
+            "file:///tmp/provider",
+            "https://user:secret@example.com/v1/chat",
+        ] {
+            assert!(
+                canonical_session_origin(invalid).is_err(),
+                "accepted invalid session URL: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn spend_limit_names_usd_amount_and_stablecoin() {
+        let mut request = test_request();
+        request.currency = "USDC".to_string();
+        request.decimals = Some(6);
+        let limit = session_spend_limit(1_000_000, &request);
+        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
+    }
+
+    #[test]
+    fn spend_limit_uses_canonical_stablecoin_decimals() {
+        let mut request = test_request();
+        request.currency = "USDC".to_string();
+        request.decimals = Some(18);
+
+        let limit = session_spend_limit(1_000_000, &request);
+
+        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
+    }
+
+    #[test]
+    fn spend_limit_does_not_trust_unknown_asset_decimals() {
+        let mut request = test_request();
+        request.decimals = Some(u8::MAX);
+
+        let limit = session_spend_limit(1_000_000, &request);
+
+        assert_eq!(
+            limit.display,
+            format!("1000000 base units of {}", request.currency)
+        );
+        assert_eq!(limit.usd_amount, None);
     }
 
     #[tokio::test]

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -94,12 +94,20 @@ impl Config {
             }
         }
 
-        // 3. Config file keypair field
+        self.legacy_keypair_source()
+    }
+
+    /// Resolve only legacy raw signer configuration.
+    ///
+    /// Unlike [`Self::default_active_account_name`], this deliberately skips
+    /// `accounts.yml` and `PAY_ACTIVE_ACCOUNT`; callers that need account
+    /// policy must resolve those names through the network-aware signer path.
+    pub fn legacy_keypair_source(&self) -> Option<String> {
         if let Some(path) = self.keypair_path() {
             return Some(expand_path(path).to_string());
         }
 
-        // 4. Legacy: probe platform-native keystores directly (no
+        // Legacy: probe platform-native keystores directly (no
         // accounts.yml yet). Do not probe 1Password here: `op item get`
         // can show a desktop auth prompt just to answer "does this item
         // exist?", which is surprising for commands like `pay claude` on a

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -227,7 +227,11 @@ pub async fn settle_delegated_session(
     )
     .map_err(|error| error.to_string())?;
     if actual.base_units == 0 {
-        pending.handle.touch_channel(pending.channel_id.clone());
+        pending
+            .handle
+            .touch_channel(pending.channel_id.clone())
+            .await
+            .map_err(|error| error.to_string())?;
         tracing::info!(
             channel = %pending.channel_id,
             "delegated MPP session response rated at zero"
@@ -1722,13 +1726,28 @@ async fn session_authorized(
                     .unwrap_or_default(),
                 ));
             }
-            let Some(reservation) =
-                handle.reserve_delegated_capacity(&state.channel_id, available_base_units)
-            else {
-                return GateDecision::Respond(GateResponse::json(
-                    StatusCode::PAYMENT_REQUIRED,
-                    Bytes::from_static(br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#),
-                ));
+            let reservation = match handle
+                .reserve_delegated_capacity(&state.channel_id, available_base_units)
+                .await
+            {
+                Ok(Some(reservation)) => reservation,
+                Ok(None) => {
+                    return GateDecision::Respond(GateResponse::json(
+                        StatusCode::PAYMENT_REQUIRED,
+                        Bytes::from_static(br#"{"error":"session_capacity_reserved","message":"Another request is currently using this session capacity."}"#),
+                    ));
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        channel_id = %state.channel_id,
+                        %error,
+                        "failed to wake delegated session channel"
+                    );
+                    return GateDecision::Respond(GateResponse::json(
+                        StatusCode::PAYMENT_REQUIRED,
+                        Bytes::from_static(br#"{"error":"session_close_pending","message":"The session channel is closing; open a new session."}"#),
+                    ));
+                }
             };
             let props = metering::RequestProperties {
                 body_size: req.content_length,

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -300,7 +300,7 @@ pub enum GateDecision {
     /// `receipt` is applied to the response. For x402 `upto`, `upto` carries the
     /// opened channel the adapter settles *after* the response.
     Forward {
-        session: Option<SessionForward>,
+        session: Option<Box<SessionForward>>,
         receipt: Option<ReceiptAnnotation>,
         upto: Option<Box<UptoForward>>,
         paid_request: Option<PaidRequestTelemetry>,
@@ -1744,14 +1744,14 @@ async fn session_authorized(
                 inferred_usage: None,
             };
             GateDecision::Forward {
-                session: Some(SessionForward::delegated(
+                session: Some(Box::new(SessionForward::delegated(
                     handle,
                     state.channel_id,
                     state.cumulative,
                     settlement,
                     available_base_units,
                     reservation,
-                )),
+                ))),
                 receipt: signature
                     .map(|reference| session_receipt_annotation(sm.network(), reference)),
                 upto: None,
@@ -1766,13 +1766,15 @@ async fn session_authorized(
             channel_id,
             cumulative,
         }) => GateDecision::Forward {
-            session: handle.map(|h| SessionForward {
-                handle: h,
-                channel_id,
-                committed_base_units: cumulative,
-                settlement: None,
-                available_base_units: 0,
-                _reservation: None,
+            session: handle.map(|h| {
+                Box::new(SessionForward {
+                    handle: h,
+                    channel_id,
+                    committed_base_units: cumulative,
+                    settlement: None,
+                    available_base_units: 0,
+                    _reservation: None,
+                })
             }),
             receipt: None,
             upto: None,

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -105,6 +105,14 @@ pub struct ReceiptAnnotation {
     pub reference: Option<String>,
 }
 
+/// Bounded telemetry context carried from payment verification to the adapter's
+/// final upstream response. Authentication-only forwards leave this absent.
+pub struct PaidRequestTelemetry {
+    pub protocol: &'static str,
+    pub subdomain: String,
+    pub payment: Option<telemetry::PaymentAmount>,
+}
+
 /// Session-stream metering context for a forwarded session request. The
 /// adapter attaches it so the response-stream metering layer can debit the
 /// channel as bytes flow back.
@@ -270,6 +278,15 @@ pub struct UptoForward {
     /// Response-metered settlement plan. `None` preserves the legacy fixed
     /// success amount above.
     pub settlement: Option<metering::UptoSettlementPlan>,
+    /// Stable context needed to attribute the amount actually debited after
+    /// the upstream response has been metered.
+    pub telemetry: UptoPaymentTelemetry,
+}
+
+pub struct UptoPaymentTelemetry {
+    pub subdomain: String,
+    pub path: String,
+    pub ceiling_usd: f64,
 }
 
 /// The outcome of gating a request.
@@ -286,6 +303,7 @@ pub enum GateDecision {
         session: Option<SessionForward>,
         receipt: Option<ReceiptAnnotation>,
         upto: Option<Box<UptoForward>>,
+        paid_request: Option<PaidRequestTelemetry>,
     },
     /// Not gated (discovery / free / unknown) — let normal routing handle it
     /// (forward to the default upstream, or serve a control-plane route).
@@ -554,12 +572,16 @@ impl<S: PaymentState> PaymentGate<S> {
                         }
                     }
                     Err(e) => {
-                        tracing::error!(currency = sm.currency(), error = %e, "session challenge generation failed");
+                        telemetry::record_challenge_error(
+                            "mpp/session",
+                            sm.currency(),
+                            &e.to_string(),
+                        );
                         return gen_failed();
                     }
                 }
             }
-            advertised.push("session");
+            advertised.push("mpp/session");
         }
 
         if accepted.contains(&Scheme::MppCharge) {
@@ -590,7 +612,7 @@ impl<S: PaymentState> PaymentGate<S> {
                         Ok(c) => challenges.push(c),
                         Err(e) => {
                             telemetry::record_challenge_error(
-                                "mpp",
+                                "mpp/charge",
                                 mpp.currency(),
                                 &e.to_string(),
                             );
@@ -605,7 +627,7 @@ impl<S: PaymentState> PaymentGate<S> {
                                 challenge_headers.push((header::WWW_AUTHENTICATE, hv));
                             }
                         }
-                        advertised.push("mpp");
+                        advertised.push("mpp/charge");
                     }
                     Err(_) => return gen_failed(),
                 }
@@ -646,11 +668,17 @@ impl<S: PaymentState> PaymentGate<S> {
                         HeaderValue::from_str(&value),
                     ) {
                         challenge_headers.push((n, v));
-                        advertised.push("x402");
+                        advertised.push("x402/exact");
                     }
                 }
                 // Drop only the x402 challenge on error — MPP clients are unaffected.
-                Err(e) => tracing::warn!(error = %e, "x402 challenge generation failed"),
+                Err(e) => {
+                    telemetry::record_challenge_error(
+                        "x402/exact",
+                        x402.currency(),
+                        &e.to_string(),
+                    );
+                }
             }
         }
 
@@ -669,10 +697,12 @@ impl<S: PaymentState> PaymentGate<S> {
                         HeaderValue::from_str(&value),
                     ) {
                         challenge_headers.push((n, v));
-                        advertised.push("x402-upto");
+                        advertised.push("x402/upto");
                     }
                 }
-                Err(e) => tracing::warn!(error = %e, "x402 upto challenge generation failed"),
+                Err(e) => {
+                    telemetry::record_challenge_error("x402/upto", "configured", &e.to_string());
+                }
             }
         }
 
@@ -687,10 +717,12 @@ impl<S: PaymentState> PaymentGate<S> {
                         HeaderValue::from_str(&value),
                     ) {
                         challenge_headers.push((n, v));
-                        advertised.push("x402-batch");
+                        advertised.push("x402/batch");
                     }
                 }
-                Err(e) => tracing::warn!(error = %e, "x402 batch challenge generation failed"),
+                Err(e) => {
+                    telemetry::record_challenge_error("x402/batch", "configured", &e.to_string());
+                }
             }
         }
 
@@ -709,8 +741,13 @@ impl<S: PaymentState> PaymentGate<S> {
             .as_ref()
             .and_then(|p| p.dimensions.first())
             .map(|d| d.price_usd / d.scale.max(1) as f64);
+        let challenge_protocol = if advertised.len() == 1 {
+            advertised[0]
+        } else {
+            "mixed"
+        };
         telemetry::record_402_challenge_sent(
-            "mpp",
+            challenge_protocol,
             subdomain,
             path,
             req.method.as_str(),
@@ -767,8 +804,15 @@ impl<S: PaymentState> PaymentGate<S> {
         let amount = crate::server::payment::charge_amount_from_price(
             metering::resolve_price(meter, &props, variant.as_deref(), None).as_ref(),
         );
+        let payment = amount
+            .parse()
+            .ok()
+            .map(|ui_amount| telemetry::PaymentAmount {
+                currency: x402.currency().to_string(),
+                ui_amount,
+            });
         let reject = |msg: String| {
-            telemetry::record_settlement_error("x402", subdomain, path, &msg, true);
+            telemetry::record_settlement_error("x402/exact", subdomain, path, &msg, true);
             GateDecision::Respond(GateResponse::json(
                 StatusCode::PAYMENT_REQUIRED,
                 serde_json::to_vec(&json!({"error":"verification_failed","message":msg}))
@@ -806,7 +850,13 @@ impl<S: PaymentState> PaymentGate<S> {
         };
         match x402.settle_exact(verified, signer.as_ref()).await {
             Ok(reference) => {
-                telemetry::record_payment_collected("x402", subdomain, path, None, &reference);
+                telemetry::record_payment_collected(
+                    "x402/exact",
+                    subdomain,
+                    path,
+                    payment.as_ref(),
+                    &reference,
+                );
                 let mut headers = Vec::new();
                 if let Ok(n) = HeaderName::from_bytes(PAYMENT_RESPONSE_HEADER.as_bytes())
                     && let Ok(v) = HeaderValue::from_str(&reference)
@@ -820,6 +870,11 @@ impl<S: PaymentState> PaymentGate<S> {
                         reference: Some(reference),
                     }),
                     upto: None,
+                    paid_request: Some(PaidRequestTelemetry {
+                        protocol: "x402/exact",
+                        subdomain: subdomain.to_string(),
+                        payment,
+                    }),
                 }
             }
             Err(e) => reject(e.to_string()),
@@ -867,11 +922,27 @@ impl<S: PaymentState> PaymentGate<S> {
                         open: Box::new(open),
                         settle_amount,
                         settlement,
+                        telemetry: UptoPaymentTelemetry {
+                            subdomain: subdomain.to_string(),
+                            path: path.to_string(),
+                            ceiling_usd,
+                        },
                     })),
+                    paid_request: Some(PaidRequestTelemetry {
+                        protocol: "x402/upto",
+                        subdomain: subdomain.to_string(),
+                        payment: None,
+                    }),
                 }
             }
             Err(e) => {
-                telemetry::record_settlement_error("x402", subdomain, path, &e.to_string(), true);
+                telemetry::record_settlement_error(
+                    "x402/upto",
+                    subdomain,
+                    path,
+                    &e.to_string(),
+                    true,
+                );
                 GateDecision::Respond(GateResponse::json(
                     StatusCode::PAYMENT_REQUIRED,
                     serde_json::to_vec(
@@ -904,6 +975,13 @@ impl<S: PaymentState> PaymentGate<S> {
         let amount = crate::server::payment::charge_amount_from_price(
             metering::resolve_price(meter, &props, variant.as_deref(), None).as_ref(),
         );
+        let payment = amount
+            .parse()
+            .ok()
+            .map(|ui_amount| telemetry::PaymentAmount {
+                currency: "USD".to_string(),
+                ui_amount,
+            });
         match batch.verify_payment(pay_header, &amount).await {
             Ok(outcome) => {
                 let mut headers = Vec::new();
@@ -922,12 +1000,23 @@ impl<S: PaymentState> PaymentGate<S> {
                     .map(|c| c.channel_id.clone());
                 if outcome.serve {
                     if let Some(r) = &reference {
-                        telemetry::record_payment_collected("x402", subdomain, path, None, r);
+                        telemetry::record_payment_collected(
+                            "x402/batch",
+                            subdomain,
+                            path,
+                            payment.as_ref(),
+                            r,
+                        );
                     }
                     GateDecision::Forward {
                         session: None,
                         receipt: Some(ReceiptAnnotation { headers, reference }),
                         upto: None,
+                        paid_request: Some(PaidRequestTelemetry {
+                            protocol: "x402/batch",
+                            subdomain: subdomain.to_string(),
+                            payment,
+                        }),
                     }
                 } else {
                     // Cooperative refund / channel close — acknowledge, don't serve.
@@ -940,7 +1029,13 @@ impl<S: PaymentState> PaymentGate<S> {
                 }
             }
             Err(e) => {
-                telemetry::record_settlement_error("x402", subdomain, path, &e.to_string(), true);
+                telemetry::record_settlement_error(
+                    "x402/batch",
+                    subdomain,
+                    path,
+                    &e.to_string(),
+                    true,
+                );
                 GateDecision::Respond(GateResponse::json(
                     StatusCode::PAYMENT_REQUIRED,
                     serde_json::to_vec(
@@ -1020,7 +1115,11 @@ impl<S: PaymentState> PaymentGate<S> {
                     }
                 }
                 Err(e) => {
-                    tracing::error!(error = %e, "subscription challenge generation failed");
+                    telemetry::record_challenge_error(
+                        "mpp/subscription",
+                        "configured",
+                        &e.to_string(),
+                    );
                     return GateDecision::Respond(GateResponse::json(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Bytes::from_static(br#"{"error":"subscription_misconfigured"}"#),
@@ -1036,12 +1135,12 @@ impl<S: PaymentState> PaymentGate<S> {
                 headers.push((header::WWW_AUTHENTICATE, v));
             }
             telemetry::record_402_challenge_sent(
-                "mpp-subscription",
+                "mpp/subscription",
                 subdomain,
                 path,
                 req.method.as_str(),
                 None,
-                "subscription",
+                "mpp/subscription",
                 1,
             );
             let body = match error {
@@ -1090,6 +1189,11 @@ impl<S: PaymentState> PaymentGate<S> {
                     session: None,
                     receipt: None,
                     upto: None,
+                    paid_request: Some(PaidRequestTelemetry {
+                        protocol: "mpp/subscription",
+                        subdomain: subdomain.to_string(),
+                        payment: None,
+                    }),
                 };
             }
             return challenge_402(None);
@@ -1134,11 +1238,16 @@ impl<S: PaymentState> PaymentGate<S> {
                         reference: Some(receipt_kind.base().reference.clone()),
                     }),
                     upto: None,
+                    paid_request: Some(PaidRequestTelemetry {
+                        protocol: "mpp/subscription",
+                        subdomain: subdomain.to_string(),
+                        payment: None,
+                    }),
                 }
             }
             Err(e) => {
                 telemetry::record_settlement_error(
-                    "mpp-subscription",
+                    "mpp/subscription",
                     subdomain,
                     path,
                     &e.message,
@@ -1201,7 +1310,7 @@ impl<S: PaymentState> PaymentGate<S> {
         let external_id = match mpp_charge_payment_external_id(&credential, resource) {
             Ok(external_id) => external_id,
             Err(e) => {
-                telemetry::record_settlement_error("mpp", subdomain, path, &e, false);
+                telemetry::record_settlement_error("mpp/charge", subdomain, path, &e, false);
                 return GateDecision::Respond(GateResponse::json(
                     StatusCode::PAYMENT_REQUIRED,
                     serde_json::to_vec(&json!({
@@ -1259,7 +1368,7 @@ impl<S: PaymentState> PaymentGate<S> {
                         mpp.decimals() as u8,
                     );
                     telemetry::record_payment_collected(
-                        "mpp",
+                        "mpp/charge",
                         subdomain,
                         path,
                         payment.as_ref(),
@@ -1289,6 +1398,11 @@ impl<S: PaymentState> PaymentGate<S> {
                             reference: Some(reference),
                         }),
                         upto: None,
+                        paid_request: Some(PaidRequestTelemetry {
+                            protocol: "mpp/charge",
+                            subdomain: subdomain.to_string(),
+                            payment,
+                        }),
                     };
                 }
                 Err(e) => last_error = Some(e),
@@ -1297,7 +1411,13 @@ impl<S: PaymentState> PaymentGate<S> {
 
         let error = last_error.unwrap_or_else(|| VerificationError::new("MPP not configured"));
         let message = crate::server::payment::readable_verification_message(&error);
-        telemetry::record_settlement_error("mpp", subdomain, path, &message, error.retryable);
+        telemetry::record_settlement_error(
+            "mpp/charge",
+            subdomain,
+            path,
+            &message,
+            error.retryable,
+        );
         GateDecision::Respond(GateResponse::json(
             StatusCode::PAYMENT_REQUIRED,
             serde_json::to_vec(&json!({
@@ -1351,6 +1471,7 @@ pub async fn settle_upto<S: PaymentState>(
     open: VerifiedUptoOpen,
     settle_amount: u64,
     served_ok: bool,
+    telemetry_context: UptoPaymentTelemetry,
 ) -> Option<(HeaderName, HeaderValue)> {
     let upto = state.x402_upto()?;
     // Settle the configured voucher (clamped to the ceiling) on success, full
@@ -1360,22 +1481,49 @@ pub async fn settle_upto<S: PaymentState>(
     } else {
         0
     };
+    let amount_usd = served_ok
+        .then(|| upto_collected_amount_usd(telemetry_context.ceiling_usd, amount, open.max_amount))
+        .flatten();
     match upto.settle_actual_deferred(&open, amount).await {
         Ok(settlement) => {
             tracing::Span::current().record("tx_sig", settlement.transaction.as_str());
+            if let Some(ui_amount) = amount_usd {
+                telemetry::record_payment_collected(
+                    "x402/upto",
+                    &telemetry_context.subdomain,
+                    &telemetry_context.path,
+                    Some(&telemetry::PaymentAmount {
+                        currency: "USD".to_string(),
+                        ui_amount,
+                    }),
+                    &settlement.transaction,
+                );
+            }
             match upto.settlement_header(&settlement) {
                 Ok((name, value)) => Some((
                     HeaderName::from_bytes(name.as_bytes()).ok()?,
                     HeaderValue::from_str(&value).ok()?,
                 )),
                 Err(e) => {
-                    tracing::warn!(error = %e, "x402 upto settlement header generation failed");
+                    telemetry::record_settlement_error(
+                        "x402/upto",
+                        &telemetry_context.subdomain,
+                        &telemetry_context.path,
+                        &e.to_string(),
+                        true,
+                    );
                     None
                 }
             }
         }
         Err(e) => {
-            tracing::error!(error = %e, "x402 upto settlement failed; channel left for sweep");
+            telemetry::record_settlement_error(
+                "x402/upto",
+                &telemetry_context.subdomain,
+                &telemetry_context.path,
+                &e.to_string(),
+                true,
+            );
             None
         }
     }
@@ -1393,9 +1541,10 @@ pub async fn settle_upto_metered<S: PaymentState>(
     served_ok: bool,
     response_headers: &http::HeaderMap,
     response_body: Option<&[u8]>,
+    telemetry_context: UptoPaymentTelemetry,
 ) -> Option<(HeaderName, HeaderValue)> {
     if !served_ok {
-        return settle_upto(state, open, 0, false).await;
+        return settle_upto(state, open, 0, false, telemetry_context).await;
     }
 
     let amount = match metering::upto_actual_amount_from_response(
@@ -1406,12 +1555,27 @@ pub async fn settle_upto_metered<S: PaymentState>(
     ) {
         Ok(actual) => actual.base_units,
         Err(e) => {
-            tracing::warn!(error = %e, "x402 upto response-metered settlement failed; refunding");
+            telemetry::record_settlement_error(
+                "x402/upto",
+                &telemetry_context.subdomain,
+                &telemetry_context.path,
+                &e.to_string(),
+                false,
+            );
             0
         }
     };
 
-    settle_upto(state, open, amount, true).await
+    settle_upto(state, open, amount, true, telemetry_context).await
+}
+
+fn upto_collected_amount_usd(
+    ceiling_usd: f64,
+    settled_base_units: u64,
+    maximum_base_units: u64,
+) -> Option<f64> {
+    (settled_base_units > 0 && maximum_base_units > 0)
+        .then_some(ceiling_usd * settled_base_units as f64 / maximum_base_units as f64)
 }
 
 /// Reconstruct a minimal URI from path + query for split-rule resolution.
@@ -1591,6 +1755,11 @@ async fn session_authorized(
                 receipt: signature
                     .map(|reference| session_receipt_annotation(sm.network(), reference)),
                 upto: None,
+                paid_request: Some(PaidRequestTelemetry {
+                    protocol: "mpp/session",
+                    subdomain: subdomain.to_string(),
+                    payment: None,
+                }),
             }
         }
         Ok(SessionOutcome::Voucher {
@@ -1607,20 +1776,16 @@ async fn session_authorized(
             }),
             receipt: None,
             upto: None,
+            paid_request: Some(PaidRequestTelemetry {
+                protocol: "mpp/session",
+                subdomain: subdomain.to_string(),
+                payment: None,
+            }),
         },
-        Ok(SessionOutcome::Commit(receipt)) => {
-            telemetry::record_paid_request_completed(
-                "session",
-                subdomain,
-                path,
-                StatusCode::OK,
-                None,
-            );
-            GateDecision::Respond(GateResponse::json(
-                StatusCode::OK,
-                serde_json::to_vec(&receipt).unwrap_or_default(),
-            ))
-        }
+        Ok(SessionOutcome::Commit(receipt)) => GateDecision::Respond(GateResponse::json(
+            StatusCode::OK,
+            serde_json::to_vec(&receipt).unwrap_or_default(),
+        )),
         Ok(SessionOutcome::Closed { signature, .. }) => {
             let receipt_url = signature
                 .as_deref()
@@ -1641,7 +1806,13 @@ async fn session_authorized(
             GateDecision::Respond(resp)
         }
         Err(e) => {
-            telemetry::record_settlement_error("session", subdomain, path, &e.to_string(), true);
+            telemetry::record_settlement_error(
+                "mpp/session",
+                subdomain,
+                path,
+                &e.to_string(),
+                true,
+            );
             GateDecision::Respond(GateResponse::json(
                 StatusCode::PAYMENT_REQUIRED,
                 serde_json::to_vec(&json!({
@@ -1726,6 +1897,16 @@ mod tests {
             upto_settle_amount(Some(0.01), 0.0, CEILING_BASE),
             CEILING_BASE
         );
+    }
+
+    #[test]
+    fn upto_collected_amount_reports_the_debited_fraction_of_the_ceiling() {
+        assert_eq!(
+            upto_collected_amount_usd(0.10, 25_000, 100_000),
+            Some(0.025)
+        );
+        assert_eq!(upto_collected_amount_usd(0.10, 0, 100_000), None);
+        assert_eq!(upto_collected_amount_usd(0.10, 1, 0), None);
     }
 
     #[test]

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -91,6 +91,7 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
             session,
             receipt,
             upto,
+            paid_request,
         } => {
             let mut req = req;
             let mut delegated_session = None;
@@ -148,6 +149,7 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                                     served_ok,
                                     &parts.headers,
                                     Some(&bytes),
+                                    uf.telemetry,
                                 )
                                 .await
                                 {
@@ -163,9 +165,14 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                                 );
                                 let mut builder =
                                     Response::builder().status(StatusCode::BAD_GATEWAY);
-                                if let Some((n, v)) =
-                                    crate::server::gate::settle_upto(&state, *uf.open, 0, false)
-                                        .await
+                                if let Some((n, v)) = crate::server::gate::settle_upto(
+                                    &state,
+                                    *uf.open,
+                                    0,
+                                    false,
+                                    uf.telemetry,
+                                )
+                                .await
                                 {
                                     builder = builder.header(n, v);
                                 }
@@ -184,14 +191,20 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                         served_ok,
                         response.headers(),
                         None,
+                        uf.telemetry,
                     )
                     .await
                     {
                         response.headers_mut().append(n, v);
                     }
-                } else if let Some((n, v)) =
-                    crate::server::gate::settle_upto(&state, *uf.open, uf.settle_amount, served_ok)
-                        .await
+                } else if let Some((n, v)) = crate::server::gate::settle_upto(
+                    &state,
+                    *uf.open,
+                    uf.settle_amount,
+                    served_ok,
+                    uf.telemetry,
+                )
+                .await
                 {
                     response.headers_mut().append(n, v);
                 }
@@ -203,6 +216,15 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
                 if let Some(reference) = ann.reference {
                     tracing::Span::current().record("tx_sig", reference.as_str());
                 }
+            }
+            if let Some(paid_request) = paid_request {
+                telemetry::record_paid_request_completed(
+                    paid_request.protocol,
+                    &paid_request.subdomain,
+                    &path,
+                    response.status(),
+                    paid_request.payment.as_ref(),
+                );
             }
             response
         }

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -95,7 +95,8 @@ async fn gate_adapter<S: PaymentState>(state: S, req: Request<Body>, next: Next)
         } => {
             let mut req = req;
             let mut delegated_session = None;
-            if let Some(mut sf) = session {
+            if let Some(sf) = session {
+                let mut sf = *sf;
                 if sf.settlement.is_some() {
                     // Delegated sessions are settled from the completed
                     // response below. The client-voucher stream context waits

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1300,9 +1300,13 @@ impl SessionMpp {
                 // open, while `Err` is propagated so an unavailable RPC can
                 // never cause Redis state to be created or deleted.
                 let payment_channel_open = p.mode == SessionMode::Push || client_voucher_pull;
-                let account_confirmed = if let (true, Some(rpc_url)) =
+                let (account_confirmed, client_id) = if let (true, Some(rpc_url)) =
                     (payment_channel_open, self.rpc_url.as_deref())
                 {
+                    let client_id = self
+                        .payment_channel_open_params(payload_for_open)?
+                        .payer
+                        .to_string();
                     let signature = payload_for_open.signature.as_str();
                     let channel_id = payload_for_open
                         .session_id()
@@ -1319,9 +1323,9 @@ impl SessionMpp {
                             "payment-channel open transaction is confirmed, but channel {channel_id} is absent on-chain"
                         )));
                     }
-                    true
+                    (true, Some(client_id))
                 } else {
-                    false
+                    (false, None)
                 };
 
                 // The host has independently validated, co-signed, submitted,
@@ -1341,10 +1345,14 @@ impl SessionMpp {
                 .map_err(|e| Error::Mpp(format!("Session open failed: {e}")))?;
                 let state = acceptance.state;
 
-                if !acceptance.replay && account_confirmed {
+                if !acceptance.replay
+                    && account_confirmed
+                    && let Some(client_id) = client_id.as_deref()
+                {
                     telemetry::record_payment_channel_opened(
                         &payload_for_open.signature,
                         &state.channel_id.to_string(),
+                        client_id,
                         self.currency(),
                         self.network(),
                         state.deposit,

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -2361,6 +2361,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delegated_capacity_reservation_persists_idle_deadline_before_returning() {
+        let session = Arc::new(test_session_mpp());
+        let close_delay = Duration::from_secs(120);
+        session.start_lifecycle_runloop_with_settlement_and_batching(
+            close_delay,
+            Duration::from_secs(60),
+            Duration::ZERO,
+            SessionLifecycleReconciliation::External,
+        );
+        let challenge = session.challenge(CAP).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            test_session_signer(),
+            challenge,
+        );
+
+        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state: opened, .. } =
+            session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected open to return active session");
+        };
+        session
+            .operator_runtime
+            .channel_store
+            .update_channel(
+                &opened.channel_id,
+                Box::new(|state| {
+                    let mut state = state.unwrap();
+                    state.lifecycle.as_mut().unwrap().close_after = 1;
+                    Ok(state)
+                }),
+            )
+            .await
+            .unwrap();
+
+        let touched_after = unix_millis();
+        let _lease = session
+            .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .await
+            .unwrap()
+            .expect("request should reserve channel capacity");
+
+        let persisted = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&opened.channel_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            persisted.lifecycle.unwrap().close_after
+                >= touched_after.saturating_add(duration_millis(close_delay)),
+            "capacity reservation must persist the request-start deadline before forwarding"
+        );
+    }
+
+    #[tokio::test]
     async fn delegated_capacity_lease_defers_idle_close() {
         let session = Arc::new(test_session_mpp());
         session.start_lifecycle_runloop(Duration::from_millis(10));

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1288,15 +1288,23 @@ impl SessionMpp {
                 // broadcasts. Persist those opens without asking a second RPC
                 // client to rediscover the same signature. Opens received by
                 // any other integration retain PayKit's standard verification.
-                let state = if submitted_open.is_some() {
-                    self.server.process_preverified_open(payload_for_open).await
+                let acceptance = if submitted_open.is_some() {
+                    self.server
+                        .process_preverified_open_with_outcome(payload_for_open)
+                        .await
                 } else {
-                    self.server.process_open(payload_for_open).await
+                    self.server
+                        .process_open_with_outcome(payload_for_open)
+                        .await
                 }
                 .map_err(|e| Error::Mpp(format!("Session open failed: {e}")))?;
+                let state = acceptance.state;
 
-                if let Some(signature) = &submitted_open {
-                    tracing::info!(%signature, "payment-channel open transaction confirmed");
+                if !acceptance.replay {
+                    telemetry::record_payment_channel_opened(
+                        &payload_for_open.signature,
+                        &state.channel_id.to_string(),
+                    );
                 }
 
                 if p.mode == SessionMode::Pull && !client_voucher_pull {

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1116,6 +1116,12 @@ impl SessionMpp {
             })
             .await
             .map_err(|e| Error::PaymentRejected(e.to_string()))?;
+        telemetry::record_payment_channel_voucher_cumulative(
+            channel_id,
+            self.currency(),
+            self.network(),
+            accepted.cumulative,
+        );
         self.record_committed_watermark(channel_id.to_string(), accepted.cumulative);
         self.touch_channel(channel_id.to_string()).await?;
         Ok(accepted.cumulative)
@@ -1283,6 +1289,41 @@ impl SessionMpp {
                     p
                 };
 
+                // A replayed transaction signature can remain confirmed long
+                // after its channel account has been reclaimed. Solana RPC may
+                // return "already processed" on re-submission, and signature
+                // confirmation alone cannot distinguish that stale replay
+                // from a newly landed open. Before creating durable state,
+                // require the channel itself to exist at confirmed commitment.
+                //
+                // Keep absence and RPC failure distinct: `Ok(None)` is a stale
+                // open, while `Err` is propagated so an unavailable RPC can
+                // never cause Redis state to be created or deleted.
+                let payment_channel_open = p.mode == SessionMode::Push || client_voucher_pull;
+                let account_confirmed = if let (true, Some(rpc_url)) =
+                    (payment_channel_open, self.rpc_url.as_deref())
+                {
+                    let signature = payload_for_open.signature.as_str();
+                    let channel_id = payload_for_open
+                        .session_id()
+                        .map_err(|e| Error::Mpp(format!("Invalid session channel: {e}")))?;
+                    wait_for_transaction_confirmed(rpc_url, signature, "payment-channel open")
+                        .await?;
+                    if self
+                        .operator_runtime
+                        .fetch_payment_channel(channel_id)
+                        .await?
+                        .is_none()
+                    {
+                        return Err(Error::Mpp(format!(
+                            "payment-channel open transaction is confirmed, but channel {channel_id} is absent on-chain"
+                        )));
+                    }
+                    true
+                } else {
+                    false
+                };
+
                 // The host has independently validated, co-signed, submitted,
                 // and observed a successful status for transactions it
                 // broadcasts. Persist those opens without asking a second RPC
@@ -1300,7 +1341,7 @@ impl SessionMpp {
                 .map_err(|e| Error::Mpp(format!("Session open failed: {e}")))?;
                 let state = acceptance.state;
 
-                if !acceptance.replay {
+                if !acceptance.replay && account_confirmed {
                     telemetry::record_payment_channel_opened(
                         &payload_for_open.signature,
                         &state.channel_id.to_string(),
@@ -1326,6 +1367,12 @@ impl SessionMpp {
                     .map_err(|e| Error::PaymentRejected(e.to_string()))?
                     .cumulative;
                 let channel_id = p.voucher.data.channel_id.clone();
+                telemetry::record_payment_channel_voucher_cumulative(
+                    &channel_id,
+                    self.currency(),
+                    self.network(),
+                    cumulative,
+                );
                 self.record_committed_watermark(channel_id.clone(), cumulative);
                 self.touch_channel(channel_id.clone()).await?;
                 Ok(SessionOutcome::Voucher {
@@ -1341,6 +1388,12 @@ impl SessionMpp {
                     .await
                     .map_err(|e| Error::PaymentRejected(e.to_string()))?;
                 if let Ok(cumulative) = receipt.cumulative.parse::<u64>() {
+                    telemetry::record_payment_channel_voucher_cumulative(
+                        &receipt.session_id,
+                        self.currency(),
+                        self.network(),
+                        cumulative,
+                    );
                     self.record_committed_watermark(receipt.session_id.clone(), cumulative);
                 }
                 self.touch_channel(receipt.session_id.clone()).await?;
@@ -1382,6 +1435,12 @@ impl SessionMpp {
                         return Err(Error::Mpp(format!("Session close failed: {error}")));
                     }
                 };
+                telemetry::record_payment_channel_voucher_cumulative(
+                    &params.channel_id.to_string(),
+                    self.currency(),
+                    self.network(),
+                    params.settled,
+                );
                 self.record_committed_watermark(params.channel_id.to_string(), params.settled);
                 let settlement = self.submit_payment_channel_settlement(&params).await;
                 let signature = match settlement {

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -20,7 +20,7 @@ use pay_kit::mpp::blockhash::{BlockhashCache, CachedBlockhash};
 use pay_kit::mpp::server::session::{SealParams, SessionConfig, SessionServer};
 use pay_kit::mpp::settlement::worker::{RpcBroadcaster, SettlementConfig, SettlementHandle, spawn};
 use pay_kit::mpp::solana_keychain::SolanaSigner;
-use pay_kit::mpp::store::{ChannelState, ChannelStore, MemoryChannelStore};
+use pay_kit::mpp::store::{ChannelLifecycle, ChannelState, ChannelStore, MemoryChannelStore};
 use pay_kit::mpp::{
     Base64UrlJson, CommitReceipt, OpenPayload, PaymentChallenge, SessionAction, SessionMode,
     SessionPullVoucherStrategy, SessionSettlementAuthority, SignedVoucher, VoucherData,
@@ -29,7 +29,8 @@ use pay_kit::mpp::{
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Duration, Instant};
 
 use crate::server::telemetry;
@@ -470,29 +471,64 @@ impl SessionLifecycleHandle {
             tracing::debug!("session lifecycle runloop is not accepting events");
         }
     }
+
+    async fn touch(&self, channel_id: String, touched_at_ms: u64) -> Result<Option<ChannelState>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.tx
+            .send(SessionLifecycleCommand::Touch {
+                channel_id,
+                touched_at_ms,
+                response: response_tx,
+            })
+            .map_err(|_| Error::Mpp("session lifecycle runloop is unavailable".to_string()))?;
+        response_rx
+            .await
+            .map_err(|_| Error::Mpp("session lifecycle touch was cancelled".to_string()))?
+            .map_err(Error::Mpp)
+    }
+
+    fn touch_unconfirmed(&self, channel_id: String, touched_at_ms: u64) {
+        let (response, _discarded) = oneshot::channel();
+        self.send(SessionLifecycleCommand::Touch {
+            channel_id,
+            touched_at_ms,
+            response,
+        });
+    }
 }
 
 #[derive(Debug)]
 enum SessionLifecycleCommand {
     Configure {
         close_delay: Option<Duration>,
+        close_batch_interval: Duration,
         settlement_interval: Option<Duration>,
+        reconciliation: SessionLifecycleReconciliation,
     },
     Touch {
         channel_id: String,
+        touched_at_ms: u64,
+        response: oneshot::Sender<std::result::Result<Option<ChannelState>, String>>,
     },
-    Remove {
-        channel_id: String,
-    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLifecycleReconciliation {
+    /// This process owns the lifecycle clock and closes due channels.
+    Embedded,
+    /// This process only persists touches; an external worker owns the clock.
+    External,
 }
 
 struct SessionLifecycleRunloop {
     runtime: SessionOperatorRuntime,
+    owner: String,
     close_delay: Option<Duration>,
+    close_batch_interval: Duration,
     settlement_interval: Option<Duration>,
     next_settlement: Option<Instant>,
+    reconciliation: SessionLifecycleReconciliation,
     rx: mpsc::UnboundedReceiver<SessionLifecycleCommand>,
-    last_activity: HashMap<String, Instant>,
 }
 
 impl SessionLifecycleRunloop {
@@ -502,78 +538,122 @@ impl SessionLifecycleRunloop {
     ) -> Self {
         Self {
             runtime,
+            owner: uuid::Uuid::new_v4().to_string(),
             close_delay: None,
+            close_batch_interval: Duration::from_secs(60),
             settlement_interval: None,
             next_settlement: None,
+            reconciliation: SessionLifecycleReconciliation::Embedded,
             rx,
-            last_activity: HashMap::new(),
         }
     }
 
     async fn run(mut self) {
         loop {
-            if let Some(deadline) = self.next_wakeup() {
+            if let Some(delay) = self.next_wakeup_delay() {
                 tokio::select! {
                     command = self.rx.recv() => {
-                        if !self.handle_command(command) {
+                        if !self.handle_command(command).await {
                             break;
                         }
                     }
-                    _ = tokio::time::sleep_until(deadline) => {
-                        self.close_due_channels().await;
+                    _ = tokio::time::sleep(delay) => {
+                        if self.reconciliation == SessionLifecycleReconciliation::Embedded {
+                            self.close_due_channels().await;
+                        }
                         self.push_due_watermarks().await;
                     }
                 }
             } else {
                 let command = self.rx.recv().await;
-                if !self.handle_command(command) {
+                if !self.handle_command(command).await {
                     break;
                 }
             }
         }
     }
 
-    fn handle_command(&mut self, command: Option<SessionLifecycleCommand>) -> bool {
+    async fn handle_command(&mut self, command: Option<SessionLifecycleCommand>) -> bool {
         match command {
             Some(SessionLifecycleCommand::Configure {
                 close_delay,
+                close_batch_interval,
                 settlement_interval,
+                reconciliation,
             }) => {
                 self.close_delay = close_delay;
+                self.close_batch_interval = close_batch_interval;
                 self.settlement_interval = settlement_interval;
-                self.next_settlement = settlement_interval
-                    .filter(|_| !self.last_activity.is_empty())
-                    .map(|interval| Instant::now() + interval);
+                self.next_settlement =
+                    settlement_interval.map(|interval| Instant::now() + interval);
+                self.reconciliation = reconciliation;
                 true
             }
-            Some(SessionLifecycleCommand::Touch { channel_id }) => {
-                self.last_activity.insert(channel_id, Instant::now());
-                if self.next_settlement.is_none()
-                    && let Some(interval) = self.settlement_interval
-                {
-                    self.next_settlement = Some(Instant::now() + interval);
+            Some(SessionLifecycleCommand::Touch {
+                channel_id,
+                touched_at_ms,
+                response,
+            }) => {
+                let result = self
+                    .persist_touch(&channel_id, touched_at_ms)
+                    .await
+                    .map_err(|error| error.to_string());
+                if let Err(error) = &result {
+                    tracing::warn!(
+                        channel_id,
+                        error,
+                        "failed to persist payment-channel lifecycle touch"
+                    );
                 }
-                true
-            }
-            Some(SessionLifecycleCommand::Remove { channel_id }) => {
-                self.last_activity.remove(&channel_id);
-                if self.last_activity.is_empty() {
-                    self.next_settlement = None;
-                }
+                let _ = response.send(result);
                 true
             }
             None => false,
         }
     }
 
-    fn next_wakeup(&self) -> Option<Instant> {
-        let close = self.close_delay.and_then(|delay| {
-            self.last_activity
-                .values()
-                .map(|last_activity| *last_activity + delay)
-                .min()
-        });
-        match (close, self.next_settlement) {
+    async fn persist_touch(
+        &self,
+        channel_id: &str,
+        touched_at_ms: u64,
+    ) -> Result<Option<ChannelState>> {
+        let Some(close_delay) = self.close_delay else {
+            return Ok(None);
+        };
+        let idle_deadline = touched_at_ms.saturating_add(duration_millis(close_delay));
+        let close_after =
+            round_up_timestamp(idle_deadline, duration_millis(self.close_batch_interval));
+        let state = self
+            .runtime
+            .channel_store
+            .touch_channel_lifecycle(
+                channel_id,
+                ChannelLifecycle {
+                    owner: self.owner.clone(),
+                    close_after,
+                },
+            )
+            .await
+            .map_err(|error| {
+                Error::Mpp(format!(
+                    "failed to persist lifecycle deadline for {channel_id}: {error}"
+                ))
+            })?;
+        Ok(Some(state))
+    }
+
+    fn next_wakeup_delay(&self) -> Option<Duration> {
+        let close = if self.reconciliation == SessionLifecycleReconciliation::Embedded
+            && self.close_delay.is_some()
+        {
+            Some(duration_until_next_boundary(self.close_batch_interval))
+        } else {
+            None
+        };
+        let settlement = self
+            .next_settlement
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()));
+        match (close, settlement) {
             (Some(close), Some(settlement)) => Some(close.min(settlement)),
             (Some(close), None) => Some(close),
             (None, Some(settlement)) => Some(settlement),
@@ -582,26 +662,41 @@ impl SessionLifecycleRunloop {
     }
 
     async fn close_due_channels(&mut self) {
-        let Some(close_delay) = self.close_delay else {
+        if self.close_delay.is_none() {
             return;
+        }
+        let now_ms = unix_millis();
+        let states = match self.runtime.channel_store.list_channels().await {
+            Ok(states) => states,
+            Err(error) => {
+                tracing::warn!(%error, "failed to enumerate payment-channel lifecycle state");
+                return;
+            }
         };
-        let now = Instant::now();
-        let due = self
-            .last_activity
-            .iter()
-            .filter(|(_, last_activity)| **last_activity + close_delay <= now)
-            .map(|(channel_id, _)| channel_id.clone())
+        let due = states
+            .into_iter()
+            .filter(|state| !state.sealed && state.close_requested_at.is_none())
+            .filter_map(|state| {
+                state
+                    .lifecycle
+                    .as_ref()
+                    .filter(|lifecycle| {
+                        lifecycle.owner == self.owner && lifecycle.close_after <= now_ms
+                    })
+                    .map(|_| state.channel_id)
+            })
             .collect::<Vec<_>>();
 
         let mut closing = Vec::with_capacity(due.len());
         for channel_id in due {
-            self.last_activity.remove(&channel_id);
             // Closing and serving both claim the same channel slot. This makes
             // the reservation check atomic with the start of close: a request
             // already in flight defers close, while a close already in progress
             // prevents a new request from reserving stale capacity.
             if !self.runtime.reserve_capacity(&channel_id, 0) {
-                self.last_activity.insert(channel_id, Instant::now());
+                if let Err(error) = self.persist_touch(&channel_id, now_ms).await {
+                    tracing::warn!(channel_id, %error, "failed to defer busy channel close");
+                }
                 continue;
             }
             let runtime = self.runtime.clone();
@@ -626,7 +721,13 @@ impl SessionLifecycleRunloop {
                         error = %error,
                         "operator auto-close failed; retrying after delay"
                     );
-                    self.last_activity.insert(channel_id, Instant::now());
+                    if let Err(touch_error) = self.persist_touch(&channel_id, unix_millis()).await {
+                        tracing::warn!(
+                            channel_id,
+                            error = %touch_error,
+                            "failed to reschedule payment-channel close"
+                        );
+                    }
                 }
             }
         }
@@ -642,9 +743,25 @@ impl SessionLifecycleRunloop {
             return;
         }
 
-        // Idle channels were removed (or rescheduled after an error) by
-        // `close_due_channels`; everything left here should remain open.
-        let channels = self.last_activity.keys().cloned().collect::<Vec<_>>();
+        let states = match self.runtime.channel_store.list_channels().await {
+            Ok(states) => states,
+            Err(error) => {
+                tracing::warn!(%error, "failed to enumerate active payment channels");
+                self.next_settlement = Some(now + interval);
+                return;
+            }
+        };
+        let channels = states
+            .into_iter()
+            .filter(|state| !state.sealed && state.close_requested_at.is_none())
+            .filter(|state| {
+                state
+                    .lifecycle
+                    .as_ref()
+                    .is_some_and(|lifecycle| lifecycle.owner == self.owner)
+            })
+            .map(|state| state.channel_id)
+            .collect::<Vec<_>>();
         let mut settlements = Vec::with_capacity(channels.len());
         for channel_id in channels {
             if !self.runtime.reserve_capacity(&channel_id, 0) {
@@ -667,8 +784,37 @@ impl SessionLifecycleRunloop {
             }
         }
 
-        self.next_settlement = (!self.last_activity.is_empty()).then(|| now + interval);
+        self.next_settlement = Some(now + interval);
     }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn unix_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(duration_millis)
+        .unwrap_or_default()
+}
+
+fn round_up_timestamp(timestamp_ms: u64, interval_ms: u64) -> u64 {
+    if interval_ms == 0 {
+        return timestamp_ms;
+    }
+    let remainder = timestamp_ms % interval_ms;
+    if remainder == 0 {
+        timestamp_ms
+    } else {
+        timestamp_ms.saturating_add(interval_ms - remainder)
+    }
+}
+
+fn duration_until_next_boundary(interval: Duration) -> Duration {
+    let now = unix_millis();
+    let next = round_up_timestamp(now.saturating_add(1), duration_millis(interval));
+    Duration::from_millis(next.saturating_sub(now))
 }
 
 enum SessionCloseResult {
@@ -826,7 +972,12 @@ impl SessionMpp {
     /// The runloop is intentionally centralized: request handlers only record
     /// activity, while this task owns the close/settle/distribute sequence.
     pub fn start_lifecycle_runloop(&self, close_delay: Duration) {
-        self.start_lifecycle_runloop_with_settlement(close_delay, Duration::ZERO);
+        self.start_lifecycle_runloop_with_settlement_and_batching(
+            close_delay,
+            close_delay,
+            Duration::ZERO,
+            SessionLifecycleReconciliation::Embedded,
+        );
     }
 
     /// Configure the lifecycle runloop to reconcile active channels' latest
@@ -837,15 +988,46 @@ impl SessionMpp {
         close_delay: Duration,
         settlement_interval: Duration,
     ) {
-        let close_delay = (!close_delay.is_zero()).then_some(close_delay);
-        let settlement_interval = (!settlement_interval.is_zero()).then_some(settlement_interval);
-        self.lifecycle.send(SessionLifecycleCommand::Configure {
+        self.start_lifecycle_runloop_with_settlement_and_batching(
+            close_delay,
             close_delay,
             settlement_interval,
+            SessionLifecycleReconciliation::Embedded,
+        );
+    }
+
+    /// Configure store-backed lifecycle scheduling.
+    ///
+    /// Every request persists its rounded idle deadline through
+    /// [`ChannelStore`]. In external mode this process does not own the clock;
+    /// a durable reconciliation worker closes due channels.
+    pub fn start_lifecycle_runloop_with_settlement_and_batching(
+        &self,
+        close_delay: Duration,
+        close_batch_interval: Duration,
+        settlement_interval: Duration,
+        reconciliation: SessionLifecycleReconciliation,
+    ) {
+        let close_delay = (!close_delay.is_zero()).then_some(close_delay);
+        let close_batch_interval = if close_batch_interval.is_zero() {
+            Duration::from_secs(60)
+        } else {
+            close_batch_interval
+        };
+        let settlement_interval = (reconciliation == SessionLifecycleReconciliation::Embedded
+            && !settlement_interval.is_zero())
+        .then_some(settlement_interval);
+        self.lifecycle.send(SessionLifecycleCommand::Configure {
+            close_delay,
+            close_batch_interval,
+            settlement_interval,
+            reconciliation,
         });
         tracing::info!(
             close_delay_ms = close_delay.map(|delay| delay.as_millis()),
+            close_batch_interval_ms = close_batch_interval.as_millis(),
             settlement_interval_ms = settlement_interval.map(|interval| interval.as_millis()),
+            reconciliation = ?reconciliation,
             "started session lifecycle runloop"
         );
     }
@@ -935,25 +1117,51 @@ impl SessionMpp {
             .await
             .map_err(|e| Error::PaymentRejected(e.to_string()))?;
         self.record_committed_watermark(channel_id.to_string(), accepted.cumulative);
-        self.touch_channel(channel_id.to_string());
+        self.touch_channel(channel_id.to_string()).await?;
         Ok(accepted.cumulative)
     }
 
-    pub fn reserve_delegated_capacity(
+    pub async fn reserve_delegated_capacity(
         &self,
         channel_id: &str,
         amount: u64,
-    ) -> Option<DelegatedCapacityLease> {
-        self.operator_runtime
+    ) -> Result<Option<DelegatedCapacityLease>> {
+        self.touch_channel(channel_id.to_string()).await?;
+        Ok(self
+            .operator_runtime
             .reserve_capacity(channel_id, amount)
             .then(|| DelegatedCapacityLease {
                 runtime: self.operator_runtime.clone(),
                 channel_id: channel_id.to_string(),
-            })
+            }))
     }
 
     /// Record channel activity so the lifecycle runloop can defer auto-close.
-    pub fn touch_channel(&self, channel_id: impl Into<String>) {
+    pub async fn touch_channel(&self, channel_id: impl Into<String>) -> Result<()> {
+        let channel_id = channel_id.into();
+        if self
+            .pull_sessions
+            .lock()
+            .map(|sessions| sessions.contains(&channel_id))
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+        if let Some(state) = self.lifecycle.touch(channel_id, unix_millis()).await?
+            && (state.sealed || state.close_requested_at.is_some())
+        {
+            return Err(Error::PaymentRejected(
+                "payment channel close is pending".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Queue a best-effort lifecycle extension for a request that has already
+    /// performed a confirmed wake-up. Streaming paths use this to avoid a
+    /// Redis round trip per response chunk while still extending long-lived
+    /// requests.
+    pub fn touch_channel_unconfirmed(&self, channel_id: impl Into<String>) {
         let channel_id = channel_id.into();
         if self
             .pull_sessions
@@ -963,8 +1171,7 @@ impl SessionMpp {
         {
             return;
         }
-        self.lifecycle
-            .send(SessionLifecycleCommand::Touch { channel_id });
+        self.lifecycle.touch_unconfirmed(channel_id, unix_millis());
     }
 
     /// Latest cumulative watermark accepted by this process for a session.
@@ -1096,7 +1303,7 @@ impl SessionMpp {
                     self.record_pull_session(state.channel_id.clone());
                 }
                 self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
-                self.touch_channel(state.channel_id.clone());
+                self.touch_channel(state.channel_id.clone()).await?;
                 Ok(SessionOutcome::Active {
                     state,
                     signature: Some(payload_for_open.signature.clone()),
@@ -1112,7 +1319,7 @@ impl SessionMpp {
                     .cumulative;
                 let channel_id = p.voucher.data.channel_id.clone();
                 self.record_committed_watermark(channel_id.clone(), cumulative);
-                self.touch_channel(channel_id.clone());
+                self.touch_channel(channel_id.clone()).await?;
                 Ok(SessionOutcome::Voucher {
                     channel_id,
                     cumulative,
@@ -1128,7 +1335,7 @@ impl SessionMpp {
                 if let Ok(cumulative) = receipt.cumulative.parse::<u64>() {
                     self.record_committed_watermark(receipt.session_id.clone(), cumulative);
                 }
-                self.touch_channel(receipt.session_id.clone());
+                self.touch_channel(receipt.session_id.clone()).await?;
                 Ok(SessionOutcome::Commit(receipt))
             }
 
@@ -1139,7 +1346,7 @@ impl SessionMpp {
                     .await
                     .map_err(|e| Error::Mpp(format!("TopUp failed: {e}")))?;
                 self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
-                self.touch_channel(state.channel_id.clone());
+                self.touch_channel(state.channel_id.clone()).await?;
                 Ok(SessionOutcome::Active {
                     state,
                     signature: Some(p.signature.clone()),
@@ -1149,6 +1356,7 @@ impl SessionMpp {
             SessionAction::Close(p) => {
                 let _lease = self
                     .reserve_delegated_capacity(&p.channel_id, 0)
+                    .await?
                     .ok_or_else(|| {
                         Error::Mpp(format!(
                             "Session channel {} is busy with another request",
@@ -1200,7 +1408,6 @@ impl SessionMpp {
                         &params.channel_id.to_string(),
                     );
                 }
-                self.unschedule_channel_close(params.channel_id.to_string());
                 Ok(SessionOutcome::Closed { params, signature })
             }
         }
@@ -1230,17 +1437,11 @@ impl SessionMpp {
             .begin_delivery(request)
             .await
             .map_err(|e| Error::Mpp(format!("Failed to reserve session delivery: {e}")))?;
-        self.touch_channel(session_id);
+        self.touch_channel(session_id).await?;
         Ok(directive)
     }
 
     // ── Private helpers ──────────────────────────────────────────────────────
-
-    fn unschedule_channel_close(&self, channel_id: impl Into<String>) {
-        self.lifecycle.send(SessionLifecycleCommand::Remove {
-            channel_id: channel_id.into(),
-        });
-    }
 
     fn record_committed_watermark(&self, session_id: impl Into<String>, cumulative: u64) {
         self.operator_runtime
@@ -1821,6 +2022,8 @@ mod tests {
         let close_header = handle.close_header(Some(25)).await.unwrap();
         let competing_lease = session
             .reserve_delegated_capacity(&opened.channel_id, 0)
+            .await
+            .unwrap()
             .expect("test should reserve the channel");
         let error = session.process(&close_header).await.unwrap_err();
         assert!(
@@ -1967,20 +2170,114 @@ mod tests {
     }
 
     #[test]
-    fn delegated_capacity_lease_releases_on_drop() {
+    fn lifecycle_deadlines_round_up_to_batch_boundary() {
+        assert_eq!(round_up_timestamp(120_000, 60_000), 120_000);
+        assert_eq!(round_up_timestamp(120_001, 60_000), 180_000);
+        assert_eq!(round_up_timestamp(u64::MAX - 10, 60_000), u64::MAX);
+        assert_eq!(round_up_timestamp(123, 0), 123);
+    }
+
+    #[tokio::test]
+    async fn external_lifecycle_persists_deadline_without_closing_locally() {
+        let session = Arc::new(test_session_mpp());
+        session.start_lifecycle_runloop_with_settlement_and_batching(
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            Duration::ZERO,
+            SessionLifecycleReconciliation::External,
+        );
+        let challenge = session.challenge(CAP).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            test_session_signer(),
+            challenge,
+        );
+
+        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state: opened, .. } =
+            session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected open to return active session");
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let persisted = session
+                    .operator_runtime
+                    .channel_store
+                    .get_channel(&opened.channel_id)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                if persisted.lifecycle.is_some() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("lifecycle touch should be persisted");
+
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        let persisted = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&opened.channel_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(persisted.lifecycle.is_some());
+        assert!(
+            persisted.close_requested_at.is_none(),
+            "external mode must leave close ownership to the worker"
+        );
+
+        session
+            .operator_runtime
+            .channel_store
+            .update_channel(
+                &opened.channel_id,
+                Box::new(|state| {
+                    let mut state = state.unwrap();
+                    state.close_requested_at = Some(1);
+                    Ok(state)
+                }),
+            )
+            .await
+            .unwrap();
+        let error = session
+            .touch_channel(opened.channel_id)
+            .await
+            .expect_err("a worker-claimed close cannot be woken");
+        assert!(error.to_string().contains("close is pending"));
+    }
+
+    #[tokio::test]
+    async fn delegated_capacity_lease_releases_on_drop() {
         let session = test_session_mpp();
         let first = session
             .reserve_delegated_capacity("channel", CAP)
+            .await
+            .unwrap()
             .expect("first reservation should succeed");
         assert!(
-            session.reserve_delegated_capacity("channel", CAP).is_none(),
+            session
+                .reserve_delegated_capacity("channel", CAP)
+                .await
+                .unwrap()
+                .is_none(),
             "a live lease must exclude concurrent reservations"
         );
 
         drop(first);
 
         assert!(
-            session.reserve_delegated_capacity("channel", CAP).is_some(),
+            session
+                .reserve_delegated_capacity("channel", CAP)
+                .await
+                .unwrap()
+                .is_some(),
             "dropping the lease must release capacity"
         );
     }
@@ -2004,6 +2301,8 @@ mod tests {
         };
         let lease = session
             .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .await
+            .unwrap()
             .expect("request should reserve channel capacity");
 
         tokio::time::sleep(Duration::from_millis(60)).await;

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1345,6 +1345,9 @@ impl SessionMpp {
                     telemetry::record_payment_channel_opened(
                         &payload_for_open.signature,
                         &state.channel_id.to_string(),
+                        self.currency(),
+                        self.network(),
+                        state.deposit,
                     );
                 }
 

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
 
+use crate::server::telemetry;
 use crate::{Error, Result};
 
 const INTENT: &str = "session";
@@ -271,12 +272,7 @@ impl SessionOperatorRuntime {
             // Retain the settle signature so `/sessions/receipt/:channelId` can
             // surface the on-chain receipt URL (sessions settle out-of-band).
             self.record_settlement_signature(params.channel_id.to_string(), signature.clone());
-            tracing::info!(
-                monotonic_counter.pay_payment_channels_closed_total = 1_u64,
-                %signature,
-                channel = %params.channel_id,
-                "payment-channel settlement confirmed"
-            );
+            telemetry::record_payment_channel_closed(&signature, &params.channel_id.to_string());
         }
 
         Ok(SessionCloseResult::Closed {
@@ -1199,11 +1195,9 @@ impl SessionMpp {
                         params.channel_id.to_string(),
                         signature.clone(),
                     );
-                    tracing::info!(
-                        monotonic_counter.pay_payment_channels_closed_total = 1_u64,
-                        %signature,
-                        channel = %params.channel_id,
-                        "payment-channel settlement confirmed"
+                    telemetry::record_payment_channel_closed(
+                        signature,
+                        &params.channel_id.to_string(),
                     );
                 }
                 self.unschedule_channel_close(params.channel_id.to_string());

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -6,7 +6,7 @@
 
 use std::error::Error as StdError;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::body::Bytes;
 use futures_util::{Stream, StreamExt};
@@ -26,6 +26,7 @@ use crate::server::session_metering::{
 
 const COMMIT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const LIFECYCLE_TOUCH_INTERVAL: Duration = Duration::from_secs(30);
 
 type BoxError = Box<dyn StdError + Send + Sync>;
 
@@ -73,8 +74,9 @@ impl SessionStreamContext {
         self.session_mpp.min_voucher_delta()
     }
 
-    pub fn touch_channel(&self) {
-        self.session_mpp.touch_channel(self.session_id.clone());
+    pub fn touch_channel_unconfirmed(&self) {
+        self.session_mpp
+            .touch_channel_unconfirmed(self.session_id.clone());
     }
 }
 
@@ -148,6 +150,7 @@ pub struct SessionStreamMeter {
     gate: SessionUsageGate,
     accumulator: StreamUsageAccumulator,
     current: UsageObservation,
+    next_lifecycle_touch: Instant,
 }
 
 /// Server-authorized meter for a delegated session response stream.
@@ -163,6 +166,7 @@ pub(crate) struct DelegatedSessionStreamMeter {
     priced_context_length: Option<u64>,
     clamp_reprice_to_authorized: bool,
     authorization_exhausted: bool,
+    next_lifecycle_touch: Instant,
 }
 
 impl DelegatedSessionStreamMeter {
@@ -200,6 +204,7 @@ impl DelegatedSessionStreamMeter {
             priced_context_length,
             clamp_reprice_to_authorized: false,
             authorization_exhausted: false,
+            next_lifecycle_touch: Instant::now() + LIFECYCLE_TOUCH_INTERVAL,
         })
     }
 
@@ -331,6 +336,17 @@ impl DelegatedSessionStreamMeter {
         self.clamp_reprice_to_authorized = usage_only_chunk;
         Ok(())
     }
+
+    fn touch_channel_if_due(&mut self) {
+        let now = Instant::now();
+        if now < self.next_lifecycle_touch {
+            return;
+        }
+        self.forward
+            .handle
+            .touch_channel_unconfirmed(self.forward.channel_id.clone());
+        self.next_lifecycle_touch = now + LIFECYCLE_TOUCH_INTERVAL;
+    }
 }
 
 impl SessionStreamMeter {
@@ -351,6 +367,7 @@ impl SessionStreamMeter {
             gate,
             accumulator: StreamUsageAccumulator::new(spec, hints),
             current,
+            next_lifecycle_touch: Instant::now() + LIFECYCLE_TOUCH_INTERVAL,
         })
     }
 
@@ -382,8 +399,13 @@ impl SessionStreamMeter {
         self.gate.record_commit(committed_base_units);
     }
 
-    fn touch_channel(&self) {
-        self.context.touch_channel();
+    fn touch_channel_if_due(&mut self) {
+        let now = Instant::now();
+        if now < self.next_lifecycle_touch {
+            return;
+        }
+        self.context.touch_channel_unconfirmed();
+        self.next_lifecycle_touch = now + LIFECYCLE_TOUCH_INTERVAL;
     }
 }
 
@@ -400,7 +422,7 @@ where
         futures_util::pin_mut!(stream);
         while let Some(next) = stream.next().await {
             let chunk = next.map_err(box_error)?;
-            meter.touch_channel();
+            meter.touch_channel_if_due();
             let decision = meter.observe_chunk(&chunk, is_sse).map_err(box_error)?;
             if let Some(decision) = decision {
                 settle_decision(&mut meter, decision).await?;
@@ -434,6 +456,7 @@ where
         futures_util::pin_mut!(stream);
         while let Some(next) = stream.next().await {
             let chunk = next.map_err(box_error)?;
+            meter.touch_channel_if_due();
             let decision = meter.observe_chunk(&chunk, is_sse)?;
             if let Some(decision) = decision {
                 meter.settle(decision).await?;
@@ -1221,6 +1244,8 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
         };
         let reservation = session
             .reserve_delegated_capacity(&state.channel_id, 1_000)
+            .await
+            .unwrap()
             .expect("session capacity should be available");
         let forward = SessionForward::delegated(
             session.clone(),

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -24,6 +24,27 @@ pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_
 pub const METRIC_PAYMENT_CHANNELS_OPENED: &str = "pay_payment_channels_opened_total";
 pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
 
+/// Create the bounded session-lifecycle counter series before the server
+/// accepts traffic. The CLI force-flushes these zero values so Prometheus has
+/// a real baseline even when the first request opens a channel immediately.
+pub fn record_metric_baselines() {
+    tracing::info!(
+        monotonic_counter.pay_payment_channels_opened_total = 0_u64,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNELS_OPENED,
+        "payment-channel open confirmed",
+    );
+    for retryable in [true, false] {
+        tracing::info!(
+            monotonic_counter.pay_payment_settlement_errors_total = 0_u64,
+            protocol = "mpp/session",
+            retryable,
+            metric = METRIC_SETTLEMENT_ERRORS,
+            "payment settlement failed",
+        );
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PaymentAmount {
     pub currency: String,
@@ -344,7 +365,6 @@ pub fn record_settlement_error(
     tracing::warn!(
         monotonic_counter.pay_payment_settlement_errors_total = 1_u64,
         protocol,
-        subdomain = %subdomain,
         retryable,
         metric = METRIC_SETTLEMENT_ERRORS,
         "payment settlement failed",

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -24,6 +24,7 @@ pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_
 pub const METRIC_PAYMENT_CHANNELS_OPENED: &str = "pay_payment_channels_opened_total";
 pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
 pub const METRIC_PAYMENT_CHANNEL_ESCROWED: &str = "pay_payment_channel_escrowed_base_units";
+pub const METRIC_PAYMENT_CHANNEL_CLIENT: &str = "pay_payment_channel_client";
 pub const METRIC_PAYMENT_CHANNEL_VOUCHER_CUMULATIVE: &str =
     "pay_payment_channel_voucher_cumulative_base_units";
 
@@ -417,6 +418,7 @@ pub fn record_payment_channel_closed(signature: &str, channel: &str) {
 pub fn record_payment_channel_opened(
     signature: &str,
     channel: &str,
+    client_id: &str,
     currency: &str,
     network: &str,
     escrowed: u64,
@@ -437,6 +439,13 @@ pub fn record_payment_channel_opened(
         protocol = "mpp/session",
         metric = METRIC_PAYMENT_CHANNEL_ESCROWED,
         "payment-channel escrow confirmed",
+    );
+    tracing::info!(
+        gauge.pay_payment_channel_client = 1_u64,
+        client_id,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNEL_CLIENT,
+        "payment-channel client confirmed",
     );
     tracing::info!(
         signature = %signature,

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -23,6 +23,7 @@ pub const METRIC_FEE_PAID_SOL: &str = "pay_fee_paid_sol_total";
 pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_total";
 pub const METRIC_PAYMENT_CHANNELS_OPENED: &str = "pay_payment_channels_opened_total";
 pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
+pub const METRIC_PAYMENT_CHANNEL_ESCROWED: &str = "pay_payment_channel_escrowed_base_units";
 pub const METRIC_PAYMENT_CHANNEL_VOUCHER_CUMULATIVE: &str =
     "pay_payment_channel_voucher_cumulative_base_units";
 
@@ -413,7 +414,13 @@ pub fn record_payment_channel_closed(signature: &str, channel: &str) {
     );
 }
 
-pub fn record_payment_channel_opened(signature: &str, channel: &str) {
+pub fn record_payment_channel_opened(
+    signature: &str,
+    channel: &str,
+    currency: &str,
+    network: &str,
+    escrowed: u64,
+) {
     tracing::info!(
         monotonic_counter.pay_payment_channels_opened_total = 1_u64,
         protocol = "mpp/session",
@@ -421,6 +428,15 @@ pub fn record_payment_channel_opened(signature: &str, channel: &str) {
         verification = "account_confirmed",
         metric = METRIC_PAYMENT_CHANNELS_OPENED,
         "payment-channel open confirmed",
+    );
+    tracing::info!(
+        gauge.pay_payment_channel_escrowed_base_units = escrowed,
+        channel_id = channel,
+        currency,
+        network,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNEL_ESCROWED,
+        "payment-channel escrow confirmed",
     );
     tracing::info!(
         signature = %signature,

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -23,6 +23,8 @@ pub const METRIC_FEE_PAID_SOL: &str = "pay_fee_paid_sol_total";
 pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_total";
 pub const METRIC_PAYMENT_CHANNELS_OPENED: &str = "pay_payment_channels_opened_total";
 pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
+pub const METRIC_PAYMENT_CHANNEL_VOUCHER_CUMULATIVE: &str =
+    "pay_payment_channel_voucher_cumulative_base_units";
 
 /// Create the bounded session-lifecycle counter series before the server
 /// accepts traffic. The CLI force-flushes these zero values so Prometheus has
@@ -31,6 +33,8 @@ pub fn record_metric_baselines() {
     tracing::info!(
         monotonic_counter.pay_payment_channels_opened_total = 0_u64,
         protocol = "mpp/session",
+        channel_kind = "payment_channel",
+        verification = "account_confirmed",
         metric = METRIC_PAYMENT_CHANNELS_OPENED,
         "payment-channel open confirmed",
     );
@@ -413,6 +417,8 @@ pub fn record_payment_channel_opened(signature: &str, channel: &str) {
     tracing::info!(
         monotonic_counter.pay_payment_channels_opened_total = 1_u64,
         protocol = "mpp/session",
+        channel_kind = "payment_channel",
+        verification = "account_confirmed",
         metric = METRIC_PAYMENT_CHANNELS_OPENED,
         "payment-channel open confirmed",
     );
@@ -420,6 +426,27 @@ pub fn record_payment_channel_opened(signature: &str, channel: &str) {
         signature = %signature,
         channel = %channel,
         "payment-channel open details",
+    );
+}
+
+/// Record the latest cumulative voucher only after it has been accepted and
+/// persisted. The channel id is intentionally a metric attribute: the
+/// settlement dashboard pairs this proxy-side watermark with the worker's
+/// confirmed on-chain watermark to derive the value still at risk.
+pub fn record_payment_channel_voucher_cumulative(
+    channel_id: &str,
+    currency: &str,
+    network: &str,
+    cumulative: u64,
+) {
+    tracing::info!(
+        gauge.pay_payment_channel_voucher_cumulative_base_units = cumulative,
+        channel_id,
+        currency,
+        network,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNEL_VOUCHER_CUMULATIVE,
+        "payment-channel voucher persisted",
     );
 }
 

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -21,6 +21,7 @@ pub const METRIC_CHALLENGE_AMOUNT_USD: &str = "pay_402_challenge_amount_usd";
 pub const METRIC_FEE_PAYER_WALLET_SOL: &str = "pay_fee_payer_wallet_sol";
 pub const METRIC_FEE_PAID_SOL: &str = "pay_fee_paid_sol_total";
 pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_total";
+pub const METRIC_PAYMENT_CHANNELS_OPENED: &str = "pay_payment_channels_opened_total";
 pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
 
 #[derive(Debug, Clone)]
@@ -385,6 +386,20 @@ pub fn record_payment_channel_closed(signature: &str, channel: &str) {
         signature = %signature,
         channel = %channel,
         "payment-channel settlement details",
+    );
+}
+
+pub fn record_payment_channel_opened(signature: &str, channel: &str) {
+    tracing::info!(
+        monotonic_counter.pay_payment_channels_opened_total = 1_u64,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNELS_OPENED,
+        "payment-channel open confirmed",
+    );
+    tracing::info!(
+        signature = %signature,
+        channel = %channel,
+        "payment-channel open details",
     );
 }
 

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -21,6 +21,7 @@ pub const METRIC_CHALLENGE_AMOUNT_USD: &str = "pay_402_challenge_amount_usd";
 pub const METRIC_FEE_PAYER_WALLET_SOL: &str = "pay_fee_payer_wallet_sol";
 pub const METRIC_FEE_PAID_SOL: &str = "pay_fee_paid_sol_total";
 pub const METRIC_FEE_PAYER_BALANCE_ERRORS: &str = "pay_fee_payer_balance_errors_total";
+pub const METRIC_PAYMENT_CHANNELS_CLOSED: &str = "pay_payment_channels_closed_total";
 
 #[derive(Debug, Clone)]
 pub struct PaymentAmount {
@@ -34,8 +35,6 @@ pub struct PaymentAmount {
 /// other than `"periodic"`) always warn so they surface for the
 /// in-flight request that just lost telemetry.
 const PERIODIC_WARN_AFTER_CONSECUTIVE_FAILURES: u64 = 5;
-const MAX_METRIC_ERROR_LABEL_BYTES: usize = 512;
-
 /// Timeout for a single `getBalance` round-trip. Without this, a stalled
 /// RPC connection can hang the periodic probe forever and accumulate
 /// warning noise on the next interval tick.
@@ -79,7 +78,6 @@ impl FeePayerWallet {
                     gauge.pay_fee_payer_wallet_sol = sol,
                     reason,
                     subdomain = %subdomain,
-                    path = %path,
                     wallet = %self.address,
                     metric = METRIC_FEE_PAYER_WALLET_SOL,
                     "fee payer wallet balance observed",
@@ -91,7 +89,6 @@ impl FeePayerWallet {
                         monotonic_counter.pay_fee_paid_sol_total = fee_paid_sol,
                         reason,
                         subdomain = %subdomain,
-                        path = %path,
                         wallet = %self.address,
                         metric = METRIC_FEE_PAID_SOL,
                         "fee payer SOL spend observed",
@@ -111,9 +108,16 @@ impl FeePayerWallet {
                 let is_periodic = reason == "periodic";
                 let should_warn =
                     !is_periodic || failures >= PERIODIC_WARN_AFTER_CONSECUTIVE_FAILURES;
+                tracing::info!(
+                    monotonic_counter.pay_fee_payer_balance_errors_total = 1_u64,
+                    reason,
+                    subdomain = %subdomain,
+                    wallet = %self.address,
+                    metric = METRIC_FEE_PAYER_BALANCE_ERRORS,
+                    "fee payer wallet balance observation failed",
+                );
                 if should_warn {
                     tracing::warn!(
-                        monotonic_counter.pay_fee_payer_balance_errors_total = 1_u64,
                         reason,
                         subdomain = %subdomain,
                         path = %path,
@@ -125,7 +129,6 @@ impl FeePayerWallet {
                     );
                 } else {
                     tracing::debug!(
-                        monotonic_counter.pay_fee_payer_balance_errors_total = 1_u64,
                         reason,
                         subdomain = %subdomain,
                         path = %path,
@@ -193,7 +196,7 @@ pub fn record_402_challenge_sent(
     path: &str,
     method: &str,
     amount_usd: Option<f64>,
-    currencies: &str,
+    schemes: &str,
     challenge_count: usize,
 ) {
     if let Some(amount_usd) = amount_usd {
@@ -202,10 +205,8 @@ pub fn record_402_challenge_sent(
             histogram.pay_402_challenge_amount_usd = amount_usd,
             protocol,
             subdomain = %subdomain,
-            path = %path,
             http_method = %method,
-            currency = %currencies,
-            challenge_count = challenge_count as u64,
+            schemes = %schemes,
             metric = METRIC_402_RESPONSES,
             "402 payment challenge sent",
         );
@@ -214,14 +215,21 @@ pub fn record_402_challenge_sent(
             monotonic_counter.pay_402_responses_total = 1_u64,
             protocol,
             subdomain = %subdomain,
-            path = %path,
             http_method = %method,
-            currency = %currencies,
-            challenge_count = challenge_count as u64,
+            schemes = %schemes,
             metric = METRIC_402_RESPONSES,
             "402 payment challenge sent",
         );
     }
+    tracing::debug!(
+        protocol,
+        subdomain = %subdomain,
+        path = %path,
+        http_method = %method,
+        schemes = %schemes,
+        challenge_count,
+        "402 payment challenge details",
+    );
 }
 
 pub fn record_challenge_error(protocol: &'static str, currency: &str, error: &str) {
@@ -229,9 +237,14 @@ pub fn record_challenge_error(protocol: &'static str, currency: &str, error: &st
         monotonic_counter.pay_402_challenge_errors_total = 1_u64,
         protocol,
         currency = %currency,
-        error = %error,
         metric = METRIC_CHALLENGE_ERRORS,
         "payment challenge generation failed",
+    );
+    tracing::error!(
+        protocol,
+        currency = %currency,
+        error = %error,
+        "payment challenge generation error details",
     );
 }
 
@@ -243,16 +256,24 @@ pub fn record_payment_collected(
     reference: &str,
 ) {
     match payment {
-        Some(payment) => tracing::info!(
-            monotonic_counter.pay_payments_collected_usd_total = payment.ui_amount,
-            protocol,
-            subdomain = %subdomain,
-            path = %path,
-            currency = %payment.currency,
-            reference = %reference,
-            metric = METRIC_PAYMENTS_COLLECTED_USD,
-            "payment collected",
-        ),
+        Some(payment) => {
+            tracing::info!(
+                monotonic_counter.pay_payments_collected_usd_total = payment.ui_amount,
+                protocol,
+                subdomain = %subdomain,
+                metric = METRIC_PAYMENTS_COLLECTED_USD,
+                "payment collected",
+            );
+            tracing::info!(
+                protocol,
+                subdomain = %subdomain,
+                path = %path,
+                currency = %payment.currency,
+                amount_usd = payment.ui_amount,
+                reference = %reference,
+                "payment collection details",
+            );
+        }
         None => tracing::info!(
             protocol,
             subdomain = %subdomain,
@@ -276,10 +297,8 @@ pub fn record_paid_request_completed(
                 monotonic_counter.pay_402_requests_successful_total = 1_u64,
                 protocol,
                 subdomain = %subdomain,
-                path = %path,
                 status = status.as_u16() as u64,
                 currency = %payment.currency,
-                amount_usd = payment.ui_amount,
                 metric = METRIC_402_SUCCESS,
                 "paid request completed",
             ),
@@ -287,7 +306,6 @@ pub fn record_paid_request_completed(
                 monotonic_counter.pay_402_requests_successful_total = 1_u64,
                 protocol,
                 subdomain = %subdomain,
-                path = %path,
                 status = status.as_u16() as u64,
                 metric = METRIC_402_SUCCESS,
                 "paid request completed",
@@ -300,12 +318,19 @@ pub fn record_paid_request_completed(
             monotonic_counter.pay_paid_delivery_errors_total = 1_u64,
             protocol,
             subdomain = %subdomain,
-            path = %path,
             status = status.as_u16() as u64,
             metric = METRIC_PAID_DELIVERY_ERRORS,
             "paid upstream delivery failed",
         );
     }
+    tracing::debug!(
+        protocol,
+        subdomain = %subdomain,
+        path = %path,
+        status = status.as_u16() as u64,
+        amount_usd = payment.map(|amount| amount.ui_amount),
+        "paid request completion details",
+    );
 }
 
 pub fn record_settlement_error(
@@ -315,39 +340,51 @@ pub fn record_settlement_error(
     error: &str,
     retryable: bool,
 ) {
-    let error = bounded_metric_label(error, MAX_METRIC_ERROR_LABEL_BYTES);
     tracing::warn!(
         monotonic_counter.pay_payment_settlement_errors_total = 1_u64,
+        protocol,
+        subdomain = %subdomain,
+        retryable,
+        metric = METRIC_SETTLEMENT_ERRORS,
+        "payment settlement failed",
+    );
+    tracing::warn!(
         protocol,
         subdomain = %subdomain,
         path = %path,
         retryable,
         error = %error,
-        metric = METRIC_SETTLEMENT_ERRORS,
-        "payment settlement failed",
+        "payment settlement error details",
     );
-}
-
-fn bounded_metric_label(value: &str, max_bytes: usize) -> &str {
-    if value.len() <= max_bytes {
-        return value;
-    }
-    let mut end = max_bytes;
-    while !value.is_char_boundary(end) {
-        end -= 1;
-    }
-    &value[..end]
 }
 
 pub fn record_upstream_error(subdomain: &str, path: &str, upstream: &str, error: &str) {
     tracing::error!(
         monotonic_counter.pay_upstream_errors_total = 1_u64,
         subdomain = %subdomain,
+        metric = METRIC_UPSTREAM_ERRORS,
+        "upstream request failed",
+    );
+    tracing::error!(
+        subdomain = %subdomain,
         path = %path,
         upstream = %upstream,
         error = %error,
-        metric = METRIC_UPSTREAM_ERRORS,
-        "upstream request failed",
+        "upstream request error details",
+    );
+}
+
+pub fn record_payment_channel_closed(signature: &str, channel: &str) {
+    tracing::info!(
+        monotonic_counter.pay_payment_channels_closed_total = 1_u64,
+        protocol = "mpp/session",
+        metric = METRIC_PAYMENT_CHANNELS_CLOSED,
+        "payment-channel settlement confirmed",
+    );
+    tracing::info!(
+        signature = %signature,
+        channel = %channel,
+        "payment-channel settlement details",
     );
 }
 
@@ -390,15 +427,5 @@ mod tests {
     fn paid_delivery_error_is_5xx() {
         assert!(is_paid_delivery_error(StatusCode::BAD_GATEWAY));
         assert!(!is_paid_delivery_error(StatusCode::BAD_REQUEST));
-    }
-
-    #[test]
-    fn metric_error_labels_are_bounded_on_utf8_boundaries() {
-        let error = format!("{}failure", "é".repeat(300));
-        let bounded = bounded_metric_label(&error, MAX_METRIC_ERROR_LABEL_BYTES);
-
-        assert!(bounded.len() <= MAX_METRIC_ERROR_LABEL_BYTES);
-        assert!(bounded.is_char_boundary(bounded.len()));
-        assert_eq!(bounded.len(), 512);
     }
 }

--- a/rust/crates/core/tests/surfpool_tests.rs
+++ b/rust/crates/core/tests/surfpool_tests.rs
@@ -470,12 +470,16 @@ async fn push_session_full_flow() {
     use pay_core::PaymentState;
     use pay_core::server::session::SessionMpp;
     use pay_kit::mpp::client::session::ActiveSession;
+    use pay_kit::mpp::program::payment_channels::generated::generated::{
+        accounts::Channel, types::SettlementWatermarks,
+    };
     use pay_kit::mpp::server::session::SessionConfig;
     use pay_kit::mpp::solana_keychain::memory::MemorySigner;
     use pay_kit::mpp::{
         PaymentCredential, SessionMode, format_authorization, parse_www_authenticate,
     };
     use pay_types::metering::ApiSpec;
+    use std::str::FromStr;
     use std::sync::Arc;
 
     // ── App state ──────────────────────────────────────────────────────────
@@ -595,13 +599,84 @@ async fn push_session_full_flow() {
     )
     .await;
 
-    // Channel ID is any valid Solana pubkey (would be the real Fiber channel
-    // in production; here it's just a key for the in-memory store).
-    let channel_id = Keypair::new().pubkey();
+    // Surfpool does not load the payment-channels program for this middleware
+    // integration test, so install the account state that a confirmed open
+    // would have created. The server now requires both the confirmed open
+    // signature and the channel account before it creates session state.
+    let deposit = 1_000_000u64; // 1 USDC
+    let mint = solana_pubkey::Pubkey::from_str(pay_kit::mpp::mints::USDC_MAINNET).unwrap();
+    let token_program =
+        solana_pubkey::Pubkey::from_str(pay_kit::mpp::programs::TOKEN_PROGRAM).unwrap();
+    let salt = 42;
+    let open_slot = pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient::new(rpc_url.clone())
+        .get_slot()
+        .unwrap();
+    let grace_period = 900;
+    let program_id = pay_kit::mpp::program::payment_channels::default_program_id();
+    let open_params = pay_kit::mpp::program::payment_channels::OpenChannelParams {
+        payer: client_kp.pubkey(),
+        rent_payer: operator.pubkey(),
+        payee: recipient.pubkey(),
+        mint,
+        authorized_signer: session_kp.pubkey(),
+        salt,
+        open_slot,
+        deposit,
+        grace_period,
+        recipients: vec![],
+        token_program,
+        program_id,
+    };
+    let channel_id =
+        pay_kit::mpp::program::payment_channels::derive_channel_addresses(&open_params).channel;
+    let (_, bump) = pay_kit::mpp::program::payment_channels::find_channel_pda(
+        &open_params.payer,
+        &open_params.payee,
+        &open_params.mint,
+        &open_params.authorized_signer,
+        open_params.salt,
+        open_params.open_slot,
+        &open_params.program_id,
+    );
+    let channel = Channel {
+        discriminator: 1,
+        version: 1,
+        bump,
+        status: 0,
+        salt,
+        deposit,
+        settlement: SettlementWatermarks {
+            settled: 0,
+            payout_watermark: 0,
+        },
+        closure_started_at: 0,
+        payer_withdrawn_at: 0,
+        grace_period,
+        distribution_hash: [0; 32],
+        payer: client_kp.pubkey(),
+        payee: recipient.pubkey(),
+        authorized_signer: session_kp.pubkey(),
+        mint,
+        rent_payer: operator.pubkey(),
+        open_slot,
+    };
+    let channel_data = borsh::to_vec(&channel).unwrap();
+    surfnet
+        .cheatcodes()
+        .set_account(&channel_id, 1_000_000, &channel_data, &program_id)
+        .unwrap();
     let mut active = ActiveSession::new(channel_id, session_signer);
 
-    let deposit = 1_000_000u64; // 1 USDC
-    let open_action = active.open_action(deposit, &open_tx_sig);
+    let open_action = active.open_payment_channel_action(
+        deposit,
+        &client_kp.pubkey().to_string(),
+        &recipient.pubkey().to_string(),
+        &mint.to_string(),
+        salt,
+        grace_period,
+        open_slot,
+        &open_tx_sig,
+    );
     let auth =
         format_authorization(&PaymentCredential::new(challenge.to_echo(), open_action)).unwrap();
 
@@ -613,12 +688,16 @@ async fn push_session_full_flow() {
         .send()
         .await
         .unwrap();
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
     assert_eq!(
-        resp.status(),
-        402,
+        status, 402,
         "open should acknowledge with 402, got {}: {}",
-        resp.status(),
-        resp.text().await.unwrap()
+        status, body
+    );
+    assert!(
+        body.contains("session_voucher_required"),
+        "open should request the first voucher, got: {body}"
     );
 
     // ── Step 3: Voucher (subsequent API call) ──────────────────────────────

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -45,6 +45,28 @@ pub enum PaymentLimit {
     AboveUsd50,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaymentAmountKind {
+    Exact,
+    Maximum,
+}
+
+impl PaymentAmountKind {
+    const fn headline(self) -> &'static str {
+        match self {
+            Self::Exact => "authorize a payment.",
+            Self::Maximum => "authorize a series of payments.",
+        }
+    }
+
+    const fn field_label(self) -> &'static str {
+        match self {
+            Self::Exact => "amount",
+            Self::Maximum => "up to",
+        }
+    }
+}
+
 impl PaymentLimit {
     const BUCKETS: &[(u64, Self)] = &[
         (1, Self::Usd00001),
@@ -127,20 +149,13 @@ impl AuthIntent {
     }
 
     pub fn authorize_payment_details(amount: &str, reason: &str, operator: &str) -> Self {
-        let mut message = format!("authorize a payment of {amount}.");
-        message.push_str("\n\nreason: ");
-        message.push_str(&truncate_detail(&prompt_detail(reason), 64));
-        // Skip the "operator: ..." line when we don't have a meaningful
-        // domain (e.g. localhost/loopback requests where the prompt would
-        // render the placeholder "unknown" or an empty value). Keeps the
-        // Touch ID panel tight instead of advertising a blank field.
-        if let Some(label) = meaningful_operator(operator) {
-            message.push_str("\n\noperator: ");
-            message.push_str(&label);
-        }
-
         Self::AuthorizePayment {
-            message,
+            message: payment_authorization_message(
+                PaymentAmountKind::Exact,
+                amount,
+                Some(reason),
+                operator,
+            ),
             limit: PaymentLimit::from_amount(amount),
         }
     }
@@ -190,11 +205,14 @@ impl AuthIntent {
         Self::OpenSession("authorize opening a pay session".to_string())
     }
 
-    pub fn authorize_spend_up_to(amount: Option<&str>, limit: &str, url: &str) -> Self {
-        let limit = truncate_detail(&prompt_detail(limit), 48);
-        let url = truncate_detail(&prompt_detail(url), 128);
+    pub fn authorize_spend_up_to(amount: Option<&str>, limit: &str, operator: &str) -> Self {
         Self::AuthorizePayment {
-            message: format!("allow pay to spend up to {limit} on requests to {url}"),
+            message: payment_authorization_message(
+                PaymentAmountKind::Maximum,
+                limit,
+                None,
+                operator,
+            ),
             limit: amount.and_then(PaymentLimit::from_amount),
         }
     }
@@ -318,8 +336,37 @@ fn truncate_detail(value: &str, max_chars: usize) -> String {
     }
 }
 
+fn payment_authorization_message(
+    amount_kind: PaymentAmountKind,
+    amount: &str,
+    reason: Option<&str>,
+    operator: &str,
+) -> String {
+    let mut message = amount_kind.headline().to_string();
+    message.push_str("\n\n");
+    message.push_str(amount_kind.field_label());
+    message.push_str(": ");
+    message.push_str(&truncate_detail(&prompt_detail(amount), 48));
+
+    if let Some(reason) = reason {
+        message.push_str("\n\nreason: ");
+        message.push_str(&truncate_detail(&prompt_detail(reason), 64));
+    }
+
+    if let Some(label) = meaningful_operator(operator) {
+        message.push_str("\n\noperator: ");
+        message.push_str(&label);
+    }
+
+    message
+}
+
 fn payment_message_with_account(message: &str, account: &str) -> String {
-    if !message.trim_start().starts_with("authorize a payment of ") {
+    let trimmed = message.trim_start();
+    if !trimmed.starts_with("authorize a payment of ")
+        && !trimmed.starts_with("authorize a payment.")
+        && !trimmed.starts_with("authorize a series of payments.")
+    {
         return message.to_string();
     }
 
@@ -444,15 +491,29 @@ mod tests {
     }
 
     #[test]
-    fn session_prompt_names_spending_limit_and_url() {
+    fn session_prompt_names_spending_limit_and_operator() {
         assert_eq!(
             AuthIntent::authorize_spend_up_to(
                 Some("$1.00"),
                 "$1.00 USD (1 USDC)",
-                "https://modelstudio.alibaba.gateway-402.com",
+                "modelstudio.alibaba.gateway-402.com",
             )
             .prompt_message(),
-            "allow pay to spend up to $1.00 USD (1 USDC) on requests to https://modelstudio.alibaba.gateway-402.com"
+            "authorize a series of payments.\n\nup to: $1.00 USD (1 USDC)\n\noperator: modelstudio.alibaba.gateway-402.com"
+        );
+    }
+
+    #[test]
+    fn session_prompt_includes_account_on_first_sentence() {
+        assert_eq!(
+            AuthIntent::authorize_spend_up_to(
+                Some("$1.00"),
+                "$1.00 USD (1 USDC)",
+                "modelstudio.alibaba.gateway-402.com",
+            )
+            .with_account_context("default")
+            .prompt_message(),
+            "authorize a series of payments from default.\n\nup to: $1.00 USD (1 USDC)\n\noperator: modelstudio.alibaba.gateway-402.com"
         );
     }
 
@@ -461,7 +522,7 @@ mod tests {
         assert_eq!(
             AuthIntent::authorize_payment_details("$1.00", "Run a SQL query", "gateway-402.com")
                 .prompt_message(),
-            "authorize a payment of $1.00.\n\nreason: Run a SQL query\n\noperator: gateway-402.com"
+            "authorize a payment.\n\namount: $1.00\n\nreason: Run a SQL query\n\noperator: gateway-402.com"
         );
     }
 
@@ -471,7 +532,7 @@ mod tests {
             AuthIntent::authorize_payment_details("$0.30", "Send USDC", "gateway-402.com")
                 .with_account_context("test")
                 .prompt_message(),
-            "authorize a payment of $0.30 from test.\n\nreason: Send USDC\n\noperator: gateway-402.com"
+            "authorize a payment from test.\n\namount: $0.30\n\nreason: Send USDC\n\noperator: gateway-402.com"
         );
     }
 
@@ -484,7 +545,7 @@ mod tests {
                 .prompt_message();
 
         assert!(message.starts_with(
-            "authorize a payment of $0.30 from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
+            "authorize a payment from aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
         ));
     }
 
@@ -506,7 +567,7 @@ mod tests {
 
         assert_eq!(
             message,
-            "authorize a payment of $1.00.\n\nreason: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\noperator: gateway-402.com"
+            "authorize a payment.\n\namount: $1.00\n\nreason: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n\noperator: gateway-402.com"
         );
         assert_eq!(
             message
@@ -629,7 +690,7 @@ mod tests {
             AuthIntent::authorize_spend_up_to(
                 Some("$1.00"),
                 "$1.00 USD (1 USDC)",
-                "https://api.example.com",
+                "api.example.com",
             )
             .payment_limit(),
             Some(PaymentLimit::Usd1)

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -190,6 +190,15 @@ impl AuthIntent {
         Self::OpenSession("authorize opening a pay session".to_string())
     }
 
+    pub fn authorize_spend_up_to(amount: Option<&str>, limit: &str, url: &str) -> Self {
+        let limit = truncate_detail(&prompt_detail(limit), 48);
+        let url = truncate_detail(&prompt_detail(url), 128);
+        Self::AuthorizePayment {
+            message: format!("allow pay to spend up to {limit} on requests to {url}"),
+            limit: amount.and_then(PaymentLimit::from_amount),
+        }
+    }
+
     pub fn use_gateway_fee_payer() -> Self {
         Self::UseGatewayFeePayer("use your pay account as the gateway fee payer".to_string())
     }
@@ -435,6 +444,19 @@ mod tests {
     }
 
     #[test]
+    fn session_prompt_names_spending_limit_and_url() {
+        assert_eq!(
+            AuthIntent::authorize_spend_up_to(
+                Some("$1.00"),
+                "$1.00 USD (1 USDC)",
+                "https://modelstudio.alibaba.gateway-402.com",
+            )
+            .prompt_message(),
+            "allow pay to spend up to $1.00 USD (1 USDC) on requests to https://modelstudio.alibaba.gateway-402.com"
+        );
+    }
+
+    #[test]
     fn payment_details_render_touch_id_context() {
         assert_eq!(
             AuthIntent::authorize_payment_details("$1.00", "Run a SQL query", "gateway-402.com")
@@ -598,6 +620,19 @@ mod tests {
             AuthIntent::from_reason("authorize payment of $0.0501 for accessing API")
                 .payment_limit(),
             Some(PaymentLimit::Usd01)
+        );
+    }
+
+    #[test]
+    fn session_budget_uses_existing_payment_limit_bucket() {
+        assert_eq!(
+            AuthIntent::authorize_spend_up_to(
+                Some("$1.00"),
+                "$1.00 USD (1 USDC)",
+                "https://api.example.com",
+            )
+            .payment_limit(),
+            Some(PaymentLimit::Usd1)
         );
     }
 

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -62,7 +62,7 @@ impl PaymentAmountKind {
     const fn field_label(self) -> &'static str {
         match self {
             Self::Exact => "amount",
-            Self::Maximum => "up to",
+            Self::Maximum => "total allowance",
         }
     }
 }
@@ -499,7 +499,7 @@ mod tests {
                 "modelstudio.alibaba.gateway-402.com",
             )
             .prompt_message(),
-            "authorize a series of payments.\n\nup to: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
+            "authorize a series of payments.\n\ntotal allowance: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
         );
     }
 
@@ -513,7 +513,7 @@ mod tests {
             )
             .with_account_context("default")
             .prompt_message(),
-            "authorize a series of payments from default.\n\nup to: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
+            "authorize a series of payments from default.\n\ntotal allowance: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
         );
     }
 

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -495,11 +495,11 @@ mod tests {
         assert_eq!(
             AuthIntent::authorize_spend_up_to(
                 Some("$1.00"),
-                "$1.00 USD (1 USDC)",
+                "$1.00",
                 "modelstudio.alibaba.gateway-402.com",
             )
             .prompt_message(),
-            "authorize a series of payments.\n\nup to: $1.00 USD (1 USDC)\n\noperator: modelstudio.alibaba.gateway-402.com"
+            "authorize a series of payments.\n\nup to: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
         );
     }
 
@@ -508,12 +508,12 @@ mod tests {
         assert_eq!(
             AuthIntent::authorize_spend_up_to(
                 Some("$1.00"),
-                "$1.00 USD (1 USDC)",
+                "$1.00",
                 "modelstudio.alibaba.gateway-402.com",
             )
             .with_account_context("default")
             .prompt_message(),
-            "authorize a series of payments from default.\n\nup to: $1.00 USD (1 USDC)\n\noperator: modelstudio.alibaba.gateway-402.com"
+            "authorize a series of payments from default.\n\nup to: $1.00\n\noperator: modelstudio.alibaba.gateway-402.com"
         );
     }
 
@@ -687,12 +687,8 @@ mod tests {
     #[test]
     fn session_budget_uses_existing_payment_limit_bucket() {
         assert_eq!(
-            AuthIntent::authorize_spend_up_to(
-                Some("$1.00"),
-                "$1.00 USD (1 USDC)",
-                "api.example.com",
-            )
-            .payment_limit(),
+            AuthIntent::authorize_spend_up_to(Some("$1.00"), "$1.00", "api.example.com",)
+                .payment_limit(),
             Some(PaymentLimit::Usd1)
         );
     }

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -688,7 +688,7 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                         telemetry: u.telemetry,
                     }
                 });
-                ctx.session = session_forward;
+                ctx.session = session_forward.map(|pending| *pending);
                 // Delegated sessions always settle before releasing a
                 // successful response, including fixed-price endpoints. x402
                 // `upto` only needs this path when pricing consumes response

--- a/rust/crates/proxy/src/http402.rs
+++ b/rust/crates/proxy/src/http402.rs
@@ -28,13 +28,15 @@ use futures_util::StreamExt;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use pay_core::PaymentState;
 use pay_core::server::gate::{
-    GateDecision, GateRequest, GateResponse, PaymentGate, ReceiptAnnotation, SessionForward,
+    GateDecision, GateRequest, GateResponse, PaidRequestTelemetry, PaymentGate, ReceiptAnnotation,
+    SessionForward, UptoPaymentTelemetry,
     settle_delegated_session as settle_delegated_session_forward, settle_upto, settle_upto_metered,
 };
 use pay_core::server::metering::{self, UptoSettlementPlan};
 use pay_core::server::proxy::{
     STRIP_HEADERS, UpstreamPlan, prepare_upstream, routing_signs_request_body,
 };
+use pay_core::server::telemetry;
 use pay_kit::x402::server::VerifiedUptoOpen;
 use pay_types::metering::ApiSpec;
 use pingora::http::{RequestHeader, ResponseHeader};
@@ -53,6 +55,8 @@ enum Target {
         sni: String,
         host_header: String,
         path_and_query: String,
+        subdomain: String,
+        upstream: String,
         /// Forwarded client headers (minus stripped) + injected auth headers.
         headers: Vec<(String, String)>,
     },
@@ -72,6 +76,9 @@ pub struct Ctx {
     /// rated with the same usage pipeline as x402 `upto`, then the gateway
     /// signs and persists the cumulative voucher before returning the body.
     session: Option<SessionForward>,
+    /// Present only for payment-backed forwards. Consumed by `logging`, where
+    /// Pingora exposes the final downstream status for every forwarding path.
+    paid_request: Option<PaidRequestTelemetry>,
     /// Captured at `request_filter` for the Payment Debugger exchange emitted
     /// in `logging` (the data plane is Pingora, so the old axum logging
     /// middleware never sees proxied traffic).
@@ -95,6 +102,7 @@ struct PendingUpto {
     open: VerifiedUptoOpen,
     settle_amount: u64,
     settlement: Option<UptoSettlementPlan>,
+    telemetry: UptoPaymentTelemetry,
 }
 
 /// Request-side facts captured up front for the PDB exchange.
@@ -195,7 +203,7 @@ impl<S: PaymentState> Http402Gate<S> {
         // No body-signing auth → an empty placeholder body is safe for prep.
         match prepare_upstream(api, method, uri, headers, &[]).await {
             Ok(UpstreamPlan::Forward(prepared)) => {
-                ctx.target = Some(target_from_prepared(prepared));
+                ctx.target = Some(target_from_prepared(prepared, api.subdomain.clone()));
                 Ok(false)
             }
             Ok(UpstreamPlan::Respond(resp)) => {
@@ -298,10 +306,20 @@ impl<S: PaymentState> Http402Gate<S> {
                     served_ok,
                     response_headers,
                     response_body,
+                    pending.telemetry,
                 )
                 .await
             }
-            None => settle_upto(&self.state, pending.open, pending.settle_amount, served_ok).await,
+            None => {
+                settle_upto(
+                    &self.state,
+                    pending.open,
+                    pending.settle_amount,
+                    served_ok,
+                    pending.telemetry,
+                )
+                .await
+            }
         }
     }
 
@@ -389,6 +407,12 @@ impl<S: PaymentState> Http402Gate<S> {
         let upstream = match upstream_req.send().await {
             Ok(resp) => resp,
             Err(e) => {
+                telemetry::record_upstream_error(
+                    &api.subdomain,
+                    uri.path(),
+                    prepared.url.as_str(),
+                    &e.to_string(),
+                );
                 tracing::error!(error = %e, upstream = %prepared.url, "buffered upstream request failed");
                 let extra = self.drain_payment_headers(ctx, false).await;
                 write_buffered_response(
@@ -405,10 +429,24 @@ impl<S: PaymentState> Http402Gate<S> {
 
         let status = StatusCode::from_u16(upstream.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        if status.is_server_error() {
+            telemetry::record_upstream_error(
+                &api.subdomain,
+                uri.path(),
+                prepared.url.as_str(),
+                &format!("upstream returned {status}"),
+            );
+        }
         let response_headers = filtered_response_headers(upstream.headers());
         let body = match collect_reqwest_body(upstream, response_limit).await {
             Ok(body) => body,
             Err(e) => {
+                telemetry::record_upstream_error(
+                    &api.subdomain,
+                    uri.path(),
+                    prepared.url.as_str(),
+                    &e.to_string(),
+                );
                 tracing::warn!(error = %e, "failed to buffer response-metered body");
                 let extra = self.drain_payment_headers(ctx, false).await;
                 write_buffered_response(
@@ -554,6 +592,7 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
             receipt: None,
             upto: None,
             session: None,
+            paid_request: None,
             log: None,
             observer: None,
             buffered_usage: None,
@@ -634,8 +673,10 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                 session: session_forward,
                 receipt,
                 upto,
+                paid_request,
             } => {
                 ctx.receipt = receipt;
+                ctx.paid_request = paid_request;
                 // x402 `upto`: the channel is open; hold it for post-response
                 // settlement (response_filter on success, logging on failure).
                 ctx.upto = upto.map(|u| {
@@ -644,6 +685,7 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                         open: *u.open,
                         settle_amount: u.settle_amount,
                         settlement: u.settlement,
+                        telemetry: u.telemetry,
                     }
                 });
                 ctx.session = session_forward;
@@ -765,6 +807,21 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
         upstream_response: &mut ResponseHeader,
         ctx: &mut Ctx,
     ) -> pingora::Result<()> {
+        if upstream_response.status.is_server_error()
+            && let Some(Target::Api {
+                subdomain,
+                upstream,
+                ..
+            }) = &ctx.target
+        {
+            let path = ctx.log.as_ref().map_or("", |log| log.path.as_str());
+            telemetry::record_upstream_error(
+                subdomain,
+                path,
+                upstream,
+                &format!("upstream returned {}", upstream_response.status),
+            );
+        }
         if let Some(receipt) = &ctx.receipt {
             for (name, value) in &receipt.headers {
                 // Pass the HeaderValue through unchanged (a receipt can carry
@@ -844,7 +901,7 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
     /// plane, so the old axum `logging_middleware` never sees proxied traffic —
     /// this is what keeps PDB populated. Fires for every request (short-circuit
     /// 402s included); control-plane paths were filtered out at capture time.
-    async fn logging(&self, session: &mut Session, _e: Option<&pingora::Error>, ctx: &mut Ctx)
+    async fn logging(&self, session: &mut Session, error: Option<&pingora::Error>, ctx: &mut Ctx)
     where
         Self::CTX: Send + Sync,
     {
@@ -864,6 +921,26 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                 .await
         {
             deferred_payment_headers.push(header);
+        }
+        if let Some(paid_request) = ctx.paid_request.take() {
+            let status = session
+                .response_written()
+                .and_then(|response| StatusCode::from_u16(response.status.as_u16()).ok())
+                .unwrap_or_else(|| {
+                    if error.is_some() {
+                        StatusCode::BAD_GATEWAY
+                    } else {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                });
+            let path = ctx.log.as_ref().map_or("", |log| log.path.as_str());
+            telemetry::record_paid_request_completed(
+                paid_request.protocol,
+                &paid_request.subdomain,
+                path,
+                status,
+                paid_request.payment.as_ref(),
+            );
         }
         let Some(log) = ctx.log.take() else {
             return;
@@ -937,6 +1014,16 @@ impl<S: PaymentState> ProxyHttp for Http402Gate<S> {
                 pingora::ErrorSource::Internal | pingora::ErrorSource::Unset => 500,
             },
         };
+        if code >= 500
+            && let Some(Target::Api {
+                subdomain,
+                upstream,
+                ..
+            }) = &ctx.target
+        {
+            let path = ctx.log.as_ref().map_or("", |log| log.path.as_str());
+            telemetry::record_upstream_error(subdomain, path, upstream, &e.to_string());
+        }
 
         if code > 0 {
             if extra.is_empty() {
@@ -1011,8 +1098,12 @@ fn is_control_plane(path: &str) -> bool {
 }
 
 /// Split a prepared upstream request into a connectable [`Target::Api`].
-fn target_from_prepared(prepared: pay_core::server::proxy::PreparedUpstreamRequest) -> Target {
+fn target_from_prepared(
+    prepared: pay_core::server::proxy::PreparedUpstreamRequest,
+    subdomain: String,
+) -> Target {
     let url = prepared.url;
+    let upstream = url.to_string();
     let tls = url.scheme() == "https";
     let host = url.host_str().unwrap_or("").to_string();
     let port = url
@@ -1034,6 +1125,8 @@ fn target_from_prepared(prepared: pay_core::server::proxy::PreparedUpstreamReque
         sni: host,
         host_header,
         path_and_query,
+        subdomain,
+        upstream,
         headers: prepared.headers,
     }
 }

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -866,6 +866,12 @@ pub struct SessionSpec {
     /// Defaults to `15000` when omitted. Set to `0` to disable automatic close.
     #[serde(default = "default_session_close_delay_ms")]
     pub close_delay_ms: u64,
+    /// Boundary used to group idle channel closes into settlement batches.
+    ///
+    /// The close deadline is rounded up to the next boundary. Defaults to
+    /// `60000` (one minute). Must be non-zero when automatic close is enabled.
+    #[serde(default = "default_session_close_batch_interval_ms")]
+    pub close_batch_interval_ms: u64,
     /// Interval between operator pushes of the latest accepted cumulative
     /// watermark to the payment-channel program.
     ///
@@ -896,6 +902,10 @@ fn default_session_batch_open_interval_ms() -> u64 {
 
 fn default_session_close_delay_ms() -> u64 {
     15_000
+}
+
+fn default_session_close_batch_interval_ms() -> u64 {
+    60_000
 }
 
 fn default_session_settlement_interval_ms() -> u64 {
@@ -1642,6 +1652,15 @@ pub fn validate_api_spec(spec: &ApiSpec) -> Vec<String> {
     // Channel distribution splits from a top-level `session:` block.
     if let Some(session) = &spec.session {
         validate_session_splits(session, &spec.recipients, &mut errs);
+        if session.close_delay_ms > 0
+            && (session.close_batch_interval_ms < 60_000
+                || session.close_batch_interval_ms % 60_000 != 0)
+        {
+            errs.push(
+                "session.close_batch_interval_ms must be a whole number of minutes when automatic close is enabled"
+                    .to_string(),
+            );
+        }
     }
 
     errs
@@ -2535,11 +2554,31 @@ mod tests {
 
         assert_eq!(session.batch_open_interval_ms, 400);
         assert_eq!(session.close_delay_ms, 15_000);
+        assert_eq!(session.close_batch_interval_ms, 60_000);
         assert_eq!(session.settlement_interval_ms, 5_000);
         assert_eq!(
             session.settlement_authority,
             SessionSettlementAuthority::ClientVoucher
         );
+    }
+
+    #[test]
+    fn validate_session_close_batch_interval_uses_whole_minutes() {
+        let mut spec = test_spec(vec![]);
+        let mut session: SessionSpec = serde_json::from_str(r#"{"cap_usdc":10.0}"#).unwrap();
+        session.close_batch_interval_ms = 15_000;
+        spec.session = Some(session);
+
+        let errors = validate_api_spec(&spec);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("whole number of minutes")),
+            "got: {errors:?}"
+        );
+
+        spec.session.as_mut().unwrap().close_batch_interval_ms = 120_000;
+        assert!(validate_api_spec(&spec).is_empty());
     }
 
     #[test]
@@ -3739,6 +3778,7 @@ value_from_env: PAY_SIGNER_KEYPAIR
             pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
             batch_open_interval_ms: 400,
             close_delay_ms: 15_000,
+            close_batch_interval_ms: 60_000,
             settlement_interval_ms: 5_000,
             splits: vec![],
         });
@@ -3905,6 +3945,7 @@ value_from_env: PAY_SIGNER_KEYPAIR
             pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
             batch_open_interval_ms: 400,
             close_delay_ms: 15_000,
+            close_batch_interval_ms: 60_000,
             settlement_interval_ms: 5_000,
             splits,
         });

--- a/rust/xtream-gate.yaml
+++ b/rust/xtream-gate.yaml
@@ -1,0 +1,136 @@
+# Xtream IPTV gate — stablecoin-gate an existing Xtream-Codes panel.
+# =============================================================================
+# Puts a pay 402 gate in front of an Xtream panel so clients pay in USDC to
+# browse and resolve streams. The panel password is injected server-side from
+# $XT_PASS and never appears in this file.
+#
+# Sandbox test (no real funds):
+#   XT_PASS=... cargo run -p pay -- --sandbox server start xtream-gate.yaml
+#   cargo run -p pay -- --sandbox curl \
+#     "http://127.0.0.1:1402/player_api.php?username=<PANEL_USER>&action=get_live_categories"
+#
+# Verified against pay 0.22.0. Notes on the design choices below.
+#
+# ── How Xtream carries credentials (and how we inject them) ──────────────────
+# Xtream puts username+password in EVERY request, two different ways:
+#   • player_api.php?username=U&password=P&action=…   (query params)
+#   • /live|movie|series/U/P/ID.ext                    (path segments)
+# The client sends the username (not the secret — it is echoed everywhere) and
+# a throwaway password; the gate supplies the real password from $XT_PASS.
+#
+#   - Query: `auth: query_param` appends `password=$XT_PASS`. Standard XUI/PHP
+#     panels take the LAST value when a param repeats, so the injected one wins
+#     over the client's throwaway. (If your panel doesn't, have the client omit
+#     the password entirely — televisor "gateway account" mode.)
+#   - Path: a single path_rewrite forces all its {placeholders} to one env
+#     value, so we anchor on the KNOWN, STATIC username as a literal and rewrite
+#     only the password segment.
+#
+# ── Security reality (read before relying on this) ───────────────────────────
+# This is a FORWARD proxy: it does not rewrite response bodies or upstream
+# redirects. So a determined *paying* client can still recover the panel
+# password, because Xtream leaks it back:
+#   1. player_api.php with NO action returns `user_info` echoing the password.
+#      → Don't rely on the gate to hide it; either accept that payers can read
+#        it, or run per-customer sub-accounts (see below).
+#   2. Catch-up (`/timeshift/U/P/…`) 302-redirects to a URL whose PATH contains
+#      the raw credentials. Live/VOD/series redirect to an OPAQUE media token
+#      (safe). This spec therefore does NOT expose /timeshift.
+# If you need payers to be UNABLE to extract the credential, don't proxy one
+# shared account — mint a short-lived per-customer panel account on payment
+# (Mother-of-all fix; needs your panel's reseller API). This spec is the
+# pragmatic "monetize access to my deal" option, not a DRM boundary.
+
+name: xtream-gate
+subdomain: "acme-tv" # → acme-tv.pay.sh
+title: "ACME TV"
+description: "Stablecoin-gated access to an Xtream IPTV panel."
+category: media
+version: v1
+
+profile:
+  type: xtream-codes
+  version: v1
+
+routing:
+  type: proxy
+  url: "http://panel.example.com:8080/" # your panel origin
+  path_rewrites:
+    # Anchor on your real (static) panel username; inject only the password.
+    - prefix: "live/71e138bb92f1/{pass}"
+      env: XT_PASS
+    - prefix: "movie/71e138bb92f1/{pass}"
+      env: XT_PASS
+    - prefix: "series/71e138bb92f1/{pass}"
+      env: XT_PASS
+  auth:
+    method: query_param
+    key: "password"
+    value_from_env: XT_PASS
+
+operator:
+  currencies:
+    usd: ["USDC"]
+  network: mainnet # use localnet under --sandbox first
+  fee_payer: true
+  recipient: "<YOUR_REVENUE_WALLET_B58>"
+  # For a long-running server, pin the settlement signer instead of relying on
+  # ~/.config/pay/accounts.yml:
+  # signer: { backend: file, path: /etc/pay/keypair.json }
+
+endpoints:
+  # Metadata: cheap per call. get_* actions do NOT echo the password.
+  - method: GET
+    path: "player_api.php"
+    resource: "api"
+    description: "Xtream JSON API (categories, streams, VOD, series, EPG)."
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.001
+
+  # Stream resolution: one payment resolves one playable (opaque) media URL,
+  # which the client then streams directly (video bypasses this gate).
+  - method: GET
+    path: "live/{username}/{password}/{stream}"
+    resource: "stream"
+    description: "Resolve a live channel."
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.05
+  - method: GET
+    path: "movie/{username}/{password}/{stream}"
+    resource: "stream"
+    description: "Resolve a movie (VOD)."
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.05
+  - method: GET
+    path: "series/{username}/{password}/{episode}"
+    resource: "stream"
+    description: "Resolve a series episode."
+    metering:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.05
+
+  # Flat monthly pass instead of per-request: replace an endpoint's `metering`
+  # block with this.
+  #   subscription:
+  #     period: "30d"
+  #     price_usd: 6.00
+  #     currency: USDC

--- a/typescript/packages/solana-pay/core/package.json
+++ b/typescript/packages/solana-pay/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "1.0.24",
+    "version": "1.0.25",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-foundation/pay",
     "license": "MIT",


### PR DESCRIPTION
## Summary

- restore Windows release builds, add a Windows CLI compile check, and update release versions
- preserve authentication gates for file-backed server accounts and describe session authorization using the funded stablecoin limit and provider origin
- emit reliable payment, collection, settlement, delivery, upstream, and channel lifecycle metrics with bounded protocol labels such as `x402/exact`, `x402/upto`, `mpp/charge`, and `mpp/session`
- move the session idle-close clock from horizontally scaled proxies into the durable `ChannelStore`, with one-minute rounded deadlines for worker-side batching
- pin the reviewed PayKit lifecycle store implementation from solana-foundation/pay-kit#256

## Test Plan

- `cargo fmt --check`
- `cargo check -p pay -p pay-proxy --all-targets`
- `cargo test -p pay-proxy`
- GitHub Actions: Windows Rust check, Rust lint/tests, and TypeScript lint/tests

