### PR TITLE
fix(cli): preserve auth gates and clarify session spend

### DIFF
--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -243,7 +243,9 @@ impl Command {
             }
             Command::Setup(cmd) => return cmd.run(),
             Command::Topup(cmd) => return cmd.run(),
-            Command::Server { command } => return command.run(keypair_override, sandbox),
+            Command::Server { command } => {
+                return command.run(keypair_override, account_override, sandbox);
+            }
             Command::Mcp => {
                 let rt = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -572,6 +574,7 @@ fn handle_outcome(
                 return pay_session_and_retry(
                     &challenge,
                     req.as_ref(),
+                    &resource_url,
                     tool,
                     output_fmt,
                     fetch_headers,
@@ -1672,6 +1675,7 @@ fn pay_x402_siwx_and_retry(
 fn pay_session_and_retry(
     challenge: &mpp::Challenge,
     req: Option<&SessionRequest>,
+    resource_url: &str,
     tool: &Tool,
     output_fmt: Option<OutputFormat>,
     fetch_headers: Option<Vec<(String, String)>>,
@@ -1742,6 +1746,7 @@ fn pay_session_and_retry(
                         account_override,
                         deposit,
                         SessionMode::Pull,
+                        resource_url,
                         sandbox,
                     )?;
                 header
@@ -1769,6 +1774,7 @@ fn pay_session_and_retry(
                 network_override,
                 account_override,
                 deposit,
+                resource_url,
                 sandbox,
             )?;
             header

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -113,6 +113,8 @@ pub struct PayerUpstream {
 struct PayerState {
     /// Upstream base URL without a trailing slash.
     upstream: String,
+    /// Logical provider URL shown in session spending authorization.
+    authorization_url: String,
     host_header: Option<HeaderValue>,
     dialect: Dialect,
     /// Chat-completions path without a leading slash (translation target).
@@ -152,6 +154,12 @@ impl PayerState {
             .map(HeaderValue::from_str)
             .transpose()
             .map_err(|e| pay_core::Error::Config(format!("payer proxy Host header: {e}")))?;
+        let parsed_upstream = reqwest::Url::parse(&upstream.base_url)
+            .map_err(|e| pay_core::Error::Config(format!("payer proxy upstream URL: {e}")))?;
+        let authorization_url = match upstream.host_header.as_deref() {
+            Some(host) => format!("{}://{host}", parsed_upstream.scheme()),
+            None => upstream.base_url.clone(),
+        };
         // Do not impose a total request timeout: streamed completions may stay
         // open for minutes. Bound connection setup and silent read stalls so a
         // hung provider cannot retain the session mutex forever.
@@ -164,6 +172,7 @@ impl PayerState {
             .map_err(|e| pay_core::Error::Config(format!("payer proxy HTTP client: {e}")))?;
         Ok(Self {
             upstream: upstream.base_url.trim_end_matches('/').to_string(),
+            authorization_url,
             host_header,
             dialect: upstream.dialect,
             chat_path: upstream.chat_path.trim_start_matches('/').to_string(),
@@ -830,6 +839,7 @@ fn build_session_authorization(
         state.network_override.as_deref(),
         state.account_override.as_deref(),
         deposit,
+        &state.authorization_url,
         sandbox,
     )?;
 

--- a/rust/crates/cli/src/commands/server/demo.rs
+++ b/rust/crates/cli/src/commands/server/demo.rs
@@ -32,7 +32,12 @@ pub struct DemoCommand {
 }
 
 impl DemoCommand {
-    pub fn run(self, active_account_name: Option<&str>, _sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        _sandbox: bool,
+    ) -> pay_core::Result<()> {
         // Extract embedded spec to ./pay-demo.yaml in the current directory
         let spec_path = std::path::PathBuf::from("pay-demo.yaml");
         std::fs::write(&spec_path, DEMO_SPEC)
@@ -59,6 +64,6 @@ impl DemoCommand {
             no_register: false,
             scaffolded_spec: Some("./pay-demo.yaml".to_string()),
         };
-        cmd.run(active_account_name, true)
+        cmd.run(legacy_signer_source, account_override, true)
     }
 }

--- a/rust/crates/cli/src/commands/server/inference/mod.rs
+++ b/rust/crates/cli/src/commands/server/inference/mod.rs
@@ -366,7 +366,8 @@ fn usage_to_info(usage: &pay_core::InferenceUsage) -> InferenceInfo {
 impl InferenceCommand {
     pub fn run(
         self,
-        active_account_name: Option<&str>,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
         global_sandbox: bool,
     ) -> pay_core::Result<()> {
         let sandbox = self.sandbox || global_sandbox;
@@ -408,17 +409,23 @@ impl InferenceCommand {
             let signer = if let Some(signer) = state.fee_payer_signer.clone() {
                 signer
             } else {
-                let source = active_account_name.ok_or_else(|| {
+                let intent = pay_core::keystore::AuthIntent::from_reason(
+                    "register your inference service in the pay provider registry",
+                );
+                let network = if sandbox { "localnet" } else { "mainnet" };
+                let signer = super::load_account_or_legacy_signer(
+                    network,
+                    account_override,
+                    legacy_signer_source,
+                    &intent,
+                )?
+                .ok_or_else(|| {
                     pay_core::Error::Config(
                         "provider registration requires an active account; pass --no-register to serve without publishing"
                             .to_string(),
                     )
                 })?;
-                let intent = pay_core::keystore::AuthIntent::from_reason(
-                    "register your inference service in the pay provider registry",
-                );
-                Arc::new(pay_core::signer::load_signer_with_intent(source, &intent)?)
-                    as Arc<dyn SolanaSigner>
+                Arc::new(signer) as Arc<dyn SolanaSigner>
             };
             let registration = super::provider_registration::ServiceRegistration::new(
                 "inference",

--- a/rust/crates/cli/src/commands/server/mod.rs
+++ b/rust/crates/cli/src/commands/server/mod.rs
@@ -46,15 +46,55 @@ impl ServerCommand {
         }
     }
 
-    pub fn run(self, active_account_name: Option<&str>, sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        sandbox: bool,
+    ) -> pay_core::Result<()> {
         match self {
-            Self::Demo(cmd) => cmd.run(active_account_name, sandbox),
-            Self::Start(cmd) => cmd.run(active_account_name, sandbox),
-            Self::Inference(cmd) => cmd.run(active_account_name, sandbox),
+            Self::Demo(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
+            Self::Start(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
+            Self::Inference(cmd) => cmd.run(legacy_signer_source, account_override, sandbox),
             Self::Scaffold(cmd) => cmd.run(),
             Self::Plans { command } => match command {
                 PlansCommand::Publish(cmd) => cmd.run(),
             },
         }
     }
+}
+
+/// Load the account selected for `network` without flattening its auth policy.
+///
+/// Named accounts (`--account`, then `PAY_ACTIVE_ACCOUNT`) and the network's
+/// active account go through the existing account-aware loader. A raw
+/// `pay.toml`/legacy keystore source is used only when no account is selected.
+pub(crate) fn load_account_or_legacy_signer(
+    network: &str,
+    cli_account: Option<&str>,
+    legacy_source: Option<&str>,
+    intent: &pay_core::keystore::AuthIntent,
+) -> pay_core::Result<Option<pay_kit::mpp::solana_keychain::MemorySigner>> {
+    let env_account = std::env::var("PAY_ACTIVE_ACCOUNT")
+        .ok()
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty());
+    let account_override = cli_account.or(env_account.as_deref());
+    let accounts = pay_core::accounts::AccountsFile::load()?;
+    let has_network_account = accounts.account_for_network(network).is_some();
+
+    if account_override.is_some() || has_network_account {
+        let store = pay_core::accounts::FileAccountsStore::default_path();
+        let (signer, _) = pay_core::signer::load_signer_for_network_with_intent(
+            network,
+            &store,
+            account_override,
+            intent,
+        )?;
+        return Ok(Some(signer));
+    }
+
+    legacy_source
+        .map(|source| pay_core::signer::load_signer_with_intent(source, intent))
+        .transpose()
 }

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -578,7 +578,12 @@ fn x402_upto_beneficiary_pubkey(
 }
 
 impl StartCommand {
-    pub fn run(self, active_account_name: Option<&str>, sandbox: bool) -> pay_core::Result<()> {
+    pub fn run(
+        self,
+        legacy_signer_source: Option<&str>,
+        account_override: Option<&str>,
+        sandbox: bool,
+    ) -> pay_core::Result<()> {
         let debugger = self.debugger || sandbox;
         let expanded = shellexpand::tilde(&self.spec);
         let contents = std::fs::read_to_string(expanded.as_ref())
@@ -715,7 +720,8 @@ impl StartCommand {
 
         let fee_payer = op.map(|o| o.fee_payer).unwrap_or(false);
         let signer_cfg = op.and_then(|o| o.signer.clone());
-        let active_account_name_owned = active_account_name.map(|s| s.to_string());
+        let legacy_signer_source = legacy_signer_source.map(str::to_string);
+        let account_override = account_override.map(str::to_string);
 
         // Create the runtime first — everything async runs inside it so
         // background tasks (like GCP auth token refresh) stay alive. Worker
@@ -769,7 +775,12 @@ impl StartCommand {
                 Some(signer)
             } else if let Some(ref cfg) = signer_cfg {
                 Some(resolve_signer(cfg).await?)
-            } else if let Some(ref source) = active_account_name_owned {
+            } else if let Some(signer) = super::load_account_or_legacy_signer(
+                network.slug(),
+                account_override.as_deref(),
+                legacy_signer_source.as_deref(),
+                &pay_core::keystore::AuthIntent::use_gateway_fee_payer(),
+            )? {
                 // Mainnet (or unknown network) with no `operator.signer`
                 // block but a default keypair from `pay setup` —
                 // typically `keychain:default`. Load it once at startup
@@ -777,8 +788,6 @@ impl StartCommand {
                 // tells the user *why* it's being asked. The same
                 // signer is then used as both the fee-payer and the
                 // recipient-pubkey source (no second load).
-                let intent = pay_core::keystore::AuthIntent::use_gateway_fee_payer();
-                let signer = pay_core::signer::load_signer_with_intent(source, &intent)?;
                 Some(Arc::new(signer) as Arc<dyn SolanaSigner>)
             } else {
                 None
@@ -792,7 +801,7 @@ impl StartCommand {
             //   3. PAY_PAYMENT_RECIPIENT env var
             //   4. fee_payer_signer's pubkey — covers sandbox, throwaway-
             //      network smart default, explicit operator.signer block,
-            //      and the active_account_name fallback (all four set
+            //      and the resolved signer fallback (all four set
             //      fee_payer_signer above).
             let recipient = if let Some(r) = op.and_then(|o| o.recipient.as_ref()) {
                 r.clone()

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -227,10 +227,10 @@ fn main() {
         unsafe { std::env::set_var("PAY_PROTOCOL_ENFORCED", "mpp") };
     }
 
-    // ── Legacy keypair source for non-payment commands ─────────────────────
+    // ── Legacy signer fallback for non-payment commands ────────────────────
     //
-    // `pay topup` and server commands still use the original
-    // keystore-source-string flow.
+    // Server commands resolve accounts after reading the spec's network; this
+    // value is only their raw pay.toml/platform-keystore fallback.
     // Launcher commands (`pay claude`/`pay codex`) pass only an explicit
     // `--account` through to the MCP server and must not resolve an account
     // before the first-run setup hook below.
@@ -262,7 +262,9 @@ fn main() {
                 | Command::Mcp
         ) {
         None
-    } else if matches!(command, Command::Server { .. } | Command::Topup(_)) {
+    } else if matches!(command, Command::Server { .. }) {
+        config.legacy_keypair_source()
+    } else if matches!(command, Command::Topup(_)) {
         config.default_active_account_name()
     } else {
         resolve_keypair(&config)

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -265,6 +265,7 @@ pub fn open_session_header(
 ///
 /// The transaction is signed by the payer and fee-payer/cosigned by the server
 /// when it processes the `open` action.
+#[allow(clippy::too_many_arguments)]
 pub fn open_payment_channel_session_header(
     challenge: &PaymentChallenge,
     request: &pay_kit::mpp::SessionRequest,
@@ -272,6 +273,7 @@ pub fn open_payment_channel_session_header(
     network_override: Option<&str>,
     account_override: Option<&str>,
     deposit: u64,
+    resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
     open_payment_channel_session_header_with_mode(
@@ -282,11 +284,12 @@ pub fn open_payment_channel_session_header(
         account_override,
         deposit,
         pay_kit::mpp::SessionMode::Push,
+        resource_url,
         sandbox,
     )
 }
 
-/// Open a payment-channel session with an explicit submission mode.
+/// Open a payment-channel session in `submission_mode`.
 #[allow(clippy::too_many_arguments)]
 pub fn open_payment_channel_session_header_with_mode(
     challenge: &PaymentChallenge,
@@ -296,6 +299,7 @@ pub fn open_payment_channel_session_header_with_mode(
     account_override: Option<&str>,
     deposit: u64,
     submission_mode: pay_kit::mpp::SessionMode,
+    resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
     use pay_kit::mpp::client::{
@@ -315,7 +319,13 @@ pub fn open_payment_channel_session_header_with_mode(
             .clone()
             .unwrap_or_else(|| "mainnet".to_string())
     });
-    let intent = crate::keystore::AuthIntent::open_session();
+    let authorization_origin = canonical_session_origin(resource_url)?;
+    let limit = session_spend_limit(deposit, request);
+    let intent = crate::keystore::AuthIntent::authorize_spend_up_to(
+        limit.usd_amount.as_deref(),
+        &limit.display,
+        &authorization_origin,
+    );
     let (signer, ephemeral_notice) = crate::signer::load_signer_for_network_with_intent(
         &network,
         store,
@@ -440,6 +450,56 @@ pub fn voucher_header_sync(handle: &SessionHandle, amount: u64) -> Result<String
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+pub(crate) fn canonical_session_origin(resource_url: &str) -> Result<String> {
+    let url = reqwest::Url::parse(resource_url)
+        .map_err(|e| Error::Mpp(format!("invalid session authorization URL: {e}")))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+        return Err(Error::Mpp(
+            "session authorization URL must be an absolute HTTP(S) URL".to_string(),
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(Error::Mpp(
+            "session authorization URL must not contain credentials".to_string(),
+        ));
+    }
+    Ok(url.origin().ascii_serialization())
+}
+
+struct SessionSpendLimit {
+    display: String,
+    usd_amount: Option<String>,
+}
+
+fn session_spend_limit(deposit: u64, request: &SessionRequest) -> SessionSpendLimit {
+    let stablecoin = pay_types::Stablecoin::from_mint(&request.currency)
+        .or_else(|| pay_types::Stablecoin::parse_symbol(&request.currency));
+
+    if let Some(stablecoin) = stablecoin {
+        let amount = crate::client::send::format_token_amount(deposit, stablecoin.decimals());
+        let usd = if !amount.contains('.') {
+            format!("{amount}.00")
+        } else if amount
+            .split_once('.')
+            .is_some_and(|(_, fraction)| fraction.len() == 1)
+        {
+            format!("{amount}0")
+        } else {
+            amount.clone()
+        };
+        let usd_amount = format!("${usd}");
+        SessionSpendLimit {
+            display: format!("{usd_amount} USD ({amount} {})", stablecoin.symbol()),
+            usd_amount: Some(usd_amount),
+        }
+    } else {
+        SessionSpendLimit {
+            display: format!("{deposit} base units of {}", request.currency),
+            usd_amount: None,
+        }
+    }
+}
+
 fn build_header(challenge: &PaymentChallenge, action: &SessionAction) -> Result<String> {
     let credential = PaymentCredential::new(challenge.to_echo(), action);
     format_authorization(&credential)
@@ -519,6 +579,68 @@ mod tests {
         let non_session = test_challenge("charge").to_header().unwrap();
         assert!(SessionHandle::parse_challenge(&non_session).is_none());
         assert!(SessionHandle::parse_challenge("not a challenge").is_none());
+    }
+
+    #[test]
+    fn canonical_origin_normalizes_paths_case_and_default_ports() {
+        assert_eq!(
+            canonical_session_origin("HTTPS://Example.COM:443/v1/chat?model=test").unwrap(),
+            "https://example.com"
+        );
+        assert_eq!(
+            canonical_session_origin("http://localhost:1402/v1/chat").unwrap(),
+            "http://localhost:1402"
+        );
+    }
+
+    #[test]
+    fn canonical_origin_rejects_relative_non_http_and_credential_urls() {
+        for invalid in [
+            "/v1/chat",
+            "file:///tmp/provider",
+            "https://user:secret@example.com/v1/chat",
+        ] {
+            assert!(
+                canonical_session_origin(invalid).is_err(),
+                "accepted invalid session URL: {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn spend_limit_names_usd_amount_and_stablecoin() {
+        let mut request = test_request();
+        request.currency = "USDC".to_string();
+        request.decimals = Some(6);
+        let limit = session_spend_limit(1_000_000, &request);
+        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
+    }
+
+    #[test]
+    fn spend_limit_uses_canonical_stablecoin_decimals() {
+        let mut request = test_request();
+        request.currency = "USDC".to_string();
+        request.decimals = Some(18);
+
+        let limit = session_spend_limit(1_000_000, &request);
+
+        assert_eq!(limit.display, "$1.00 USD (1 USDC)");
+        assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
+    }
+
+    #[test]
+    fn spend_limit_does_not_trust_unknown_asset_decimals() {
+        let mut request = test_request();
+        request.decimals = Some(u8::MAX);
+
+        let limit = session_spend_limit(1_000_000, &request);
+
+        assert_eq!(
+            limit.display,
+            format!("1000000 base units of {}", request.currency)
+        );
+        assert_eq!(limit.usd_amount, None);
     }
 
     #[tokio::test]

--- a/rust/crates/core/src/config.rs
+++ b/rust/crates/core/src/config.rs
@@ -94,12 +94,20 @@ impl Config {
             }
         }
 
-        // 3. Config file keypair field
+        self.legacy_keypair_source()
+    }
+
+    /// Resolve only legacy raw signer configuration.
+    ///
+    /// Unlike [`Self::default_active_account_name`], this deliberately skips
+    /// `accounts.yml` and `PAY_ACTIVE_ACCOUNT`; callers that need account
+    /// policy must resolve those names through the network-aware signer path.
+    pub fn legacy_keypair_source(&self) -> Option<String> {
         if let Some(path) = self.keypair_path() {
             return Some(expand_path(path).to_string());
         }
 
-        // 4. Legacy: probe platform-native keystores directly (no
+        // Legacy: probe platform-native keystores directly (no
         // accounts.yml yet). Do not probe 1Password here: `op item get`
         // can show a desktop auth prompt just to answer "does this item
         // exist?", which is surprising for commands like `pay claude` on a

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -190,6 +190,15 @@ impl AuthIntent {
         Self::OpenSession("authorize opening a pay session".to_string())
     }
 
+    pub fn authorize_spend_up_to(amount: Option<&str>, limit: &str, url: &str) -> Self {
+        let limit = truncate_detail(&prompt_detail(limit), 48);
+        let url = truncate_detail(&prompt_detail(url), 128);
+        Self::AuthorizePayment {
+            message: format!("allow pay to spend up to {limit} on requests to {url}"),
+            limit: amount.and_then(PaymentLimit::from_amount),
+        }
+    }
+
     pub fn use_gateway_fee_payer() -> Self {
         Self::UseGatewayFeePayer("use your pay account as the gateway fee payer".to_string())
     }
@@ -435,6 +444,19 @@ mod tests {
     }
 
     #[test]
+    fn session_prompt_names_spending_limit_and_url() {
+        assert_eq!(
+            AuthIntent::authorize_spend_up_to(
+                Some("$1.00"),
+                "$1.00 USD (1 USDC)",
+                "https://modelstudio.alibaba.gateway-402.com",
+            )
+            .prompt_message(),
+            "allow pay to spend up to $1.00 USD (1 USDC) on requests to https://modelstudio.alibaba.gateway-402.com"
+        );
+    }
+
+    #[test]
     fn payment_details_render_touch_id_context() {
         assert_eq!(
             AuthIntent::authorize_payment_details("$1.00", "Run a SQL query", "gateway-402.com")
@@ -598,6 +620,19 @@ mod tests {
             AuthIntent::from_reason("authorize payment of $0.0501 for accessing API")
                 .payment_limit(),
             Some(PaymentLimit::Usd01)
+        );
+    }
+
+    #[test]
+    fn session_budget_uses_existing_payment_limit_bucket() {
+        assert_eq!(
+            AuthIntent::authorize_spend_up_to(
+                Some("$1.00"),
+                "$1.00 USD (1 USDC)",
+                "https://api.example.com",
+            )
+            .payment_limit(),
+            Some(PaymentLimit::Usd1)
         );
     }
 


### PR DESCRIPTION
Resolve server operator accounts through the network-aware loader so file-backed accounts retain their authentication policy while ephemeral accounts remain ungated.\n\nDescribe session authorization with the funded stablecoin limit and provider origin, using trusted decimals and raw base units for unknown assets.