### PR TITLE
fix(session): keep active channels reusable

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=a569ac524872b73cceed373136db362a5d875517#a569ac524872b73cceed373136db362a5d875517"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=3524a11be770824cfa0add1ee35c61d686b06756#3524a11be770824cfa0add1ee35c61d686b06756"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=2d7f605c08c1b32abad99b2e13c0960112d929b9#2d7f605c08c1b32abad99b2e13c0960112d929b9"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=db0babf2098b86fc3c1b2b17c417d24da1dc713c#db0babf2098b86fc3c1b2b17c417d24da1dc713c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=db0babf2098b86fc3c1b2b17c417d24da1dc713c#db0babf2098b86fc3c1b2b17c417d24da1dc713c"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=c07fa269f777f35a9bd9148ee35489250aee2f4a#c07fa269f777f35a9bd9148ee35489250aee2f4a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=c07fa269f777f35a9bd9148ee35489250aee2f4a#c07fa269f777f35a9bd9148ee35489250aee2f4a"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=a569ac524872b73cceed373136db362a5d875517#a569ac524872b73cceed373136db362a5d875517"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10762,8 +10762,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pay-kit"
-version = "0.4.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=3524a11be770824cfa0add1ee35c61d686b06756#3524a11be770824cfa0add1ee35c61d686b06756"
+version = "0.5.0"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=dc3a36ee8ad93bb4dcf6de8f5a03091518a539db#dc3a36ee8ad93bb4dcf6de8f5a03091518a539db"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "db0babf2098b86fc3c1b2b17c417d24da1dc713c", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "c07fa269f777f35a9bd9148ee35489250aee2f4a", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "3524a11be770824cfa0add1ee35c61d686b06756", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "dc3a36ee8ad93bb4dcf6de8f5a03091518a539db", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "a569ac524872b73cceed373136db362a5d875517", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "3524a11be770824cfa0add1ee35c61d686b06756", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "2d7f605c08c1b32abad99b2e13c0960112d929b9", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "db0babf2098b86fc3c1b2b17c417d24da1dc713c", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "c07fa269f777f35a9bd9148ee35489250aee2f4a", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "a569ac524872b73cceed373136db362a5d875517", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/crates/cli/src/commands/agent/mod.rs
+++ b/rust/crates/cli/src/commands/agent/mod.rs
@@ -1287,7 +1287,11 @@ mod tests {
 
                 assert_eq!(providers.len(), 1);
                 assert_eq!(providers[0].slug(), "acme-inference");
-                assert_eq!(providers[0].models, ["acme-large", "acme-small"]);
+                assert_eq!(
+                    providers[0].models,
+                    ["acme-large"],
+                    "live models without a configured pricing variant must not be offered"
+                );
                 assert_eq!(
                     providers[0]
                         .pricing_hint_for_model(Some("acme-large"))

--- a/rust/crates/cli/src/commands/agent/mod.rs
+++ b/rust/crates/cli/src/commands/agent/mod.rs
@@ -977,7 +977,7 @@ fn discover_catalog_providers() -> Vec<DiscoveredProvider> {
         return Vec::new();
     };
     rt.block_on(async {
-        let mut resolved = match load_catalog_quietly() {
+        let mut resolved = match load_or_fetch_catalog().await {
             Ok(mut catalog) => {
                 let fqns = catalog_providers::picker_catalog_fqns(&catalog);
                 catalog_providers::resolve_catalog_providers(&mut catalog, &fqns).await
@@ -1049,9 +1049,19 @@ fn discover_catalog_providers() -> Vec<DiscoveredProvider> {
 /// anonymous 127.0.0.1 row on every `pay claude` launch. Provider selection is
 /// not a catalog-update command, so any non-empty on-disk snapshot is suitable;
 /// pinned OpenAPI sources are refreshed separately in the background.
-fn load_catalog_quietly() -> pay_core::Result<pay_core::skills::Catalog> {
+/// Cached catalog when one exists, else a fetch, else pinned providers only.
+///
+/// The fetch keeps the picker priced when no cache file exists at all (fresh
+/// machine, or a concurrent refresh pruned it): without it discovery would
+/// silently degrade to the built-in fallback providers, which carry no
+/// pricing metadata, and every hosted model would render "unpriced".
+/// `load_skills_for` writes the cache back and merges pins itself.
+async fn load_or_fetch_catalog() -> pay_core::Result<pay_core::skills::Catalog> {
     if let Ok(mut catalog) = pay_core::skills::load_cached_skills() {
         pay_core::skills::overlay::merge_pins_into(&mut catalog);
+        return Ok(catalog);
+    }
+    if let Ok(catalog) = pay_core::skills::load_skills_for(pay_core::ClientApp::Cli).await {
         return Ok(catalog);
     }
     let mut catalog = pay_core::skills::Catalog {

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -587,7 +587,10 @@ fn handle_outcome(
             let req: Option<SessionRequest> = challenge.request.decode().ok();
             let cap_display = req
                 .as_ref()
-                .map(|request| display_token_amount(&request.cap, &request.currency))
+                .and_then(|request| {
+                    session_deposit_amount(request)
+                        .map(|deposit| display_token_amount(deposit, &request.currency))
+                })
                 .unwrap_or_else(|| "unknown".to_string());
 
             if auto_pay {
@@ -611,11 +614,13 @@ fn handle_outcome(
                     "status": 402,
                     "protocol": "mpp-session",
                     "challenge": {
-                        "cap": req.as_ref().map(|r| &r.cap),
+                        "suggested_deposit": req.as_ref().and_then(session_deposit_amount),
                         "cap_display": cap_display,
                         "currency": req.as_ref().map(|r| &r.currency),
-                        "network": req.as_ref().and_then(|r| r.network.as_deref()),
-                        "min_voucher_delta": req.as_ref().and_then(|r| r.min_voucher_delta.as_deref()),
+                        "network": req.as_ref().map(|r| &r.method_details.network),
+                        "min_voucher_delta": req
+                            .as_ref()
+                            .and_then(|r| r.method_details.min_voucher_delta.as_deref()),
                         "recipient": req.as_ref().map(|r| &r.recipient),
                     },
                     "resource": resource_url,
@@ -1164,6 +1169,15 @@ fn mpp_challenges_within_cap(
     ))
 }
 
+/// Deposit a session challenge asks the client to lock: the server's
+/// suggestion, falling back to its minimum.
+fn session_deposit_amount(request: &SessionRequest) -> Option<&str> {
+    request
+        .suggested_deposit
+        .as_deref()
+        .or(request.minimum_deposit.as_deref())
+}
+
 fn enforce_session_cap(
     request: Option<&SessionRequest>,
     payment_cap: Option<u64>,
@@ -1176,7 +1190,8 @@ fn enforce_session_cap(
             "session payment cap requires a decoded SessionRequest".to_string(),
         ));
     };
-    let required_micro = amount_as_stablecoin_micro(&request.cap, &request.currency)?;
+    let required = session_deposit_amount(request).unwrap_or("0");
+    let required_micro = amount_as_stablecoin_micro(required, &request.currency)?;
 
     if required_micro <= payment_cap {
         return Ok(());
@@ -1705,105 +1720,49 @@ fn pay_session_and_retry(
     sandbox: bool,
     verbose: bool,
 ) -> pay_core::Result<()> {
-    use pay_kit::mpp::{SessionMode, SessionPullVoucherStrategy};
-
     let is_json = no_dna::should_json(output_fmt);
     validate_tool_request_before_signing(tool)?;
 
-    // Deposit = min_voucher_delta * 1000, clamped to [1 USDC, cap].
-    let min_delta = req
-        .and_then(|r| r.min_voucher_delta.as_deref())
-        .and_then(|s| s.parse::<u64>().ok())
-        .unwrap_or(1_000);
-    let cap = req
-        .and_then(|r| r.cap.parse::<u64>().ok())
-        .unwrap_or(1_000_000);
-    let deposit = (min_delta * 1_000).max(1_000_000).min(cap);
-    let cap_display = req
-        .map(|request| display_token_amount(&request.cap, &request.currency))
-        .unwrap_or_else(|| format!("{cap} base units"));
-    let deposit_display = req
-        .map(|request| display_token_amount(&deposit.to_string(), &request.currency))
-        .unwrap_or_else(|| format!("{deposit} base units"));
+    let Some(request) = req else {
+        return Err(pay_core::Error::Mpp(
+            "session challenge did not decode into a SessionRequest".to_string(),
+        ));
+    };
+
+    // Deposit: server suggestion, floored by its minimum; fall back to 1 USDC.
+    let minimum = request
+        .minimum_deposit
+        .as_deref()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
+    let deposit = request
+        .suggested_deposit
+        .as_deref()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(1_000_000)
+        .max(minimum)
+        .max(1);
+    let deposit_display = display_token_amount(&deposit.to_string(), &request.currency);
 
     if verbose && !is_json {
         crate::components::print_notice(
             crate::components::NoticeLevel::Success,
             "Authorizing MPP session",
-            &payment_authorization_notice_body(&cap_display, Some(&deposit_display)),
+            &payment_authorization_notice_body(&deposit_display, Some(&deposit_display)),
         );
     }
 
-    let supports_push = req
-        .map(|r| r.modes.is_empty() || r.modes.contains(&SessionMode::Push))
-        .unwrap_or(true);
-    let use_pull = req
-        .map(|r| {
-            r.modes.contains(&SessionMode::Pull)
-                && (!supports_push
-                    || matches!(
-                        r.pull_voucher_strategy.as_ref(),
-                        Some(SessionPullVoucherStrategy::ClientVoucher)
-                    ))
-        })
-        .unwrap_or(false);
-
-    let auth_header = if use_pull {
-        let Some(request) = req else {
-            return Err(pay_core::Error::Mpp(
-                "pull-mode session requires a decoded SessionRequest".to_string(),
-            ));
-        };
-
-        let store = pay_core::accounts::FileAccountsStore::default_path();
-        match request.pull_voucher_strategy.as_ref() {
-            Some(SessionPullVoucherStrategy::ClientVoucher) => {
-                let (_handle, header) =
-                    pay_core::session::open_payment_channel_session_header_with_mode(
-                        challenge,
-                        request,
-                        &store,
-                        network_override,
-                        account_override,
-                        deposit,
-                        SessionMode::Pull,
-                        resource_url,
-                        sandbox,
-                    )?;
-                header
-            }
-            Some(SessionPullVoucherStrategy::OperatedVoucher) => {
-                return Err(pay_core::Error::Mpp(
-                    "operated-voucher pull sessions are no longer supported; \
-                     use a client-voucher payment-channel session instead"
-                        .to_string(),
-                ));
-            }
-            None => {
-                return Err(pay_core::Error::Mpp(
-                    "pull-mode session challenge missing pullVoucherStrategy".to_string(),
-                ));
-            }
-        }
-    } else {
-        if let Some(request) = req {
-            let store = pay_core::accounts::FileAccountsStore::default_path();
-            let (_handle, header) = pay_core::session::open_payment_channel_session_header(
-                challenge,
-                request,
-                &store,
-                network_override,
-                account_override,
-                deposit,
-                resource_url,
-                sandbox,
-            )?;
-            header
-        } else {
-            let (_handle, header) = pay_core::session::open_session_header(challenge, deposit)?;
-            header
-        }
-    };
+    let store = pay_core::accounts::FileAccountsStore::default_path();
+    let (_handle, auth_header) = pay_core::session::open_payment_channel_session_header(
+        challenge,
+        request,
+        &store,
+        network_override,
+        account_override,
+        deposit,
+        resource_url,
+        sandbox,
+    )?;
 
     let receipt_network = network_override
         .map(str::to_string)

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -1178,6 +1178,26 @@ fn session_deposit_amount(request: &SessionRequest) -> Option<&str> {
         .or(request.minimum_deposit.as_deref())
 }
 
+/// The exact base-unit deposit `pay_session_and_retry` will sign for. Shared
+/// with `enforce_session_cap` so the cap can never be checked against a
+/// different amount than the one that gets locked: server suggestion,
+/// floored by its minimum, falling back to 1 USDC when the challenge omits
+/// both.
+fn resolve_session_deposit(request: &SessionRequest) -> u64 {
+    let minimum = request
+        .minimum_deposit
+        .as_deref()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
+    request
+        .suggested_deposit
+        .as_deref()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(1_000_000)
+        .max(minimum)
+        .max(1)
+}
+
 fn enforce_session_cap(
     request: Option<&SessionRequest>,
     payment_cap: Option<u64>,
@@ -1190,8 +1210,8 @@ fn enforce_session_cap(
             "session payment cap requires a decoded SessionRequest".to_string(),
         ));
     };
-    let required = session_deposit_amount(request).unwrap_or("0");
-    let required_micro = amount_as_stablecoin_micro(required, &request.currency)?;
+    let required = resolve_session_deposit(request).to_string();
+    let required_micro = amount_as_stablecoin_micro(&required, &request.currency)?;
 
     if required_micro <= payment_cap {
         return Ok(());
@@ -1729,19 +1749,7 @@ fn pay_session_and_retry(
         ));
     };
 
-    // Deposit: server suggestion, floored by its minimum; fall back to 1 USDC.
-    let minimum = request
-        .minimum_deposit
-        .as_deref()
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(0);
-    let deposit = request
-        .suggested_deposit
-        .as_deref()
-        .and_then(|value| value.parse::<u64>().ok())
-        .unwrap_or(1_000_000)
-        .max(minimum)
-        .max(1);
+    let deposit = resolve_session_deposit(request);
     let deposit_display = display_token_amount(&deposit.to_string(), &request.currency);
 
     if verbose && !is_json {
@@ -1983,6 +1991,60 @@ fn handle_retry_outcome(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pay_kit::mpp::SessionMethodDetails;
+
+    fn test_session_request_with_deposits(
+        minimum_deposit: Option<&str>,
+        suggested_deposit: Option<&str>,
+    ) -> SessionRequest {
+        SessionRequest {
+            amount: "25".to_string(),
+            currency: "USDC".to_string(),
+            recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+            description: None,
+            external_id: None,
+            minimum_deposit: minimum_deposit.map(str::to_string),
+            suggested_deposit: suggested_deposit.map(str::to_string),
+            unit_type: None,
+            method_details: SessionMethodDetails {
+                network: "localnet".to_string(),
+                channel_program: solana_pubkey::Pubkey::new_unique().to_string(),
+                channel_id: None,
+                recent_blockhash: Some("11111111111111111111111111111111".to_string()),
+                recent_slot: Some(1),
+                decimals: Some(6),
+                token_program: None,
+                fee_payer: None,
+                fee_payer_key: None,
+                voucher_signer: None,
+                operator: None,
+                min_voucher_delta: None,
+                ttl_seconds: None,
+                idle_timeout_options_seconds: None,
+                idle_timeout_seconds: None,
+                grace_period_seconds: None,
+                distribution_splits: vec![],
+            },
+        }
+    }
+
+    #[test]
+    fn enforce_session_cap_bounds_the_exact_amount_that_gets_signed() {
+        // A challenge with neither `suggested_deposit` nor `minimum_deposit`
+        // set: `resolve_session_deposit` (and therefore
+        // `pay_session_and_retry`) falls back to signing 1 USDC. The cap
+        // check must reject this against a $0.10 cap instead of silently
+        // treating the required amount as zero.
+        let request = test_session_request_with_deposits(None, None);
+        assert_eq!(resolve_session_deposit(&request), 1_000_000);
+
+        let cap_10_cents = 100_000u64;
+        let result = enforce_session_cap(Some(&request), Some(cap_10_cents));
+        assert!(
+            result.is_err(),
+            "a deposit-less challenge must be capped at what it will actually sign, not 0"
+        );
+    }
 
     #[test]
     fn verbose_challenge_rendering_groups_decoded_protocols() {

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -404,12 +404,6 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         return deliver(first, translated, session_authorization.take()).await;
     }
 
-    // The cached channel may have expired, closed, or exhausted its cap. Drop
-    // it before consuming the fresh challenge and opening a replacement.
-    if let Some(cached) = session_authorization.as_mut() {
-        **cached = None;
-    }
-
     // Buffer the 402 so it can be passed through untouched when payment
     // is impossible. 402 bodies are small (a JSON error envelope).
     let mut status = first.status();
@@ -433,17 +427,80 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             .filter_map(|value| value.to_str().ok()),
     );
 
-    // A cached delegated session is represented by its idempotent `open`
-    // credential. Once the server seals that channel, the resulting 402 is a
-    // terminal-session error rather than a fresh challenge. Rediscovery must
-    // therefore happen without the stale credential before we can open a
-    // replacement channel.
+    let mut has_session_challenge = mpp_challenges.iter().any(|challenge| {
+        challenge.method.as_str() == "solana" && challenge.intent.as_str() == "session"
+    });
+
     if state.payment_protocol == PaymentProtocol::MppSession
         && used_cached_session
-        && !mpp_challenges.iter().any(|challenge| {
-            challenge.method.as_str() == "solana" && challenge.intent.as_str() == "session"
-        })
+        && !has_session_challenge
+        && retryable_cached_session_error(&resp_body)
     {
+        tracing::info!(%url, "payer proxy: retrying transient cached MPP session rejection");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        let retried = match send_upstream(
+            &state,
+            &method,
+            &url,
+            &headers,
+            body.clone(),
+            cached_payment.as_ref(),
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::warn!(%url, %error, "payer proxy: cached MPP session retry failed");
+                return buffered_response(status, &resp_headers, resp_body);
+            }
+        };
+        if retried.status() != StatusCode::PAYMENT_REQUIRED {
+            return deliver(retried, translated, session_authorization.take()).await;
+        }
+        status = retried.status();
+        resp_headers = retried.headers().clone();
+        resp_body = match retried.bytes().await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                tracing::warn!(%url, %error, "payer proxy: failed to read cached MPP session retry");
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!("payer proxy: upstream error: {error}"),
+                )
+                    .into_response();
+            }
+        };
+        mpp_challenges = pay_core::mpp::parse_all(
+            resp_headers
+                .get_all(header::WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|value| value.to_str().ok()),
+        );
+        has_session_challenge = mpp_challenges.iter().any(|challenge| {
+            challenge.method.as_str() == "solana" && challenge.intent.as_str() == "session"
+        });
+    }
+
+    // A cached delegated session is represented by its idempotent `open`
+    // credential. Only a definitive terminal error or a fresh session
+    // challenge proves that the cached channel should be replaced. Transient
+    // store contention must preserve it for the next request.
+    if state.payment_protocol == PaymentProtocol::MppSession
+        && used_cached_session
+        && !has_session_challenge
+        && !terminal_cached_session_error(&resp_body)
+    {
+        tracing::warn!(%url, "payer proxy: preserving cached MPP session after non-terminal 402");
+        return buffered_response(status, &resp_headers, resp_body);
+    }
+
+    if state.payment_protocol == PaymentProtocol::MppSession
+        && used_cached_session
+        && !has_session_challenge
+    {
+        if let Some(cached) = session_authorization.as_mut() {
+            **cached = None;
+        }
         tracing::info!(%url, "payer proxy: cached MPP session ended; requesting a fresh challenge");
         let refreshed = match send_upstream(&state, &method, &url, &headers, body.clone(), None)
             .await
@@ -486,6 +543,11 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
                 .iter()
                 .filter_map(|value| value.to_str().ok()),
         );
+    } else if state.payment_protocol == PaymentProtocol::MppSession
+        && used_cached_session
+        && let Some(cached) = session_authorization.as_mut()
+    {
+        **cached = None;
     }
 
     let charge_challenges: Vec<_> = mpp_challenges
@@ -585,6 +647,41 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             buffered_response(status, &resp_headers, resp_body)
         }
     }
+}
+
+fn cached_session_error_text(body: &[u8]) -> String {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            let error = value
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            let message = value
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            (!error.is_empty() || !message.is_empty()).then(|| format!("{error} {message}"))
+        })
+        .unwrap_or_else(|| String::from_utf8_lossy(body).into_owned())
+        .to_ascii_lowercase()
+}
+
+fn retryable_cached_session_error(body: &[u8]) -> bool {
+    let text = cached_session_error_text(body);
+    text.contains("concurrent channel update")
+        || text.contains("retry the request")
+        || text.contains("session_capacity_reserved")
+}
+
+fn terminal_cached_session_error(body: &[u8]) -> bool {
+    let text = cached_session_error_text(body);
+    text.contains("session_cap_exhausted")
+        || text.contains("session_close_pending")
+        || text.contains("already sealed")
+        || text.contains("close is pending")
+        || text.contains("cap has been exhausted")
+        || text.contains("exceeds available deposit")
 }
 
 /// Hosted providers must challenge successful inference requests, but model
@@ -2240,6 +2337,97 @@ mod tests {
                 Some("Payment test-session".to_string()),
             ],
             "a terminal cached session must be followed by unauthenticated challenge discovery",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn retryable_cached_session_error_reuses_channel() {
+        fn open_test_session(
+            _state: &PayerState,
+            _challenge: &pay_core::mpp::Challenge,
+        ) -> pay_core::Result<(PaidHeaders, String)> {
+            let authorization = "Payment retryable-session".to_string();
+            Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+        let record = seen.clone();
+        let app = Router::new().fallback(any(move |req: Request| {
+            let record = record.clone();
+            async move {
+                let authorization = req
+                    .headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let _ = axum::body::to_bytes(req.into_body(), MAX_BODY_BYTES).await;
+                let mut seen = record.lock().unwrap();
+                seen.push(authorization.clone());
+                match seen.len() {
+                    1 => Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::WWW_AUTHENTICATE, session_challenge_header())
+                        .body(Body::from(r#"{"error":"payment required"}"#))
+                        .unwrap(),
+                    2 | 4 => (StatusCode::OK, "session paid").into_response(),
+                    3 => Response::builder()
+                        .status(StatusCode::PAYMENT_REQUIRED)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(
+                            r#"{"error":"session_failed","message":"Store error: Concurrent channel update; retry the request"}"#,
+                        ))
+                        .unwrap(),
+                    call => panic!("unexpected upstream call {call}"),
+                }
+            }
+        }));
+        let upstream = spawn_server(app).await;
+        let store: Arc<dyn AccountsStore> = Arc::new(MemoryAccountsStore::new());
+        let state = Arc::new(
+            PayerState::new(
+                PayerUpstream {
+                    base_url: upstream,
+                    host_header: None,
+                    dialect: Dialect::Anthropic,
+                    chat_path: "v1/chat/completions".to_string(),
+                    responses_path: "v1/responses".to_string(),
+                    require_payment: true,
+                    payment_protocol: PaymentProtocol::MppSession,
+                },
+                store,
+                None,
+                None,
+            )
+            .unwrap()
+            .with_session_opener(open_test_session),
+        );
+        let payer = spawn_server(router(state.clone())).await;
+
+        let client = reqwest::Client::new();
+        for prompt in ["one", "two"] {
+            let response = client
+                .post(format!("{payer}/v1/messages"))
+                .body(prompt)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                None,
+                Some("Payment retryable-session".to_string()),
+                Some("Payment retryable-session".to_string()),
+                Some("Payment retryable-session".to_string()),
+            ],
+            "a retryable store conflict must retry the same channel without rediscovery",
+        );
+        assert_eq!(
+            state.session_authorization.lock().await.as_deref(),
+            Some("Payment retryable-session"),
+            "a transient 402 must preserve the cached session"
         );
     }
 

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -621,29 +621,35 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
             return buffered_response(status, &resp_headers, resp_body);
         }
     };
-    if let (Some(cache), Some(authorization)) = (
-        session_authorization.as_mut(),
-        new_session_authorization.as_ref(),
-    ) {
-        **cache = Some(authorization.clone());
-    }
-
     tracing::info!(%url, "payer proxy: 402 paid — retrying once with payment credential");
     match send_upstream(&state, &method, &url, &headers, body, Some(&payment)).await {
         Ok(retry) => {
-            if retry.status() == StatusCode::PAYMENT_REQUIRED
-                && let Some(cache) = session_authorization.as_mut()
-            {
-                **cache = None;
+            // Only adopt the new credential once a request has actually gone
+            // through on it. Caching it before this point risks stranding a
+            // credential for a channel whose open transaction never landed
+            // (or whose response was lost) — a use of that credential then
+            // fails with a terminal-looking rejection (e.g. "unknown session
+            // channel") that never clears without a manual restart.
+            if retry.status() == StatusCode::PAYMENT_REQUIRED {
+                if let Some(cache) = session_authorization.as_mut() {
+                    **cache = None;
+                }
+            } else if let (Some(cache), Some(authorization)) = (
+                session_authorization.as_mut(),
+                new_session_authorization.as_ref(),
+            ) {
+                **cache = Some(authorization.clone());
             }
             deliver(retry, translated, session_authorization.take()).await
         }
         Err(e) => {
-            // The open credential is idempotent and the channel may already
-            // have been funded even though the response was lost. Preserve it
-            // across transport failures; only a definitive 402 rejection
-            // above proves that the cached session cannot be reused.
-            tracing::warn!(%url, error = %e, "payer proxy: paid retry failed — preserving the session and returning the original 402");
+            // A transport failure here means we don't know whether the paid
+            // request (and, for a first use, the channel open it carried)
+            // landed upstream. Leave the cache exactly as it was before this
+            // attempt — do not adopt the unconfirmed new credential — so the
+            // next request renegotiates instead of reusing a channel that
+            // may never have opened.
+            tracing::warn!(%url, error = %e, "payer proxy: paid retry failed — preserving the prior session and returning the original 402");
             buffered_response(status, &resp_headers, resp_body)
         }
     }
@@ -675,6 +681,7 @@ fn retryable_cached_session_error(body: &[u8]) -> bool {
 }
 
 fn terminal_cached_session_error(body: &[u8]) -> bool {
+    use pay_core::server::session::terminal_errors;
     let text = cached_session_error_text(body);
     text.contains("session_cap_exhausted")
         || text.contains("session_close_pending")
@@ -682,6 +689,11 @@ fn terminal_cached_session_error(body: &[u8]) -> bool {
         || text.contains("close is pending")
         || text.contains("cap has been exhausted")
         || text.contains("exceeds available deposit")
+        || text.contains(terminal_errors::UNKNOWN_CHANNEL)
+        || text.contains(terminal_errors::CHALLENGE_ECHO_MISMATCH)
+        || text.contains(terminal_errors::OPERATOR_ONLY)
+        || text.contains(terminal_errors::PREDATES_PROOF_BINDING)
+        || text.contains(terminal_errors::PROOF_MISMATCH)
 }
 
 /// Hosted providers must challenge successful inference requests, but model
@@ -1349,6 +1361,58 @@ mod tests {
     fn payer_proxy_bind_address_is_loopback_only() {
         assert!(PAYER_PROXY_BIND_IP.is_loopback());
         assert_eq!(PAYER_PROXY_BIND_IP, Ipv4Addr::LOCALHOST);
+    }
+
+    /// One case per real `session_failed` rejection the server can produce
+    /// for a stale cached credential (see `pay_core::server::session`'s
+    /// `verify_use_authentication` and `verify_challenge_echo`). Every one
+    /// of these is terminal — the exact same cached credential will fail
+    /// identically forever, so the proxy must discard it and renegotiate
+    /// rather than preserve-and-retry. Pinned against the server's own
+    /// error text so a rewording can't silently reopen the wedge.
+    #[test]
+    fn terminal_cached_session_error_recognizes_every_server_rejection() {
+        use pay_core::server::session::terminal_errors;
+
+        let session_failed_body = |message: &str| {
+            serde_json::to_vec(&serde_json::json!({
+                "error": "session_failed",
+                "message": message,
+                "retryable": true,
+            }))
+            .unwrap()
+        };
+
+        for message in [
+            &format!("{}: 6y6WeJ8H4o", terminal_errors::UNKNOWN_CHANNEL),
+            terminal_errors::CHALLENGE_ECHO_MISMATCH,
+            terminal_errors::OPERATOR_ONLY,
+            &format!(
+                "session channel {}; open a new session",
+                terminal_errors::PREDATES_PROOF_BINDING
+            ),
+            &format!("use authentication {}", terminal_errors::PROOF_MISMATCH),
+        ] {
+            let body = session_failed_body(message);
+            assert!(
+                terminal_cached_session_error(&body),
+                "expected terminal classification for: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_cached_session_error_does_not_misclassify_a_transient_store_error() {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "error": "session_failed",
+            "message": "failed to read session channel abc123: store timeout",
+            "retryable": true,
+        }))
+        .unwrap();
+        assert!(
+            !terminal_cached_session_error(&body),
+            "a store read hiccup must stay retryable, not be treated as terminal"
+        );
     }
 
     /// A canned MPP charge challenge that signs fully offline: the
@@ -2087,7 +2151,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn session_open_credential_survives_a_paid_retry_transport_error() {
+    async fn session_open_credential_does_not_survive_a_paid_retry_transport_error() {
         fn open_test_session(
             _state: &PayerState,
             _challenge: &pay_core::mpp::Challenge,
@@ -2097,8 +2161,9 @@ mod tests {
         }
 
         // Serve exactly the challenge response, then stop listening before the
-        // paid retry. This models a connection failure after the open may
-        // already have funded its channel.
+        // paid retry. This models a connection failure after the open may or
+        // may not have landed upstream — genuinely ambiguous, since nothing
+        // confirms whether the retry was even received.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let challenge = session_challenge_header();
@@ -2147,8 +2212,11 @@ mod tests {
         assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
         assert_eq!(
             state.session_authorization.lock().await.as_deref(),
-            Some("Payment durable-open"),
-            "an ambiguous transport failure must retain the idempotent open credential"
+            None,
+            "an unconfirmed open credential must not be cached — adopting it before \
+             a paid retry proves it landed risks stranding a credential for a \
+             channel that never opened; the next request must renegotiate instead \
+             of trusting a credential no response ever confirmed"
         );
     }
 

--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -481,7 +481,7 @@ async fn proxy(State(state): State<Arc<PayerState>>, req: Request) -> Response {
         });
     }
 
-    // A cached delegated session is represented by its idempotent `open`
+    // A cached operator-signed session is represented by its reusable `use`
     // credential. Only a definitive terminal error or a fresh session
     // challenge proves that the cached channel should be replaced. Transient
     // store contention must preserve it for the next request.
@@ -975,60 +975,61 @@ impl PaidHeaders {
     }
 }
 
-/// Open a delegated push session and return the authorization reused for all
-/// subsequent requests handled by this payer proxy.
+/// Open an operator-signed session and return the initial `open`
+/// authorization plus the reusable `use` credential cached for all subsequent
+/// requests handled by this payer proxy.
 fn build_session_authorization(
     state: &PayerState,
     challenge: &pay_core::mpp::Challenge,
 ) -> pay_core::Result<(PaidHeaders, String)> {
-    use pay_kit::mpp::{SessionMode, SessionRequest, SessionSettlementAuthority};
+    use pay_kit::mpp::{SessionRequest, SessionVoucherSigner};
 
     let request: SessionRequest = challenge
         .request
         .decode()
         .map_err(|error| pay_core::Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
-    if request.settlement_authority != SessionSettlementAuthority::Delegated {
+    if request.method_details.voucher_signer != Some(SessionVoucherSigner::Operator) {
         return Err(pay_core::Error::Mpp(
-            "agent payer requires a delegated MPP session".to_string(),
+            "agent payer requires an operator-signed MPP session".to_string(),
         ));
     }
-    if !request.modes.is_empty() && !request.modes.contains(&SessionMode::Push) {
-        return Err(pay_core::Error::Mpp(
-            "agent payer requires MPP session push mode".to_string(),
-        ));
-    }
-    if let (Some(forced), Some(offered)) = (
-        state.network_override.as_deref(),
-        request.network.as_deref(),
-    ) && forced != offered
+    if let Some(forced) = state.network_override.as_deref()
+        && forced != request.method_details.network
     {
         return Err(pay_core::Error::Mpp(format!(
-            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{offered}`"
+            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{}`",
+            request.method_details.network
         )));
     }
 
-    let cap = request.cap.parse::<u64>().map_err(|_| {
-        pay_core::Error::Mpp(format!(
-            "MPP session challenge advertised a non-numeric cap: {}",
-            request.cap
-        ))
-    })?;
-    if cap == 0 {
-        return Err(pay_core::Error::Mpp(
-            "MPP session challenge advertised a zero cap".to_string(),
-        ));
-    }
-    let min_delta = request
-        .min_voucher_delta
+    let minimum = request
+        .minimum_deposit
         .as_deref()
-        .unwrap_or("1")
-        .parse::<u64>()
-        .map_err(|_| {
-            pay_core::Error::Mpp("MPP session challenge has invalid minVoucherDelta".to_string())
-        })?;
-    let deposit = min_delta.saturating_mul(1_000).max(1_000_000).min(cap);
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                pay_core::Error::Mpp(format!(
+                    "MPP session challenge advertised a non-numeric minimumDeposit: {value}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(0);
+    let deposit = request
+        .suggested_deposit
+        .as_deref()
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                pay_core::Error::Mpp(format!(
+                    "MPP session challenge advertised a non-numeric suggestedDeposit: {value}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(1_000_000)
+        .max(minimum)
+        .max(1);
     let sandbox = state.network_override.as_deref() == Some("localnet");
-    let (_handle, authorization) = pay_core::session::open_payment_channel_session_header(
+    let (handle, open_authorization) = pay_core::session::open_payment_channel_session_header(
         challenge,
         &request,
         state.store.as_ref(),
@@ -1039,7 +1040,15 @@ fn build_session_authorization(
         sandbox,
     )?;
 
-    Ok((PaidHeaders::mpp(authorization.clone()), authorization))
+    // Subsequent requests authenticate with the reusable payer proof bound at
+    // open; the operator meters delivered service and signs the vouchers.
+    let use_authorization = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| pay_core::Error::Mpp(format!("Failed to build runtime: {error}")))?
+        .block_on(handle.use_header())?;
+
+    Ok((PaidHeaders::mpp(open_authorization), use_authorization))
 }
 
 /// Select a payable MPP challenge and build the `Authorization: Payment …`

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -144,11 +144,15 @@ impl CatalogProvider {
         let Some(json) = get_json(client, base_url.trim_end_matches('/'), &path).await else {
             return (fallback(), Vec::new());
         };
-        let models = parse_model_names(&json);
-        let models = if models.is_empty() {
+        let advertised_models = parse_model_names(&json);
+        let models = if advertised_models.is_empty() {
             fallback()
         } else {
-            models
+            models_matching_configured_families(
+                advertised_models,
+                &self.endpoints,
+                &self.fallback_models,
+            )
         };
         (models, parse_openai_model_pricing(&json))
     }
@@ -718,6 +722,38 @@ fn models_from_pricing_variants(endpoints: &[pay_core::skills::Endpoint]) -> Vec
     models
 }
 
+/// Restrict a provider's broad model catalog to the model families priced by
+/// its inference endpoints, or its built-in fallback families while a catalog
+/// entry is not yet published. Alibaba's OpenAI-compatible model list includes
+/// audio, image, embedding, and realtime models that chat harnesses cannot
+/// call. These configured families are the agent route's supported allowlist.
+///
+/// Matching intentionally mirrors runtime pricing: a variant value is a
+/// substring of the advertised model id, so dated aliases remain available.
+/// The `default` pricing sentinel is excluded by
+/// [`models_from_pricing_variants`] and therefore cannot admit every model.
+fn models_matching_configured_families(
+    advertised_models: Vec<String>,
+    endpoints: &[pay_core::skills::Endpoint],
+    fallback_models: &[String],
+) -> Vec<String> {
+    let mut configured_models = models_from_pricing_variants(endpoints);
+    if configured_models.is_empty() {
+        configured_models.extend_from_slice(fallback_models);
+    }
+    if configured_models.is_empty() {
+        return advertised_models;
+    }
+    advertised_models
+        .into_iter()
+        .filter(|model| {
+            configured_models
+                .iter()
+                .any(|configured| model.contains(configured))
+        })
+        .collect()
+}
+
 /// Picker title for a catalog entry. Known default fqns get a short brand
 /// name (catalog titles like "Generative Language API (Gemini)" are too
 /// verbose for a picker row); everything else uses the catalog title,
@@ -1265,6 +1301,63 @@ mod tests {
         assert_eq!(
             models_from_pricing_variants(&provider.endpoints),
             vec!["gemini-2.5-flash-lite", "gemini-2.5-flash"]
+        );
+    }
+
+    #[test]
+    fn live_models_are_intersected_with_priced_model_families() {
+        let provider = gemini_variant_priced();
+        assert_eq!(
+            models_matching_configured_families(
+                vec![
+                    "qwen-audio-3.0-asr-flash".to_string(),
+                    "gemini-2.5-flash".to_string(),
+                    "gemini-2.5-flash-2026-07-15".to_string(),
+                    "gemini-2.5-pro".to_string(),
+                ],
+                &provider.endpoints,
+                &provider.fallback_models,
+            ),
+            ["gemini-2.5-flash", "gemini-2.5-flash-2026-07-15",],
+            "unpriced model families must not leak into an agent picker"
+        );
+    }
+
+    #[test]
+    fn live_models_remain_authoritative_without_pricing_variants() {
+        let provider = CatalogProvider::from_service(&blockrun_service());
+        let advertised = vec![
+            "openai/gpt-5.6-sol".to_string(),
+            "anthropic/claude-sonnet-5".to_string(),
+        ];
+        assert_eq!(
+            models_matching_configured_families(
+                advertised.clone(),
+                &provider.endpoints,
+                &provider.fallback_models,
+            ),
+            advertised,
+            "providers with live per-model pricing must retain their catalog"
+        );
+    }
+
+    #[test]
+    fn fallback_model_families_filter_broad_live_catalogs() {
+        let provider = alibaba_modelstudio_fallback();
+        assert_eq!(
+            models_matching_configured_families(
+                vec![
+                    "qwen-audio-3.0-asr-flash".to_string(),
+                    "qwen3.7-max".to_string(),
+                    "qwen3.7-max-2026-06-08".to_string(),
+                    "qwen3-coder-next".to_string(),
+                    "qwen-image-2.0".to_string(),
+                ],
+                &provider.endpoints,
+                &provider.fallback_models,
+            ),
+            ["qwen3.7-max", "qwen3.7-max-2026-06-08", "qwen3-coder-next",],
+            "fallback families must exclude non-agent Alibaba models"
         );
     }
 

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -608,7 +608,7 @@ fn match_variant<'a>(
         let Some(value) = variant.get("value").and_then(|v| v.as_str()) else {
             continue;
         };
-        if value == "default" {
+        if value.eq_ignore_ascii_case("default") {
             default = default.or(Some(variant));
         } else if model.contains(value) {
             return Some(variant);
@@ -644,10 +644,16 @@ fn dimension_prices(variant: &serde_json::Value) -> Vec<(f64, f64)> {
 /// Model names from a model-list response body. Understands Gemini's
 /// `{"models":[{"name":"models/gemini-…"}]}` (the `models/` prefix is
 /// stripped) and the OpenAI-compatible `{"data":[{"id":"…"}]}`.
+///
+/// Gemini entries advertise their capabilities in
+/// `supportedGenerationMethods`; models that cannot serve `generateContent`
+/// (embeddings, imagen, aqa) are dropped so the picker only offers models
+/// the chat route can call. Entries without the field are kept.
 fn parse_model_names(json: &serde_json::Value) -> Vec<String> {
     if let Some(items) = json.get("models").and_then(|v| v.as_array()) {
         return items
             .iter()
+            .filter(|item| supports_generate_content(item))
             .filter_map(|item| item.get("name")?.as_str())
             .map(|name| name.strip_prefix("models/").unwrap_or(name).to_string())
             .collect();
@@ -659,6 +665,22 @@ fn parse_model_names(json: &serde_json::Value) -> Vec<String> {
             .collect();
     }
     Vec::new()
+}
+
+/// Whether a Gemini model-list entry can serve the chat route. Entries
+/// without capability metadata are kept — absence of the field must not
+/// hide a model.
+fn supports_generate_content(item: &serde_json::Value) -> bool {
+    let Some(methods) = item
+        .get("supportedGenerationMethods")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return true;
+    };
+    methods
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .any(|method| method == "generateContent" || method == "streamGenerateContent")
 }
 
 /// Per-million-token rates returned by OpenAI-style model catalogs such as
@@ -713,13 +735,27 @@ fn models_from_pricing_variants(endpoints: &[pay_core::skills::Endpoint]) -> Vec
         .flatten()
         .filter_map(|variant| variant.get("value"))
         .filter_map(serde_json::Value::as_str)
-        .filter(|value| *value != "default")
+        .filter(|value| !value.eq_ignore_ascii_case("default"))
     {
         if !models.iter().any(|model| model == value) {
             models.push(value.to_string());
         }
     }
     models
+}
+
+/// Whether any priced endpoint declares the `default` pricing sentinel —
+/// the runtime accepts and prices every model for such providers.
+fn has_default_pricing_variant(endpoints: &[pay_core::skills::Endpoint]) -> bool {
+    endpoints
+        .iter()
+        .filter_map(|endpoint| endpoint.pricing.as_ref())
+        .filter_map(|pricing| pricing.get("variants"))
+        .filter_map(serde_json::Value::as_array)
+        .flatten()
+        .filter_map(|variant| variant.get("value"))
+        .filter_map(serde_json::Value::as_str)
+        .any(|value| value.eq_ignore_ascii_case("default"))
 }
 
 /// Restrict a provider's broad model catalog to the model families priced by
@@ -730,13 +766,20 @@ fn models_from_pricing_variants(endpoints: &[pay_core::skills::Endpoint]) -> Vec
 ///
 /// Matching intentionally mirrors runtime pricing: a variant value is a
 /// substring of the advertised model id, so dated aliases remain available.
-/// The `default` pricing sentinel is excluded by
-/// [`models_from_pricing_variants`] and therefore cannot admit every model.
+/// A `default` pricing sentinel is the catalog's explicit promise that
+/// unlisted models are accepted and priced (metering's `resolve_variant`
+/// falls back to it), so providers that declare one keep their full
+/// advertised list — hiding a model here would desynchronize the picker
+/// from the gateway's support policy. Non-chat noise in those lists is
+/// removed by the capability filter in [`parse_model_names`] instead.
 fn models_matching_configured_families(
     advertised_models: Vec<String>,
     endpoints: &[pay_core::skills::Endpoint],
     fallback_models: &[String],
 ) -> Vec<String> {
+    if has_default_pricing_variant(endpoints) {
+        return advertised_models;
+    }
     let mut configured_models = models_from_pricing_variants(endpoints);
     if configured_models.is_empty() {
         configured_models.extend_from_slice(fallback_models);
@@ -1156,8 +1199,9 @@ mod tests {
         assert_eq!(hint, provider.pricing_hint().unwrap());
     }
 
-    #[test]
-    fn unmatched_model_is_unpriced_when_variants_are_model_specific() {
+    /// The Gemini fixture with its `default` sentinel stripped: a provider
+    /// that prices only the named model families.
+    fn variant_priced_without_default() -> CatalogProvider {
         let mut provider = gemini_variant_priced();
         for endpoint in &mut provider.endpoints {
             if let Some(variants) = endpoint
@@ -1169,6 +1213,12 @@ mod tests {
                 variants.retain(|variant| variant["value"] != "default");
             }
         }
+        provider
+    }
+
+    #[test]
+    fn unmatched_model_is_unpriced_when_variants_are_model_specific() {
+        let provider = variant_priced_without_default();
 
         assert!(
             provider
@@ -1288,6 +1338,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_model_names_drops_models_that_cannot_generate_content() {
+        let json = serde_json::json!({
+            "models": [
+                { "name": "models/gemini-2.5-flash",
+                  "supportedGenerationMethods": ["generateContent", "countTokens"] },
+                { "name": "models/text-embedding-004",
+                  "supportedGenerationMethods": ["embedContent"] },
+                { "name": "models/gemini-mystery" }
+            ]
+        });
+        assert_eq!(
+            parse_model_names(&json),
+            vec!["gemini-2.5-flash", "gemini-mystery"],
+            "non-chat models must not reach the agent picker; entries \
+             without capability metadata stay"
+        );
+    }
+
+    #[test]
     fn parse_model_names_handles_openai_compat_data_ids() {
         let json: serde_json::Value =
             serde_json::from_str(r#"{"data":[{"id":"qwen-max"},{"id":"qwen-plus"}]}"#).unwrap();
@@ -1306,7 +1375,7 @@ mod tests {
 
     #[test]
     fn live_models_are_intersected_with_priced_model_families() {
-        let provider = gemini_variant_priced();
+        let provider = variant_priced_without_default();
         assert_eq!(
             models_matching_configured_families(
                 vec![
@@ -1320,6 +1389,30 @@ mod tests {
             ),
             ["gemini-2.5-flash", "gemini-2.5-flash-2026-07-15",],
             "unpriced model families must not leak into an agent picker"
+        );
+    }
+
+    #[test]
+    fn default_priced_catalogs_keep_every_live_model() {
+        // The live Gemini entry describes its `default` variant as the
+        // "Fallback for unlisted Gemini models": the runtime accepts and
+        // prices models beyond the named families, so the picker must not
+        // hide them (pay#416 review). Non-chat models are dropped earlier,
+        // by capability, in `parse_model_names`.
+        let provider = gemini_variant_priced();
+        let advertised = vec![
+            "gemini-2.5-flash".to_string(),
+            "gemini-2.0-flash".to_string(),
+            "gemini-exp-2026".to_string(),
+        ];
+        assert_eq!(
+            models_matching_configured_families(
+                advertised.clone(),
+                &provider.endpoints,
+                &provider.fallback_models,
+            ),
+            advertised,
+            "models priced by the `default` sentinel must stay in the picker"
         );
     }
 

--- a/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
+++ b/rust/crates/cli/src/commands/server/inference/providers/catalog.rs
@@ -772,6 +772,15 @@ fn has_default_pricing_variant(endpoints: &[pay_core::skills::Endpoint]) -> bool
 /// advertised list — hiding a model here would desynchronize the picker
 /// from the gateway's support policy. Non-chat noise in those lists is
 /// removed by the capability filter in [`parse_model_names`] instead.
+///
+/// Top-level endpoint `dimensions` are also a runtime pricing fallback
+/// (`resolve_price` never leaves a metered endpoint unpriced), but they
+/// deliberately do *not* admit models here: the `default` sentinel is the
+/// catalog author's promise that unlisted models are first-class, while
+/// top-level dimensions are a quote-safety backstop at a conservative
+/// (punitive) rate. Hiding unlisted models from such providers steers
+/// users toward correctly-priced families instead of silently billing
+/// them at the backstop rate.
 fn models_matching_configured_families(
     advertised_models: Vec<String>,
     endpoints: &[pay_core::skills::Endpoint],

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -267,6 +267,28 @@ fn x402_currency_configs(
     configs
 }
 
+/// Session challenges and metered settlement convert USD prices into token
+/// base units by decimal scaling alone (`payment::price_unit_base_amount`),
+/// which is only sound when one whole token is worth exactly one USD. A
+/// non-pegged session currency (e.g. `SOL`) would advertise and settle a
+/// `$0.01` price as `0.01 SOL`, so refuse to boot instead of mispricing
+/// every voucher.
+fn ensure_session_currencies_usd_pegged(
+    currency_configs: &[(String, String, u8)],
+) -> pay_core::Result<()> {
+    for (symbol, mint, _decimals) in currency_configs {
+        if Stablecoin::parse_symbol(symbol).is_none() && Stablecoin::from_mint(mint).is_none() {
+            return Err(pay_core::Error::Config(format!(
+                "session currency `{symbol}` is not a recognized USD-pegged stablecoin: \
+                 session prices are USD amounts settled 1:1 in token base units, so a \
+                 non-pegged asset would be mispriced; use {}",
+                Stablecoin::SYMBOL_LIST
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn resolve_session_splits(
     api: &ApiSpec,
     session: &pay_types::metering::SessionSpec,
@@ -943,6 +965,8 @@ impl StartCommand {
                 use pay_kit::mpp::server::session::{SessionConfig, VoucherSigner};
                 use pay_types::metering::SessionVoucherSigner as ConfigVoucherSigner;
                 use std::str::FromStr;
+
+                ensure_session_currencies_usd_pegged(&currency_configs)?;
 
                 let session_secret = std::env::var("PAY_SESSION_SECRET")
                     .unwrap_or_else(|_| challenge_binding_secret.clone());
@@ -2958,8 +2982,9 @@ mod tests {
         surfpool_funding_targets, surfpool_prep_notice_body,
     };
     use super::{
-        build_pdb_config, default_bind, delegated_session_channel_payout, payout_recipient_pubkeys,
-        payout_recipient_targets, resolve_operator_currencies, session_lifecycle_reconciliation,
+        build_pdb_config, default_bind, delegated_session_channel_payout,
+        ensure_session_currencies_usd_pegged, payout_recipient_pubkeys, payout_recipient_targets,
+        resolve_operator_currencies, session_lifecycle_reconciliation,
         validate_browser_rpc_request, x402_currency_configs, x402_upto_beneficiary_pubkey,
         x402_upto_payout_for_recipient,
     };
@@ -3471,6 +3496,41 @@ endpoints:
             resolve_currency("USDG", "mainnet").0,
             pay_types::stablecoin_mints::USDG_MAINNET
         );
+    }
+
+    #[test]
+    fn session_currencies_require_usd_pegged_stablecoins() {
+        // Stablecoin symbols and recognized stablecoin mints pass.
+        let pegged: Vec<(String, String, u8)> = vec![
+            resolve_currency_config("USDC", "mainnet"),
+            resolve_currency_config("usdt", "mainnet"),
+            (
+                pay_types::stablecoin_mints::PYUSD_MAINNET.to_string(),
+                pay_types::stablecoin_mints::PYUSD_MAINNET.to_string(),
+                6,
+            ),
+        ];
+        assert!(ensure_session_currencies_usd_pegged(&pegged).is_ok());
+
+        // SOL resolves (9 decimals) for other schemes but must not open
+        // sessions: $0.01 would be advertised and settled as 0.01 SOL.
+        let sol = vec![resolve_currency_config("SOL", "mainnet")];
+        let err = ensure_session_currencies_usd_pegged(&sol).unwrap_err();
+        assert!(err.to_string().contains("not a recognized USD-pegged"));
+        assert!(err.to_string().contains("SOL"));
+
+        // Unrecognized raw mints fail closed rather than assume a peg.
+        let unknown = vec![(
+            "BonkMintAddress111111111111111111111111111".to_string(),
+            "BonkMintAddress111111111111111111111111111".to_string(),
+            6,
+        )];
+        assert!(ensure_session_currencies_usd_pegged(&unknown).is_err());
+    }
+
+    fn resolve_currency_config(symbol: &str, network: &str) -> (String, String, u8) {
+        let (mint, decimals) = resolve_currency(symbol, network);
+        (symbol.to_string(), mint, decimals)
     }
 
     #[test]

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -74,7 +74,7 @@ async fn session_channel_store()
                 pay_core::Error::Config(format!("failed to connect session Redis store: {error}"))
             })?;
         tracing::info!("using durable Redis channel store for MPP sessions");
-        return Ok((Arc::new(store), true));
+        Ok((Arc::new(store), true))
     }
 
     #[cfg(not(feature = "redis-session-store"))]
@@ -446,44 +446,6 @@ fn parse_payout_recipient(
         label,
         pubkey: recipient,
     })
-}
-
-async fn create_surfpool_payment_channel_payer(
-    rpc_url: &str,
-) -> pay_core::Result<Arc<dyn SolanaSigner>> {
-    use ed25519_dalek::SigningKey;
-    use pay_kit::mpp::solana_keychain::MemorySigner;
-
-    let sk = SigningKey::generate(&mut rand::rngs::OsRng);
-    let vk = sk.verifying_key();
-    let mut kp = [0u8; 64];
-    kp[..32].copy_from_slice(sk.as_bytes());
-    kp[32..].copy_from_slice(vk.as_bytes());
-    let signer = MemorySigner::from_bytes(&kp).map_err(|e| {
-        pay_core::Error::Config(format!(
-            "failed to create session channel payer signer: {e}"
-        ))
-    })?;
-    let pubkey = signer.pubkey().to_string();
-    pay_core::client::sandbox::fund_via_surfpool(rpc_url, &pubkey).await?;
-    Ok(Arc::new(signer) as Arc<dyn SolanaSigner>)
-}
-
-async fn ensure_surfpool_session_distribution_accounts(
-    rpc_url: &str,
-    splits: &[pay_kit::mpp::server::session::Split],
-) -> pay_core::Result<()> {
-    let treasury = pay_kit::mpp::program::payment_channels::treasury_owner().to_string();
-    pay_core::client::sandbox::set_surfpool_usdc_token_account(rpc_url, &treasury, 0).await?;
-    for split in splits {
-        pay_core::client::sandbox::set_surfpool_usdc_token_account(
-            rpc_url,
-            &split.recipient.to_string(),
-            0,
-        )
-        .await?;
-    }
-    Ok(())
 }
 
 fn add_payout_recipient_target(
@@ -978,113 +940,49 @@ impl StartCommand {
             )?;
             // ── Create one session MPP server per configured currency ──
             let session_mpps: Vec<Arc<SessionMpp>> = if let Some(ref sess) = api.session {
-                use pay_core::server::session::PullVoucherStrategy;
-                use pay_types::metering::{
-                    SessionPullVoucherStrategy as ConfigPullVoucherStrategy,
-                    SessionSettlementAuthority as ConfigSettlementAuthority,
-                };
-                use pay_kit::mpp::server::session::{
-                    SessionConfig, SettlementAuthority,
-                };
-                use pay_kit::mpp::{SessionMode, SessionPullVoucherStrategy};
+                use pay_kit::mpp::server::session::{SessionConfig, VoucherSigner};
+                use pay_types::metering::SessionVoucherSigner as ConfigVoucherSigner;
                 use std::str::FromStr;
 
                 let session_secret = std::env::var("PAY_SESSION_SECRET")
                     .unwrap_or_else(|_| challenge_binding_secret.clone());
-                // Default to pull + clientVoucher (payment-channel) when `modes`
-                // is omitted — matches the canonical pay-kit `session()` adapter
-                // and the JS playground client. Explicit `modes:` is respected.
-                let modes_omitted = sess.modes.is_empty();
-                let requested_modes: Vec<SessionMode> = if modes_omitted {
-                    vec![SessionMode::Pull]
-                } else {
-                    sess.modes
-                        .iter()
-                        .map(|m| match m.as_str() {
-                            "pull" => SessionMode::Pull,
-                            _ => SessionMode::Push,
-                        })
-                        .collect()
-                };
-                let pull_voucher_strategy = match sess.pull_voucher_strategy {
-                    // Omitting `modes` opts into the pull default, so also enable
-                    // clientVoucher (otherwise pull gets stripped back to push).
-                    ConfigPullVoucherStrategy::Disabled if modes_omitted => {
-                        PullVoucherStrategy::ClientVoucher
-                    }
-                    ConfigPullVoucherStrategy::Disabled => PullVoucherStrategy::Disabled,
-                    ConfigPullVoucherStrategy::ClientVoucher => PullVoucherStrategy::ClientVoucher,
-                    ConfigPullVoucherStrategy::OperatedVoucher => {
-                        return Err(pay_core::Error::Config(
-                            "session.pull_voucher_strategy = operated_voucher is no longer \
-                             supported; use client_voucher or disabled"
-                                .to_string(),
-                        ));
-                    }
-                };
-                let mut modes = requested_modes.clone();
-                if pull_voucher_strategy == PullVoucherStrategy::Disabled {
-                    if requested_modes.contains(&SessionMode::Pull) {
-                        tracing::warn!(
-                            "pull mode requested but pull_voucher_strategy is disabled; advertising push only"
-                        );
-                    }
-                    modes.retain(|mode| mode != &SessionMode::Pull);
-                }
-                if modes.is_empty() {
-                    modes.push(SessionMode::Push);
-                }
-                let sdk_pull_voucher_strategy = if modes.contains(&SessionMode::Pull) {
-                    match pull_voucher_strategy {
-                        PullVoucherStrategy::Disabled => None,
-                        PullVoucherStrategy::ClientVoucher => {
-                            Some(SessionPullVoucherStrategy::ClientVoucher)
-                        }
-                    }
-                } else {
-                    None
-                };
                 let channel_program_id = std::env::var("PAY_PAYMENT_CHANNELS_PROGRAM_ID")
                     .or_else(|_| std::env::var("PAY_FIBER_PROGRAM_ID"))
                     .ok()
                     .and_then(|value| solana_pubkey::Pubkey::from_str(&value).ok())
                     .unwrap_or_else(pay_kit::mpp::program::payment_channels::default_program_id);
                 let session_splits = resolve_session_splits(&api, sess)?;
-                let client_voucher_pull = modes.contains(&SessionMode::Pull)
-                    && pull_voucher_strategy == PullVoucherStrategy::ClientVoucher;
-                let settlement_authority = match sess.settlement_authority {
-                    ConfigSettlementAuthority::ClientVoucher => {
-                        SettlementAuthority::ClientVoucher
-                    }
-                    ConfigSettlementAuthority::Delegated => SettlementAuthority::Delegated,
+                let voucher_signer = match sess.voucher_signer {
+                    ConfigVoucherSigner::Client => VoucherSigner::Client,
+                    ConfigVoucherSigner::Operator => VoucherSigner::Operator,
                 };
-                if settlement_authority == SettlementAuthority::Delegated
-                    && fee_payer_signer.is_none()
-                {
+                if voucher_signer == VoucherSigner::Operator && fee_payer_signer.is_none() {
                     return Err(pay_core::Error::Config(
-                        "delegated session settlement requires operator.fee_payer so the gateway can sign metered vouchers".to_string(),
+                        "operator-signed sessions require operator.fee_payer so the gateway can sign metered vouchers".to_string(),
                     ));
                 }
-                if client_voucher_pull
-                    && let Some(settlement_signer) = fee_payer_signer.as_ref()
-                    && recipient != settlement_signer.pubkey().to_string()
-                {
-                    return Err(pay_core::Error::Config(
-                        "pull/client_voucher sessions require the primary recipient to match the gateway settlement signer. Remove operator.recipient or set it to the configured signer pubkey.".to_string(),
-                    ));
+                if let Some(options) = sess.idle_timeout_options_seconds.as_deref() {
+                    pay_kit::mpp::validate_idle_timeout_options(options).map_err(|error| {
+                        pay_core::Error::Config(format!(
+                            "invalid session.idle_timeout_options_seconds: {error}"
+                        ))
+                    })?;
                 }
-                let session_channel_payer_signer = if client_voucher_pull && should_fund {
-                    Some(create_surfpool_payment_channel_payer(&rpc_url).await?)
+                // The negotiated idle timeout mirrors the lifecycle close
+                // delay; disabled auto-close advertises the spec maximum.
+                let idle_timeout_seconds = if sess.close_delay_ms == 0 {
+                    pay_kit::mpp::MAX_IDLE_TIMEOUT_SECONDS
                 } else {
-                    None
+                    u32::try_from(sess.close_delay_ms.div_ceil(1_000))
+                        .unwrap_or(pay_kit::mpp::MAX_IDLE_TIMEOUT_SECONDS)
+                        .clamp(1, pay_kit::mpp::MAX_IDLE_TIMEOUT_SECONDS)
                 };
                 let session_operator = fee_payer_signer
                     .as_ref()
-                    .or(session_channel_payer_signer.as_ref())
                     .map(|signer| signer.pubkey().to_string())
                     .unwrap_or_else(|| recipient.clone());
                 let (session_recipient, session_splits) =
-                    if settlement_authority == SettlementAuthority::Delegated {
+                    if voucher_signer == VoucherSigner::Operator {
                         delegated_session_channel_payout(
                             &recipient,
                             &session_operator,
@@ -1093,10 +991,6 @@ impl StartCommand {
                     } else {
                         (recipient.clone(), session_splits)
                     };
-                if client_voucher_pull && should_fund {
-                    ensure_surfpool_session_distribution_accounts(&rpc_url, &session_splits)
-                        .await?;
-                }
 
                 let (session_channel_store, durable_session_store) =
                     session_channel_store().await?;
@@ -1111,15 +1005,21 @@ impl StartCommand {
                         currency: session_mpp_currency.clone(),
                         decimals: *session_decimals,
                         network: network.slug().to_string(),
-                        max_cap: cap_base,
+                        // Per-unit price; the gate overrides it per challenge
+                        // from the endpoint's resolved metering price.
+                        amount: 1,
+                        suggested_deposit: Some(cap_base),
+                        minimum_deposit: None,
                         min_voucher_delta: sess.min_voucher_delta,
-                        settlement_authority,
-                        modes: modes.clone(),
-                        pull_voucher_strategy: sdk_pull_voucher_strategy.clone(),
+                        voucher_signer,
+                        operator_signing_key: None,
+                        idle_timeout_options_seconds: sess.idle_timeout_options_seconds.clone(),
+                        idle_timeout_seconds,
                         grace_period_seconds:
                             pay_kit::mpp::program::payment_channels::DEFAULT_GRACE_PERIOD_SECONDS,
                         rpc_url: Some(rpc_url.clone()),
-                        program_id: Some(channel_program_id),
+                        channel_program: Some(channel_program_id),
+                        token_program: None,
                     };
 
                     let mut smpp = SessionMpp::new_with_channel_store(
@@ -1128,13 +1028,9 @@ impl StartCommand {
                         Arc::clone(&session_channel_store),
                     )
                         .with_realm(api.title.clone())
-                        .with_pull_voucher_strategy(pull_voucher_strategy)
                         .with_blockhash_cache(blockhash_cache.clone());
                     if let Some(operator_signer) = fee_payer_signer.clone() {
                         smpp = smpp.with_payment_channel_signer(operator_signer);
-                    }
-                    if let Some(channel_payer_signer) = session_channel_payer_signer.clone() {
-                        smpp = smpp.with_payment_channel_payer_signer(channel_payer_signer);
                     }
 
                     let smpp = Arc::new(smpp);

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -8,10 +8,11 @@
 //!
 //! ```text
 //! 1. Server returns 402 with session challenge (intent="session")
-//! 2. Client creates a payment channel on-chain → gets channel_id + tx_sig
-//! 3. Client calls SessionHandle::new() and sends open_header() on first request
-//! 4. For each subsequent request: voucher_header(cost_per_request)
-//! 5. When done: close_header() triggers on-chain settlement
+//! 2. Client builds a challenge-bound open transaction and sends the `open`
+//!    action; the server verifies, broadcasts, and confirms it
+//! 3. Client-signed channels send voucher_header(cost) per request;
+//!    operator-signed channels send use_header() and the operator meters
+//! 4. When done: close_header() triggers on-chain settlement
 //! ```
 
 use std::sync::Arc;
@@ -19,8 +20,9 @@ use std::sync::Arc;
 use pay_kit::mpp::client::session::ActiveSession;
 use pay_kit::mpp::solana_keychain::SolanaSigner;
 use pay_kit::mpp::{
-    PaymentChallenge, PaymentCredential, SessionAction, SessionMode, SessionRequest,
-    format_authorization, parse_www_authenticate,
+    ClosePayload, PaymentChallenge, PaymentCredential, SessionAction, SessionAuthentication,
+    SessionAuthenticationType, SessionRequest, SessionVoucherSigner, SignedVoucher, UsePayload,
+    VoucherData, VoucherSignatureType, format_authorization, parse_www_authenticate,
 };
 use solana_pubkey::Pubkey;
 use tokio::sync::Mutex;
@@ -32,8 +34,8 @@ use crate::{Error, Result};
 pub use pay_kit::mpp::client::session::ActiveSession as RawSession;
 
 /// A live session: wraps an [`ActiveSession`] and the original challenge so
-/// voucher authorization headers can be produced without re-parsing the
-/// challenge on each call.
+/// authorization headers can be produced without re-parsing the challenge on
+/// each call.
 ///
 /// `SessionHandle` is `Clone` and `Send + Sync` — safe to share across async
 /// tasks (e.g., a middleware that reuses the same channel for all in-flight
@@ -43,9 +45,13 @@ pub struct SessionHandle {
     inner: Arc<Mutex<ActiveSession>>,
     /// Original challenge — echoed back in every `PaymentCredential`.
     challenge: PaymentChallenge,
-    /// Delegated sessions bind the operator, rather than the local ephemeral
-    /// voucher key, as the channel's on-chain authorized signer.
-    authorized_signer_override: Option<Pubkey>,
+    /// Reusable payer proof bound at open. Present for operator-signed
+    /// channels, where it authenticates `use` and `close` actions.
+    authentication: Option<SessionAuthentication>,
+    /// Client-mode ephemeral voucher key. Kept so `close_header` can sign an
+    /// equal-watermark voucher (close authentication without advancing
+    /// settlement) — [`ActiveSession`] only signs strictly increasing ones.
+    voucher_key: Option<ed25519_dalek::SigningKey>,
 }
 
 impl SessionHandle {
@@ -73,35 +79,37 @@ impl SessionHandle {
         signer: Box<dyn SolanaSigner>,
         challenge: PaymentChallenge,
     ) -> Self {
+        Self::from_active(ActiveSession::new(channel_id, signer), challenge)
+    }
+
+    /// Wrap an existing [`ActiveSession`] (e.g. one produced by the PayKit
+    /// session opener).
+    pub fn from_active(session: ActiveSession, challenge: PaymentChallenge) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(ActiveSession::new(channel_id, signer))),
+            inner: Arc::new(Mutex::new(session)),
             challenge,
-            authorized_signer_override: None,
+            authentication: None,
+            voucher_key: None,
         }
     }
 
-    fn with_authorized_signer(mut self, authorized_signer: Pubkey) -> Self {
-        self.authorized_signer_override = Some(authorized_signer);
+    /// Attach the reusable payer proof bound at open (operator-signed mode).
+    pub fn with_authentication(mut self, authentication: SessionAuthentication) -> Self {
+        self.authentication = Some(authentication);
         self
     }
 
-    /// Build an `Authorization` header for the `open` action.
-    ///
-    /// Send this on the **first** request after the on-chain open transaction
-    /// has been confirmed.
-    ///
-    /// * `deposit` — amount locked on-chain (base units, e.g. µUSDC)
-    /// * `open_tx_signature` — base58 Solana transaction signature
-    pub async fn open_header(&self, deposit: u64, open_tx_signature: &str) -> Result<String> {
-        let session = self.inner.lock().await;
-        let action = session.open_action(deposit, open_tx_signature);
-        build_header(&self.challenge, &action)
+    /// Retain the client-mode ephemeral voucher key so `close_header` can
+    /// authenticate a close without advancing settlement.
+    pub fn with_voucher_key(mut self, key: ed25519_dalek::SigningKey) -> Self {
+        self.voucher_key = Some(key);
+        self
     }
 
     /// Build an `Authorization` header carrying a voucher for `amount` base units.
     ///
     /// Increments the cumulative watermark by `amount`. Call this before every
-    /// metered API request (after the initial open).
+    /// metered API request on a client-signed channel.
     pub async fn voucher_header(&self, amount: u64) -> Result<String> {
         let mut session = self.inner.lock().await;
         let action = session
@@ -111,25 +119,82 @@ impl SessionHandle {
         build_header(&self.challenge, &action)
     }
 
+    /// Build an `Authorization` header for a metered request on an
+    /// operator-signed channel, presenting the reusable payer proof.
+    pub async fn use_header(&self) -> Result<String> {
+        let authentication = self.authentication.clone().ok_or_else(|| {
+            Error::Mpp("use requires the payer proof bound at open (operator mode)".to_string())
+        })?;
+        let session = self.inner.lock().await;
+        let action = SessionAction::Use(UsePayload {
+            channel_id: session.channel_id_str(),
+            authentication,
+        });
+        build_header(&self.challenge, &action)
+    }
+
     /// Build an `Authorization` header for cooperative channel close.
     ///
-    /// `final_increment` optionally adds a last voucher for any outstanding
-    /// balance before close. Pass `None` if the channel is already fully
-    /// settled.
+    /// Operator-signed channels authenticate with the bound payer proof and
+    /// never carry a voucher. Client-signed channels must always authenticate
+    /// with a final voucher: `final_increment` adds any outstanding balance,
+    /// while `None` (or zero) re-signs the current watermark, which
+    /// authenticates the close without advancing settlement.
     pub async fn close_header(&self, final_increment: Option<u64>) -> Result<String> {
         let mut session = self.inner.lock().await;
-        let action = session
-            .close_action(final_increment)
-            .await
-            .map_err(|e| Error::Mpp(format!("Failed to build close action: {e}")))?;
+        if let Some(authentication) = self.authentication.clone() {
+            let action = SessionAction::Close(ClosePayload {
+                channel_id: session.channel_id_str(),
+                authentication: Some(authentication),
+                voucher: None,
+            });
+            return build_header(&self.challenge, &action);
+        }
+        let action = match final_increment {
+            Some(increment) if increment > 0 => session
+                .close_action(Some(increment))
+                .await
+                .map_err(|e| Error::Mpp(format!("Failed to build close action: {e}")))?,
+            _ => SessionAction::Close(ClosePayload {
+                channel_id: session.channel_id_str(),
+                authentication: None,
+                voucher: Some(self.watermark_voucher(&session)?),
+            }),
+        };
         build_header(&self.challenge, &action)
+    }
+
+    /// Sign a voucher at the session's current cumulative watermark.
+    fn watermark_voucher(&self, session: &ActiveSession) -> Result<SignedVoucher> {
+        use ed25519_dalek::Signer;
+
+        let key = self.voucher_key.as_ref().ok_or_else(|| {
+            Error::Mpp(
+                "close without a final increment requires the session voucher key".to_string(),
+            )
+        })?;
+        let data = VoucherData {
+            channel_id: session.channel_id_str(),
+            cumulative_amount: session.cumulative.to_string(),
+            expires_at: Some(pay_kit::mpp::DEFAULT_SESSION_EXPIRES_AT),
+        };
+        let message = data
+            .message_bytes()
+            .map_err(|e| Error::Mpp(format!("Failed to encode close voucher: {e}")))?;
+        let signature = bs58::encode(key.sign(&message).to_bytes()).into_string();
+        Ok(SignedVoucher {
+            data,
+            signer: session.authorized_signer(),
+            signature,
+            signature_type: VoucherSignatureType::Ed25519,
+        })
     }
 
     /// Build an `Authorization` header for a payment-channel `open` action.
     ///
-    /// `open_slot` is the channel's on-chain open slot — a channel-PDA seed
-    /// since the epoch-addressed program update — and must match the slot the
-    /// open transaction was built for (the challenge's `recentSlot`).
+    /// `open_slot` must come from the challenge's `recentSlot` and
+    /// `transaction` must be the base64 open transaction built against the
+    /// challenge's `recentBlockhash` — the server rejects anything else.
     #[allow(clippy::too_many_arguments)]
     pub async fn open_payment_channel_header(
         &self,
@@ -142,38 +207,8 @@ impl SessionHandle {
         open_slot: u64,
         transaction: String,
     ) -> Result<String> {
-        self.open_payment_channel_header_with_mode(
-            SessionMode::Push,
-            deposit,
-            payer,
-            payee,
-            mint,
-            salt,
-            grace_period,
-            open_slot,
-            transaction,
-        )
-        .await
-    }
-
-    /// Build an `Authorization` header for a payment-channel `open` action
-    /// using an explicit submission mode.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn open_payment_channel_header_with_mode(
-        &self,
-        mode: SessionMode,
-        deposit: u64,
-        payer: &str,
-        payee: &str,
-        mint: &str,
-        salt: u64,
-        grace_period: u32,
-        open_slot: u64,
-        transaction: String,
-    ) -> Result<String> {
         let session = self.inner.lock().await;
-        let SessionAction::Open(payload) = session.open_payment_channel_action_with_mode(
-            mode,
+        let SessionAction::Open(mut payload) = session.open_payment_channel_action(
             deposit,
             payer,
             payee,
@@ -181,25 +216,22 @@ impl SessionHandle {
             salt,
             grace_period,
             open_slot,
-            "pending",
+            &transaction,
         ) else {
             unreachable!("open_payment_channel_action always returns SessionAction::Open")
         };
-        let mut payload = payload.with_transaction(transaction);
-        if let Some(authorized_signer) = self.authorized_signer_override {
-            payload.authorized_signer = authorized_signer.to_string();
-        }
+        payload.authentication = self.authentication.clone();
         build_header(&self.challenge, &SessionAction::Open(payload))
     }
 
     /// Build an `Authorization` header for a top-up after adding more funds
     /// on-chain.
     ///
-    /// * `new_deposit` — new total deposit after the top-up (base units)
-    /// * `topup_tx_signature` — base58 Solana transaction signature
-    pub async fn topup_header(&self, new_deposit: u64, topup_tx_signature: &str) -> Result<String> {
+    /// * `additional_amount` — amount added to the deposit (base units)
+    /// * `transaction` — base64 signed top-up transaction
+    pub async fn topup_header(&self, additional_amount: u64, transaction: &str) -> Result<String> {
         let session = self.inner.lock().await;
-        let action = session.topup_action(new_deposit, topup_tx_signature);
+        let action = session.topup_action(additional_amount, transaction);
         build_header(&self.challenge, &action)
     }
 
@@ -219,106 +251,38 @@ impl SessionHandle {
     }
 }
 
-// ── One-shot session pay ──────────────────────────────────────────────────────
+// ── Session open ─────────────────────────────────────────────────────────────
 
-/// Make a single API call through a session-gated endpoint.
+/// Open a payment-channel session from a 402 challenge.
 ///
-/// Creates an ephemeral keypair, opens a session with the given `deposit`
-/// (base units), sends the `open` action as the Authorization header, and
-/// returns the `Authorization` header value to use for the retry.
-///
-/// The server currently trusts the deposit without on-chain verification,
-/// so this works without a real payment channel for development/testing.
-pub fn open_session_header(
-    challenge: &PaymentChallenge,
-    deposit: u64,
-) -> Result<(SessionHandle, String)> {
-    use ed25519_dalek::SigningKey;
-    use pay_kit::mpp::solana_keychain::MemorySigner;
-    use solana_pubkey::Pubkey;
-
-    // Generate a fresh ephemeral session keypair.
-    let sk = SigningKey::generate(&mut rand::thread_rng());
-    let vk = sk.verifying_key();
-    let mut kp = [0u8; 64];
-    kp[..32].copy_from_slice(sk.as_bytes());
-    kp[32..].copy_from_slice(vk.as_bytes());
-    let signer: Box<dyn pay_kit::mpp::solana_keychain::SolanaSigner> =
-        Box::new(MemorySigner::from_bytes(&kp).map_err(|e| Error::Mpp(e.to_string()))?);
-
-    // Random channel ID — server stores it keyed by this string.
-    let channel_id = Pubkey::new_unique();
-
-    let handle = SessionHandle::new(channel_id, signer, challenge.clone());
-
-    // Build the open header (fake tx sig — server trusts it for now).
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| Error::Mpp(format!("Failed to build runtime: {e}")))?;
-    let auth_header = rt.block_on(handle.open_header(deposit, "demo_open_tx"))?;
-
-    Ok((handle, auth_header))
-}
-
-/// Open a payment-channel push session with a payer-signed transaction.
-///
-/// The transaction is signed by the payer and fee-payer/cosigned by the server
-/// when it processes the `open` action.
+/// Builds the open transaction against the challenge's `recentBlockhash` and
+/// `recentSlot`, prompts for spend authorization, and returns the handle plus
+/// the `Authorization` header for the retry. For operator-signed challenges
+/// (`voucherSigner: "operator"`) the payer also signs the reusable session
+/// proof bound to the opening challenge and derived channel.
 #[allow(clippy::too_many_arguments)]
 pub fn open_payment_channel_session_header(
     challenge: &PaymentChallenge,
-    request: &pay_kit::mpp::SessionRequest,
+    request: &SessionRequest,
     store: &dyn crate::accounts::AccountsStore,
     network_override: Option<&str>,
     account_override: Option<&str>,
     deposit: u64,
-    resource_url: &str,
-    sandbox: bool,
-) -> Result<(SessionHandle, String)> {
-    open_payment_channel_session_header_with_mode(
-        challenge,
-        request,
-        store,
-        network_override,
-        account_override,
-        deposit,
-        pay_kit::mpp::SessionMode::Push,
-        resource_url,
-        sandbox,
-    )
-}
-
-/// Open a payment-channel session in `submission_mode`.
-#[allow(clippy::too_many_arguments)]
-pub fn open_payment_channel_session_header_with_mode(
-    challenge: &PaymentChallenge,
-    request: &pay_kit::mpp::SessionRequest,
-    store: &dyn crate::accounts::AccountsStore,
-    network_override: Option<&str>,
-    account_override: Option<&str>,
-    deposit: u64,
-    submission_mode: pay_kit::mpp::SessionMode,
     resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
     use pay_kit::mpp::client::{
-        BuildOpenPaymentChannelTransactionParams, DerivePaymentChannelOpenParams,
-        PaymentChannelOpenOptions, build_open_payment_channel_transaction,
+        DerivePaymentChannelOpenParams, PaymentChannelOpenOptions,
+        PaymentChannelSessionOpenOptions, create_payment_channel_session_opener,
         derive_payment_channel_open,
     };
     use pay_kit::mpp::protocol::solana::default_rpc_url;
     use pay_kit::mpp::solana_keychain::MemorySigner;
-    use solana_hash::Hash;
-    use solana_pubkey::Pubkey;
-    use std::str::FromStr;
 
-    let network = network_override.map(str::to_string).unwrap_or_else(|| {
-        request
-            .network
-            .clone()
-            .unwrap_or_else(|| "mainnet".to_string())
-    });
+    let details = &request.method_details;
+    let network = network_override
+        .map(str::to_string)
+        .unwrap_or_else(|| details.network.clone());
     canonical_session_origin(resource_url)?;
     let prompt_context = crate::client::prompt::payment_prompt_context(None, &[Some(resource_url)]);
     let limit = session_spend_limit(deposit, request);
@@ -334,19 +298,6 @@ pub fn open_payment_channel_session_header_with_mode(
         &intent,
     )?;
     let payer = signer.pubkey();
-    let rpc_url =
-        std::env::var("PAY_RPC_URL").unwrap_or_else(|_| default_rpc_url(&network).to_string());
-
-    let fee_payer = Pubkey::from_str(&request.operator)
-        .map_err(|_| Error::Mpp(format!("invalid operator pubkey: {}", request.operator)))?;
-    let salt = rand::random::<u64>();
-    let grace_period = 900u32;
-    let open_options = PaymentChannelOpenOptions {
-        deposit: Some(deposit),
-        grace_period: Some(grace_period),
-        salt: Some(salt),
-        ..PaymentChannelOpenOptions::default()
-    };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -355,22 +306,16 @@ pub fn open_payment_channel_session_header_with_mode(
 
     if sandbox && ephemeral_notice.is_some() {
         let pubkey = payer.to_string();
-        let rpc = rpc_url.clone();
+        let rpc =
+            std::env::var("PAY_RPC_URL").unwrap_or_else(|_| default_rpc_url(&network).to_string());
         if let Err(e) = rt.block_on(crate::client::sandbox::fund_via_surfpool(&rpc, &pubkey)) {
             tracing::warn!(error = %e, "Surfpool auto-fund failed — USDC balance may be 0");
         }
     }
 
-    let recent_blockhash = if let Some(blockhash) = request.recent_blockhash.as_deref() {
-        Hash::from_str(blockhash)
-            .map_err(|e| Error::Mpp(format!("invalid recentBlockhash in challenge: {e}")))?
-    } else {
-        use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
-        RpcClient::new(rpc_url.clone())
-            .get_latest_blockhash()
-            .map_err(|e| Error::Mpp(format!("failed to get recent blockhash: {e}")))?
-    };
-
+    // Fresh ephemeral session keypair — the voucher signer for client-signed
+    // channels; unused for signing in operator mode but still generated so the
+    // handle can be constructed uniformly.
     let sk = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
     let vk = sk.verifying_key();
     let mut kp_bytes = [0u8; 64];
@@ -378,16 +323,37 @@ pub fn open_payment_channel_session_header_with_mode(
     kp_bytes[32..].copy_from_slice(vk.as_bytes());
     let session_signer: Box<dyn pay_kit::mpp::solana_keychain::SolanaSigner> =
         Box::new(MemorySigner::from_bytes(&kp_bytes).map_err(|e| Error::Mpp(e.to_string()))?);
-    let authorized_signer = match request.settlement_authority {
-        pay_kit::mpp::SessionSettlementAuthority::ClientVoucher => session_signer.pubkey(),
-        pay_kit::mpp::SessionSettlementAuthority::Delegated => fee_payer,
+
+    let voucher_signer = details
+        .voucher_signer
+        .unwrap_or(SessionVoucherSigner::Client);
+    let authorized_signer = match voucher_signer {
+        SessionVoucherSigner::Client => session_signer.pubkey(),
+        SessionVoucherSigner::Operator => {
+            let operator = details.operator.as_deref().ok_or_else(|| {
+                Error::Mpp("operator-signed session challenge is missing operator".to_string())
+            })?;
+            std::str::FromStr::from_str(operator)
+                .map_err(|_| Error::Mpp(format!("invalid session operator: {operator}")))?
+        }
         _ => {
             return Err(Error::Mpp(
-                "unsupported MPP session settlement authority".to_string(),
+                "unsupported MPP session voucher signer".to_string(),
             ));
         }
     };
 
+    let salt = rand::random::<u64>();
+    let open_options = PaymentChannelOpenOptions {
+        deposit: Some(deposit),
+        salt: Some(salt),
+        ..PaymentChannelOpenOptions::default()
+    };
+
+    // Derive the channel address up front: the operator-mode proof signs over
+    // (challengeId, channelId) and must exist before the opener builds the
+    // payload. The opener below re-derives the same channel from the same
+    // salt/deposit/challenge inputs.
     let open = derive_payment_channel_open(DerivePaymentChannelOpenParams {
         request,
         payer,
@@ -395,45 +361,55 @@ pub fn open_payment_channel_session_header_with_mode(
         options: open_options.clone(),
     })
     .map_err(|e| Error::Mpp(format!("derive_payment_channel_open: {e}")))?;
-    let payee = open.payee;
-    let mint = open.mint;
 
-    let open_tx = rt
-        .block_on(build_open_payment_channel_transaction(
-            BuildOpenPaymentChannelTransactionParams {
-                request,
-                signer: &signer,
-                authorized_signer,
-                fee_payer: Some(fee_payer),
-                recent_blockhash,
-                options: open_options,
+    let authentication = if voucher_signer == SessionVoucherSigner::Operator {
+        let mut proof = SessionAuthentication {
+            kind: SessionAuthenticationType::Proof,
+            challenge_id: challenge.id.clone(),
+            payer: payer.to_string(),
+            signature: String::new(),
+        };
+        let message = proof
+            .message_bytes(&open.channel_id.to_string())
+            .map_err(|e| Error::Mpp(format!("failed to encode session proof: {e}")))?;
+        let signature = rt
+            .block_on(signer.sign_message(&message))
+            .map_err(|e| Error::Mpp(format!("failed to sign session proof: {e}")))?;
+        proof.signature = bs58::encode(signature.as_ref()).into_string();
+        Some(proof)
+    } else {
+        None
+    };
+
+    let opened = rt
+        .block_on(create_payment_channel_session_opener(
+            request,
+            &signer,
+            session_signer,
+            None,
+            PaymentChannelSessionOpenOptions {
+                open: open_options,
+                cumulative: None,
+                expires_at: None,
+                authentication: authentication.clone(),
+                idle_timeout_seconds: None,
             },
         ))
-        .map_err(|e| Error::Mpp(format!("build_open_payment_channel_transaction: {e}")))?;
+        .map_err(|e| Error::Mpp(format!("create_payment_channel_session_opener: {e}")))?;
+    debug_assert_eq!(opened.open.channel_id, open.channel_id);
 
-    let handle = SessionHandle::new(open_tx.channel_id, session_signer, challenge.clone())
-        .with_authorized_signer(authorized_signer);
-    let auth_header = rt.block_on(handle.open_payment_channel_header_with_mode(
-        submission_mode.clone(),
-        deposit,
-        &payer.to_string(),
-        &payee.to_string(),
-        &mint.to_string(),
-        salt,
-        grace_period,
-        // The open slot is a channel-PDA seed since the epoch-addressed
-        // program update; use the same slot the open transaction was derived
-        // for (challenge `recentSlot`, resolved inside
-        // `derive_payment_channel_open`) so the server re-derives the same PDA.
-        open.open_slot,
-        open_tx.transaction,
-    ))?;
+    let auth_header = build_header(challenge, &opened.action)?;
+    let mut handle = SessionHandle::from_active(opened.session, challenge.clone());
+    handle = match authentication {
+        Some(authentication) => handle.with_authentication(authentication),
+        None => handle.with_voucher_key(sk),
+    };
 
     tracing::debug!(
         payer = %payer,
-        channel = %open_tx.channel_id,
+        channel = %open.channel_id,
         deposit,
-        mode = ?submission_mode,
+        voucher_signer = ?voucher_signer,
         "payment-channel session authorization header ready"
     );
 
@@ -510,31 +486,40 @@ fn build_header(challenge: &PaymentChallenge, action: &SessionAction) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pay_kit::mpp::{
-        Base64UrlJson, SessionMode, SessionPullVoucherStrategy, SessionSplit, parse_authorization,
-    };
+    use pay_kit::mpp::{Base64UrlJson, SessionMethodDetails, SessionSplit, parse_authorization};
 
     fn test_request() -> SessionRequest {
         SessionRequest {
-            cap: "1000000".to_string(),
+            amount: "25".to_string(),
             currency: solana_pubkey::Pubkey::new_unique().to_string(),
-            decimals: Some(6),
-            network: Some("localnet".to_string()),
-            operator: solana_pubkey::Pubkey::new_unique().to_string(),
             recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-            splits: vec![SessionSplit {
-                recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-                bps: 100,
-            }],
-            program_id: Some(solana_pubkey::Pubkey::new_unique().to_string()),
             description: Some("test session".to_string()),
             external_id: Some("ext-123".to_string()),
-            min_voucher_delta: Some("25".to_string()),
-            settlement_authority: pay_kit::mpp::SessionSettlementAuthority::ClientVoucher,
-            modes: vec![SessionMode::Push, SessionMode::Pull],
-            pull_voucher_strategy: Some(SessionPullVoucherStrategy::ClientVoucher),
-            recent_blockhash: None,
-            recent_slot: None,
+            minimum_deposit: Some("100".to_string()),
+            suggested_deposit: Some("1000000".to_string()),
+            unit_type: Some("request".to_string()),
+            method_details: SessionMethodDetails {
+                network: "localnet".to_string(),
+                channel_program: solana_pubkey::Pubkey::new_unique().to_string(),
+                channel_id: None,
+                recent_blockhash: Some(solana_hash::Hash::new_unique().to_string()),
+                recent_slot: Some(314),
+                decimals: Some(6),
+                token_program: None,
+                fee_payer: None,
+                fee_payer_key: None,
+                voucher_signer: Some(SessionVoucherSigner::Client),
+                operator: None,
+                min_voucher_delta: Some("25".to_string()),
+                ttl_seconds: None,
+                idle_timeout_options_seconds: None,
+                idle_timeout_seconds: None,
+                grace_period_seconds: Some(900),
+                distribution_splits: vec![SessionSplit {
+                    recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+                    share_bps: 100,
+                }],
+            },
         }
     }
 
@@ -549,7 +534,7 @@ mod tests {
         )
     }
 
-    fn test_signer() -> Box<dyn SolanaSigner> {
+    fn test_keypair() -> (ed25519_dalek::SigningKey, Box<dyn SolanaSigner>) {
         use ed25519_dalek::SigningKey;
         use pay_kit::mpp::solana_keychain::MemorySigner;
 
@@ -558,7 +543,11 @@ mod tests {
         let mut kp = [0u8; 64];
         kp[..32].copy_from_slice(sk.as_bytes());
         kp[32..].copy_from_slice(vk.as_bytes());
-        Box::new(MemorySigner::from_bytes(&kp).unwrap())
+        (sk.clone(), Box::new(MemorySigner::from_bytes(&kp).unwrap()))
+    }
+
+    fn test_signer() -> Box<dyn SolanaSigner> {
+        test_keypair().1
     }
 
     fn parse_action(header: &str) -> SessionAction {
@@ -575,7 +564,7 @@ mod tests {
             panic!("expected a session challenge");
         };
         assert_eq!(parsed_challenge.intent.as_str(), "session");
-        assert_eq!(request.cap, "1000000");
+        assert_eq!(request.suggested_deposit.as_deref(), Some("1000000"));
 
         let non_session = test_challenge("charge").to_header().unwrap();
         assert!(SessionHandle::parse_challenge(&non_session).is_none());
@@ -612,28 +601,14 @@ mod tests {
     fn spend_limit_displays_usd_amount() {
         let mut request = test_request();
         request.currency = "USDC".to_string();
-        request.decimals = Some(6);
         let limit = session_spend_limit(1_000_000, &request);
-        assert_eq!(limit.display, "$1.00");
-        assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
-    }
-
-    #[test]
-    fn spend_limit_uses_canonical_stablecoin_decimals() {
-        let mut request = test_request();
-        request.currency = "USDC".to_string();
-        request.decimals = Some(18);
-
-        let limit = session_spend_limit(1_000_000, &request);
-
         assert_eq!(limit.display, "$1.00");
         assert_eq!(limit.usd_amount.as_deref(), Some("$1.00"));
     }
 
     #[test]
     fn spend_limit_does_not_trust_unknown_asset_decimals() {
-        let mut request = test_request();
-        request.decimals = Some(u8::MAX);
+        let request = test_request();
 
         let limit = session_spend_limit(1_000_000, &request);
 
@@ -649,15 +624,32 @@ mod tests {
         let channel_id = Pubkey::new_unique();
         let channel_id_str = channel_id.to_string();
         let challenge = test_challenge("session");
-        let handle = SessionHandle::new(channel_id, test_signer(), challenge.clone());
+        let (voucher_key, signer) = test_keypair();
+        let handle =
+            SessionHandle::new(channel_id, signer, challenge.clone()).with_voucher_key(voucher_key);
 
-        let open = parse_action(&handle.open_header(1_000_000, "open_sig").await.unwrap());
+        let open = parse_action(
+            &handle
+                .open_payment_channel_header(
+                    1_000_000,
+                    &Pubkey::new_unique().to_string(),
+                    &Pubkey::new_unique().to_string(),
+                    &Pubkey::new_unique().to_string(),
+                    7,
+                    900,
+                    314,
+                    "AQAB".to_string(),
+                )
+                .await
+                .unwrap(),
+        );
         match open {
             SessionAction::Open(payload) => {
-                assert_eq!(payload.mode, SessionMode::Push);
-                assert_eq!(payload.channel_id.as_deref(), Some(channel_id_str.as_str()));
-                assert_eq!(payload.deposit.as_deref(), Some("1000000"));
-                assert_eq!(payload.signature, "open_sig");
+                assert_eq!(payload.channel_id, channel_id_str);
+                assert_eq!(payload.deposit_amount, "1000000");
+                assert_eq!(payload.open_slot, 314);
+                assert_eq!(payload.transaction, "AQAB");
+                assert!(payload.authentication.is_none());
             }
             _ => panic!("expected open action"),
         }
@@ -666,7 +658,7 @@ mod tests {
         match voucher {
             SessionAction::Voucher(payload) => {
                 assert_eq!(payload.voucher.data.channel_id, channel_id_str);
-                assert_eq!(payload.voucher.data.cumulative, "125");
+                assert_eq!(payload.voucher.data.cumulative_amount, "125");
             }
             _ => panic!("expected voucher action"),
         }
@@ -674,12 +666,12 @@ mod tests {
         assert_eq!(handle.channel_id().await, channel_id.to_string());
         assert_eq!(handle.challenge().intent, challenge.intent);
 
-        let topup = parse_action(&handle.topup_header(2_000_000, "topup_sig").await.unwrap());
+        let topup = parse_action(&handle.topup_header(2_000_000, "AQAB").await.unwrap());
         match topup {
             SessionAction::TopUp(payload) => {
                 assert_eq!(payload.channel_id, channel_id.to_string());
-                assert_eq!(payload.new_deposit, "2000000");
-                assert_eq!(payload.signature, "topup_sig");
+                assert_eq!(payload.additional_amount, "2000000");
+                assert_eq!(payload.transaction, "AQAB");
             }
             _ => panic!("expected topup action"),
         }
@@ -688,56 +680,53 @@ mod tests {
         match close {
             SessionAction::Close(payload) => {
                 let voucher = payload.voucher.expect("final voucher");
-                assert_eq!(voucher.data.cumulative, "150");
+                assert_eq!(voucher.data.cumulative_amount, "150");
             }
             _ => panic!("expected close action"),
         }
     }
 
     #[tokio::test]
-    async fn delegated_open_uses_operator_as_authorized_signer() {
-        let operator = Pubkey::new_unique();
-        let handle = SessionHandle::new(
-            Pubkey::new_unique(),
-            test_signer(),
-            test_challenge("session"),
-        )
-        .with_authorized_signer(operator);
-        let header = handle
-            .open_payment_channel_header_with_mode(
-                SessionMode::Push,
-                1_000_000,
-                &Pubkey::new_unique().to_string(),
-                &Pubkey::new_unique().to_string(),
-                &Pubkey::new_unique().to_string(),
-                7,
-                900,
-                42,
-                "transaction".to_string(),
-            )
-            .await
-            .unwrap();
+    async fn client_close_without_increment_signs_watermark_voucher() {
+        let channel_id = Pubkey::new_unique();
+        let challenge = test_challenge("session");
+        let (voucher_key, signer) = test_keypair();
+        let handle =
+            SessionHandle::new(channel_id, signer, challenge).with_voucher_key(voucher_key);
+        handle.voucher_header(100).await.unwrap();
 
-        let SessionAction::Open(payload) = parse_action(&header) else {
-            panic!("expected open action");
+        let close = parse_action(&handle.close_header(None).await.unwrap());
+        let SessionAction::Close(payload) = close else {
+            panic!("expected close action");
         };
-        assert_eq!(payload.authorized_signer, operator.to_string());
+        assert!(payload.authentication.is_none());
+        let voucher = payload.voucher.expect("watermark voucher");
+        assert_eq!(voucher.data.cumulative_amount, "100");
     }
 
-    #[test]
-    fn open_session_header_returns_parseable_header() {
+    #[tokio::test]
+    async fn operator_session_uses_bound_proof_for_use_and_close() {
+        let channel_id = Pubkey::new_unique();
         let challenge = test_challenge("session");
-        let (handle, header) = open_session_header(&challenge, 1_000_000).unwrap();
-        let action = parse_action(&header);
-        match action {
-            SessionAction::Open(payload) => {
-                assert_eq!(payload.mode, SessionMode::Push);
-                assert_eq!(payload.deposit.as_deref(), Some("1000000"));
-            }
-            _ => panic!("expected open action"),
-        }
-        let parsed = SessionHandle::parse_challenge(&challenge.to_header().unwrap()).unwrap();
-        assert_eq!(parsed.0.intent, handle.challenge().intent);
+        let payer = ed25519_dalek::SigningKey::generate(&mut rand::thread_rng());
+        let proof =
+            SessionAuthentication::sign(challenge.id.clone(), &channel_id.to_string(), &payer)
+                .unwrap();
+        let handle = SessionHandle::new(channel_id, test_signer(), challenge)
+            .with_authentication(proof.clone());
+
+        let SessionAction::Use(payload) = parse_action(&handle.use_header().await.unwrap()) else {
+            panic!("expected use action");
+        };
+        assert_eq!(payload.channel_id, channel_id.to_string());
+        assert_eq!(payload.authentication, proof);
+
+        let SessionAction::Close(payload) = parse_action(&handle.close_header(None).await.unwrap())
+        else {
+            panic!("expected close action");
+        };
+        assert!(payload.voucher.is_none());
+        assert_eq!(payload.authentication, Some(proof));
     }
 
     #[test]
@@ -751,7 +740,7 @@ mod tests {
         let action = parse_action(&sync);
         match action {
             SessionAction::Voucher(payload) => {
-                assert_eq!(payload.voucher.data.cumulative, "42");
+                assert_eq!(payload.voucher.data.cumulative_amount, "42");
             }
             _ => panic!("expected voucher action"),
         }

--- a/rust/crates/core/src/server/gate.rs
+++ b/rust/crates/core/src/server/gate.rs
@@ -569,7 +569,10 @@ impl<S: PaymentState> PaymentGate<S> {
 
         if accepted.contains(&Scheme::MppSession) && !session_mpps.is_empty() {
             for sm in session_mpps {
-                match sm.challenge_header(u64::MAX) {
+                let unit_amount = price.as_ref().map(|price| {
+                    crate::server::payment::price_unit_base_amount(price, sm.decimals())
+                });
+                match sm.challenge_header(unit_amount) {
                     Ok(h) => {
                         if let Ok(v) = HeaderValue::from_str(&h) {
                             challenge_headers.push((header::WWW_AUTHENTICATE, v));
@@ -1690,8 +1693,7 @@ async fn session_authorized(
 ) -> GateDecision {
     match sm.process(auth).await {
         Ok(SessionOutcome::Active { state, signature }) => {
-            if sm.settlement_authority() == pay_kit::mpp::SessionSettlementAuthority::ClientVoucher
-            {
+            if sm.voucher_signer() == pay_kit::mpp::SessionVoucherSigner::Client {
                 let mut response = GateResponse::json(
                     StatusCode::PAYMENT_REQUIRED,
                     serde_json::to_vec(&json!({
@@ -1803,10 +1805,6 @@ async fn session_authorized(
                 payment: None,
             }),
         },
-        Ok(SessionOutcome::Commit(receipt)) => GateDecision::Respond(GateResponse::json(
-            StatusCode::OK,
-            serde_json::to_vec(&receipt).unwrap_or_default(),
-        )),
         Ok(SessionOutcome::Closed { signature, .. }) => {
             let receipt_url = signature
                 .as_deref()

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -383,6 +383,17 @@ async fn settle_axum_delegated_response(
 /// resolved price; falls back to "0.01" when no price is configured. Shared
 /// by the 402-issuing and verify paths so the advertised and expected amounts
 /// always match.
+/// Resolved per-unit price in token base units — the session challenge's
+/// `amount` field (price per unit of service).
+pub(crate) fn price_unit_base_amount(price: &metering::ResolvedPrice, decimals: u8) -> u64 {
+    let per_unit = price
+        .dimensions
+        .first()
+        .map(|d| d.price_usd / d.scale.max(1) as f64)
+        .unwrap_or(0.01);
+    ((per_unit * 10f64.powi(i32::from(decimals))).round() as u64).max(1)
+}
+
 pub(crate) fn charge_amount_from_price(price: Option<&metering::ResolvedPrice>) -> String {
     price
         .and_then(|p| p.dimensions.first())

--- a/rust/crates/core/src/server/payment.rs
+++ b/rust/crates/core/src/server/payment.rs
@@ -379,12 +379,13 @@ async fn settle_axum_delegated_response(
     }
 }
 
-/// Per-unit charge amount (USD, as a decimal string) derived from the
-/// resolved price; falls back to "0.01" when no price is configured. Shared
-/// by the 402-issuing and verify paths so the advertised and expected amounts
-/// always match.
 /// Resolved per-unit price in token base units — the session challenge's
 /// `amount` field (price per unit of service).
+///
+/// Converts the USD price by decimal scaling alone, so it is only sound for
+/// USD-pegged settlement tokens (1 whole token == $1). Server startup
+/// enforces that invariant by refusing non-pegged session currencies
+/// (`ensure_session_currencies_usd_pegged` in the CLI server start path).
 pub(crate) fn price_unit_base_amount(price: &metering::ResolvedPrice, decimals: u8) -> u64 {
     let per_unit = price
         .dimensions
@@ -394,6 +395,10 @@ pub(crate) fn price_unit_base_amount(price: &metering::ResolvedPrice, decimals: 
     ((per_unit * 10f64.powi(i32::from(decimals))).round() as u64).max(1)
 }
 
+/// Per-unit charge amount (USD, as a decimal string) derived from the
+/// resolved price; falls back to "0.01" when no price is configured. Shared
+/// by the 402-issuing and verify paths so the advertised and expected amounts
+/// always match.
 pub(crate) fn charge_amount_from_price(price: Option<&metering::ResolvedPrice>) -> String {
     price
         .and_then(|p| p.dimensions.first())

--- a/rust/crates/core/src/server/proxy.rs
+++ b/rust/crates/core/src/server/proxy.rs
@@ -306,6 +306,7 @@ pub async fn prepare_upstream(
         Some(AuthConfig::Oauth2 {
             token_url,
             scopes,
+            audience,
             client_id_from_env,
             client_secret_from_env,
             headers,
@@ -313,6 +314,7 @@ pub async fn prepare_upstream(
             match oauth2_token(
                 token_url,
                 scopes,
+                audience.as_deref(),
                 client_id_from_env.as_deref(),
                 client_secret_from_env.as_deref(),
             )
@@ -1124,14 +1126,16 @@ struct FetchedToken {
     expires_in_secs: u64,
 }
 
-/// Cache key: one entry per distinct (token_url, scopes, client_id) tuple.
-/// The metadata server returns different tokens for different scope sets,
-/// and standard OAuth2 providers key tokens by client. Caching them all under
-/// a single slot would cause one upstream's token to evict another's.
+/// Cache key: one entry per distinct (token_url, scopes, audience, client_id)
+/// tuple. The metadata server returns different tokens for different scope
+/// sets (and different audiences in identity mode), and standard OAuth2
+/// providers key tokens by client. Caching them all under a single slot would
+/// cause one upstream's token to evict another's.
 #[derive(PartialEq, Eq, Hash)]
 struct TokenKey {
     token_url: String,
     scopes: Vec<String>,
+    audience: Option<String>,
     client_id: Option<String>,
 }
 
@@ -1146,12 +1150,14 @@ fn token_cache() -> &'static Arc<RwLock<HashMap<TokenKey, CachedToken>>> {
 async fn oauth2_token(
     token_url: &str,
     scopes: &[String],
+    audience: Option<&str>,
     client_id_env: Option<&str>,
     client_secret_env: Option<&str>,
 ) -> Result<String, String> {
     let key = TokenKey {
         token_url: token_url.to_string(),
         scopes: scopes.to_vec(),
+        audience: audience.map(str::to_string),
         client_id: client_id_env.and_then(|e| std::env::var(e).ok()),
     };
 
@@ -1166,7 +1172,14 @@ async fn oauth2_token(
         }
     }
 
-    let fetched = fetch_oauth2_token(token_url, scopes, client_id_env, client_secret_env).await?;
+    let fetched = fetch_oauth2_token(
+        token_url,
+        scopes,
+        audience,
+        client_id_env,
+        client_secret_env,
+    )
+    .await?;
 
     // Refresh 60s before the provider-reported expiry. Providers (especially
     // the GCP metadata server) may return a token that's already partially
@@ -1192,6 +1205,7 @@ async fn oauth2_token(
 async fn fetch_oauth2_token(
     token_url: &str,
     scopes: &[String],
+    audience: Option<&str>,
     client_id_env: Option<&str>,
     client_secret_env: Option<&str>,
 ) -> Result<FetchedToken, String> {
@@ -1200,6 +1214,12 @@ async fn fetch_oauth2_token(
     // Special: GCP metadata server.
     if token_url == "gcp_metadata" {
         return fetch_gcp_metadata_token(&client, scopes).await;
+    }
+    if token_url == "gcp_metadata_identity" {
+        let audience = audience.ok_or_else(|| {
+            "oauth2.audience is required for token_url `gcp_metadata_identity`".to_string()
+        })?;
+        return fetch_gcp_metadata_identity_token(&client, audience).await;
     }
 
     // Standard OAuth2 client_credentials grant.
@@ -1320,6 +1340,75 @@ async fn fetch_gcp_metadata_token(
         access_token,
         expires_in_secs,
     })
+}
+
+/// Fetch an audience-bound OIDC identity token from the GCP metadata server
+/// (Cloud Run / GCE), used to invoke IAM-protected services such as private
+/// Cloud Run. Unlike access tokens there is no ADC fallback: user credentials
+/// cannot mint audience-bound identity tokens.
+async fn fetch_gcp_metadata_identity_token(
+    client: &reqwest::Client,
+    audience: &str,
+) -> Result<FetchedToken, String> {
+    let resp = client
+        .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity")
+        .query(&[("audience", audience)])
+        .header("Metadata-Flavor", "Google")
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+        .map_err(|e| {
+            format!(
+                "GCP metadata server unreachable ({e}): identity tokens require running on GCP (Cloud Run/GCE); there is no ADC fallback"
+            )
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "GCP metadata identity endpoint returned {status}: {body}"
+        ));
+    }
+
+    let token = resp
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read identity token: {e}"))?;
+    let token = token.trim().to_string();
+
+    // The /identity endpoint returns a raw JWT with no expiry envelope —
+    // read the remaining lifetime from the token's own `exp` claim.
+    let exp = jwt_exp_claim(&token)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("System clock before UNIX epoch: {e}"))?
+        .as_secs();
+
+    tracing::debug!("OIDC identity token from GCP metadata server");
+    Ok(FetchedToken {
+        access_token: token,
+        expires_in_secs: exp.saturating_sub(now),
+    })
+}
+
+/// Extract the `exp` claim (unix seconds) from a JWT without verifying the
+/// signature — the token is opaque to us; only its remaining lifetime matters
+/// for the cache.
+fn jwt_exp_claim(jwt: &str) -> Result<u64, String> {
+    let mut segments = jwt.split('.');
+    let payload_b64 = match (segments.next(), segments.next(), segments.next()) {
+        (Some(_), Some(payload), Some(_)) => payload,
+        _ => return Err("identity token is not a JWT (expected 3 dot-separated segments)".into()),
+    };
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload_b64)
+        .map_err(|e| format!("identity token payload is not base64url: {e}"))?;
+    let claims: serde_json::Value = serde_json::from_slice(&payload)
+        .map_err(|e| format!("identity token payload is not JSON: {e}"))?;
+    claims["exp"]
+        .as_u64()
+        .ok_or_else(|| "identity token has no numeric `exp` claim".to_string())
 }
 
 #[cfg(test)]
@@ -2565,6 +2654,7 @@ mod tests {
                 auth: Some(Box::new(AuthConfig::Oauth2 {
                     token_url: "https://oauth.example.com/token".to_string(),
                     scopes: vec!["scope-a".to_string()],
+                    audience: None,
                     client_id_from_env: Some("_TEST_MISSING_CLIENT_ID".to_string()),
                     client_secret_from_env: Some("_TEST_MISSING_CLIENT_SECRET".to_string()),
                     headers: HashMap::new(),
@@ -2587,6 +2677,72 @@ mod tests {
                 .unwrap()
                 .contains("client_id env var not set")
         );
+    }
+
+    #[tokio::test]
+    async fn forward_request_oauth2_identity_without_audience_returns_bad_gateway() {
+        let api = ApiSpec {
+            routing: RoutingConfig::Proxy {
+                url: "https://api.example.com".to_string(),
+                path_rewrites: vec![],
+                auth: Some(Box::new(AuthConfig::Oauth2 {
+                    token_url: "gcp_metadata_identity".to_string(),
+                    scopes: vec![],
+                    audience: None,
+                    client_id_from_env: None,
+                    client_secret_from_env: None,
+                    headers: HashMap::new(),
+                })),
+            },
+            ..make_api("test")
+        };
+
+        let uri: Uri = "/v1/protected".parse().unwrap();
+        let result =
+            forward_request(&api, Method::GET, &uri, &HeaderMap::new(), Bytes::new()).await;
+
+        let err = result.unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(err.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["message"]
+                .as_str()
+                .unwrap()
+                .contains("oauth2.audience is required")
+        );
+    }
+
+    // ── jwt_exp_claim ────────────────────────────────────────────────────
+
+    fn make_jwt(payload: &serde_json::Value) -> String {
+        let encode = |bytes: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+        let header = encode(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let body = encode(payload.to_string().as_bytes());
+        format!("{header}.{body}.signature")
+    }
+
+    #[test]
+    fn jwt_exp_claim_reads_exp() {
+        let jwt = make_jwt(&serde_json::json!({
+            "aud": "https://svc-xyz.a.run.app",
+            "exp": 1_754_100_000u64,
+            "iat": 1_754_096_400u64,
+        }));
+        assert_eq!(jwt_exp_claim(&jwt).unwrap(), 1_754_100_000);
+    }
+
+    #[test]
+    fn jwt_exp_claim_rejects_non_jwt() {
+        let err = jwt_exp_claim("not-a-jwt").unwrap_err();
+        assert!(err.contains("3 dot-separated segments"), "got: {err}");
+    }
+
+    #[test]
+    fn jwt_exp_claim_rejects_missing_exp() {
+        let jwt = make_jwt(&serde_json::json!({"aud": "https://svc.example"}));
+        let err = jwt_exp_claim(&jwt).unwrap_err();
+        assert!(err.contains("no numeric `exp` claim"), "got: {err}");
     }
 
     // ── resolve_routing ──────────────────────────────────────────────────

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -41,6 +41,26 @@ use crate::{Error, Result};
 const INTENT: &str = "session";
 const METHOD: &str = "solana";
 const DEFAULT_REALM: &str = "MPP Session";
+
+/// Rejection message fragments for session errors that will never clear on
+/// retry: the channel, credential, or proof they name cannot become valid
+/// again without a fresh session. A payer proxy caching a `use` credential
+/// must treat any of these as proof the cached session is dead, not a
+/// transient store hiccup — pinned here so the two sides can't drift apart.
+pub mod terminal_errors {
+    /// The channel a cached credential names no longer exists in the store.
+    pub const UNKNOWN_CHANNEL: &str = "unknown session channel";
+    /// The credential's challenge echo does not verify against this server's
+    /// challenge-binding secret (forged, replayed, or for a different server).
+    pub const CHALLENGE_ECHO_MISMATCH: &str =
+        "session credential echoes a challenge this server did not issue";
+    /// A `use` action against a channel that isn't operator-signed.
+    pub const OPERATOR_ONLY: &str = "use is only valid for operator-signed sessions";
+    /// The channel predates reusable-proof binding; only re-opening fixes it.
+    pub const PREDATES_PROOF_BINDING: &str = "predates proof binding";
+    /// The bearer proof presented doesn't match what was bound at open.
+    pub const PROOF_MISMATCH: &str = "does not match the proof bound at open";
+}
 fn session_close_already_finalized(message: &str) -> bool {
     message.contains("already finalized")
 }
@@ -1458,7 +1478,7 @@ impl SessionMpp {
         };
         if !challenge.verify(&self.challenge_binding_secret) {
             return Err(Error::Mpp(
-                "session credential echoes a challenge this server did not issue".to_string(),
+                terminal_errors::CHALLENGE_ECHO_MISMATCH.to_string(),
             ));
         }
         echo.request
@@ -1690,9 +1710,7 @@ impl SessionMpp {
     /// service and persists the operator-signed cumulative voucher.
     async fn verify_use_authentication(&self, payload: &UsePayload) -> Result<ChannelState> {
         if self.voucher_signer() != SessionVoucherSigner::Operator {
-            return Err(Error::Mpp(
-                "use is only valid for operator-signed sessions".to_string(),
-            ));
+            return Err(Error::Mpp(terminal_errors::OPERATOR_ONLY.to_string()));
         }
         let state = self
             .operator_runtime
@@ -1706,7 +1724,11 @@ impl SessionMpp {
                 ))
             })?
             .ok_or_else(|| {
-                Error::PaymentRejected(format!("unknown session channel: {}", payload.channel_id))
+                Error::PaymentRejected(format!(
+                    "{}: {}",
+                    terminal_errors::UNKNOWN_CHANNEL,
+                    payload.channel_id
+                ))
             })?;
         if state.sealed || state.close_requested_at.is_some() {
             return Err(Error::PaymentRejected(
@@ -1718,9 +1740,10 @@ impl SessionMpp {
         // Name it so the client knows re-opening — not retrying the proof —
         // is the fix. Mirrors PayKit's process_use.
         if state.opening_challenge_id.is_empty() && state.authentication.is_none() {
-            return Err(Error::PaymentRejected(
-                "session channel predates proof binding; open a new session".to_string(),
-            ));
+            return Err(Error::PaymentRejected(format!(
+                "session channel {}; open a new session",
+                terminal_errors::PREDATES_PROOF_BINDING
+            )));
         }
         let bound = serde_json::to_string(&payload.authentication)
             .map_err(|error| Error::Mpp(format!("serialize authentication: {error}")))?;
@@ -1738,9 +1761,10 @@ impl SessionMpp {
                 .verify(&state.channel_id)
                 .map_err(|error| Error::Mpp(error.to_string()))?
         {
-            return Err(Error::PaymentRejected(
-                "use authentication does not match the proof bound at open".to_string(),
-            ));
+            return Err(Error::PaymentRejected(format!(
+                "use authentication {}",
+                terminal_errors::PROOF_MISMATCH
+            )));
         }
         Ok(state)
     }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -16,19 +16,19 @@
 //! Server records channel state; the client signs vouchers for that channel
 //! ```
 //!
-use pay_kit::mpp::blockhash::{BlockhashCache, CachedBlockhash};
-use pay_kit::mpp::server::session::{SealParams, SessionConfig, SessionServer};
+use pay_kit::mpp::blockhash::BlockhashCache;
+use pay_kit::mpp::server::session::{SealParams, SessionConfig, SessionOpenContext, SessionServer};
 use pay_kit::mpp::settlement::worker::{RpcBroadcaster, SettlementConfig, SettlementHandle, spawn};
 use pay_kit::mpp::solana_keychain::SolanaSigner;
 use pay_kit::mpp::store::{
     ChannelLifecycle, ChannelState, ChannelStore, MemoryChannelStore, StoreError,
 };
 use pay_kit::mpp::{
-    Base64UrlJson, CommitReceipt, OpenPayload, PaymentChallenge, SessionAction, SessionMode,
-    SessionPullVoucherStrategy, SessionSettlementAuthority, SignedVoucher, VoucherData,
-    VoucherPayload, parse_authorization,
+    Base64UrlJson, PaymentChallenge, SessionAction, SessionRequest, SessionVoucherSigner,
+    SignedVoucher, UsePayload, VoucherData, VoucherPayload, VoucherSignatureType,
+    parse_authorization,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -41,12 +41,11 @@ use crate::{Error, Result};
 const INTENT: &str = "session";
 const METHOD: &str = "solana";
 const DEFAULT_REALM: &str = "MPP Session";
-fn session_close_already_finalized(error: &pay_kit::mpp::Error) -> bool {
-    error.to_string().contains("already finalized")
+fn session_close_already_finalized(message: &str) -> bool {
+    message.contains("already finalized")
 }
 
-fn session_close_needs_reconciliation(error: &pay_kit::mpp::Error) -> bool {
-    let message = error.to_string();
+fn session_close_needs_reconciliation(message: &str) -> bool {
     message.contains("Close already requested") || message.contains("Channel is already sealed")
 }
 
@@ -63,8 +62,6 @@ pub enum SessionOutcome {
     },
     /// `voucher` accepted — channel id + new settled cumulative (base units).
     Voucher { channel_id: String, cumulative: u64 },
-    /// `commit` accepted — receipt for the metered delivery.
-    Commit(CommitReceipt),
     /// `close` accepted — `SealParams` carries what's needed to submit the
     /// on-chain settle+seal + distribute transactions.
     Closed {
@@ -224,9 +221,41 @@ impl SessionOperatorRuntime {
         Ok(())
     }
 
-    async fn operator_close_channel(&self, channel_id: &str) -> Result<SessionCloseResult> {
-        use pay_kit::mpp::ClosePayload;
+    /// Record a server-initiated close request on the channel state.
+    ///
+    /// The wire `close` action authenticates the caller (client voucher or
+    /// operator-bound payer proof), so idle close cannot go through
+    /// [`SessionServer::process_close`] — the server closes on its own
+    /// authority and seals at the highest accepted watermark.
+    async fn request_server_close(&self, channel_id: &str) -> Result<()> {
+        let now = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        self.channel_store
+            .update_channel(
+                channel_id,
+                Box::new(move |state| {
+                    let mut state = state
+                        .ok_or_else(|| StoreError::Internal("Channel not found".to_string()))?;
+                    if state.sealed {
+                        return Err(StoreError::Internal(
+                            "Channel is already sealed".to_string(),
+                        ));
+                    }
+                    if state.close_requested_at.is_some() {
+                        return Err(StoreError::Internal("Close already requested".to_string()));
+                    }
+                    state.close_requested_at = Some(now);
+                    Ok(state)
+                }),
+            )
+            .await
+            .map_err(|error| Error::Mpp(format!("Session auto-close failed: {error}")))?;
+        Ok(())
+    }
 
+    async fn operator_close_channel(&self, channel_id: &str) -> Result<SessionCloseResult> {
         if self.channel_is_tombstoned_on_chain(channel_id).await {
             self.server
                 .mark_sealed(channel_id)
@@ -235,24 +264,19 @@ impl SessionOperatorRuntime {
             return Ok(SessionCloseResult::AlreadyFinalized);
         }
 
-        let payload = ClosePayload {
-            channel_id: channel_id.to_string(),
-            voucher: None,
-        };
-        let params = match self.server.process_close(&payload).await {
-            Ok(params) => params,
-            Err(error) if session_close_already_finalized(&error) => {
+        match self.request_server_close(channel_id).await {
+            Ok(()) => {}
+            Err(error) if session_close_already_finalized(&error.to_string()) => {
                 return Ok(SessionCloseResult::AlreadyFinalized);
             }
-            Err(error) if session_close_needs_reconciliation(&error) => self
-                .server
-                .seal_params(channel_id)
-                .await
-                .map_err(|e| Error::Mpp(format!("Failed to get seal params: {e}")))?,
-            Err(error) => {
-                return Err(Error::Mpp(format!("Session auto-close failed: {error}")));
-            }
-        };
+            Err(error) if session_close_needs_reconciliation(&error.to_string()) => {}
+            Err(error) => return Err(error),
+        }
+        let params = self
+            .server
+            .seal_params(channel_id)
+            .await
+            .map_err(|e| Error::Mpp(format!("Failed to get seal params: {e}")))?;
 
         self.record_committed_watermark(params.channel_id.to_string(), params.settled);
         let settlement = self.submit_payment_channel_settlement(&params).await;
@@ -985,30 +1009,18 @@ enum SessionCloseResult {
 /// Holds a [`SessionServer`] backed by an in-memory channel store.  For
 /// production, swap `MemoryChannelStore` with a persistent backend.
 ///
-/// Payment-channel push sessions submit a client-signed transaction that the
-/// server validates and co-signs. Pull-mode delegation setup remains available
-/// for compatibility, but it no longer opens a synthetic channel.
+/// Payment-channel sessions submit a client-signed open transaction that
+/// PayKit verifies against the challenge, broadcasts, and confirms.
 pub struct SessionMpp {
     server: Arc<SessionServer<Arc<dyn ChannelStore>>>,
     session_config: SessionConfig,
     challenge_binding_secret: String,
     realm: String,
-    rpc_url: Option<String>,
-    blockhash_cache: Option<BlockhashCache>,
     payment_channel_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     payment_channel_payer_signer: Arc<Mutex<Option<Arc<dyn SolanaSigner>>>>,
     committed_watermarks: Arc<Mutex<HashMap<String, u64>>>,
-    pull_sessions: Arc<Mutex<HashSet<String>>>,
     lifecycle: SessionLifecycleHandle,
     operator_runtime: SessionOperatorRuntime,
-    pull_voucher_strategy: PullVoucherStrategy,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum PullVoucherStrategy {
-    #[default]
-    Disabled,
-    ClientVoucher,
 }
 
 impl SessionMpp {
@@ -1045,7 +1057,6 @@ impl SessionMpp {
         let reserved_capacity = Arc::new(Mutex::new(HashMap::new()));
         let delegated_voucher_lock = Arc::new(tokio::sync::Mutex::new(()));
         let settlement_signatures = Arc::new(Mutex::new(HashMap::new()));
-        let pull_sessions = Arc::new(Mutex::new(HashSet::new()));
         let operator_runtime = SessionOperatorRuntime {
             server: Arc::clone(&server),
             channel_store,
@@ -1067,8 +1078,6 @@ impl SessionMpp {
         }
 
         Self {
-            rpc_url: session_config.rpc_url.clone(),
-            blockhash_cache: None,
             server,
             session_config,
             challenge_binding_secret: challenge_binding_secret.into(),
@@ -1076,10 +1085,8 @@ impl SessionMpp {
             payment_channel_signer,
             payment_channel_payer_signer,
             committed_watermarks,
-            pull_sessions,
             lifecycle: SessionLifecycleHandle { tx },
             operator_runtime,
-            pull_voucher_strategy: PullVoucherStrategy::Disabled,
         }
     }
 
@@ -1088,16 +1095,24 @@ impl SessionMpp {
         self
     }
 
-    pub fn with_pull_voucher_strategy(mut self, strategy: PullVoucherStrategy) -> Self {
-        self.pull_voucher_strategy = strategy;
-        self
-    }
-
     /// Share the server's recent-blockhash cache with session challenge
     /// issuance so `recentBlockhash` and `recentSlot` come from the same
-    /// `getLatestBlockhash` observation.
+    /// `getLatestBlockhash` observation instead of a per-challenge RPC call.
+    ///
+    /// Rebuilds the inner [`SessionServer`] with the cache attached. The
+    /// lifecycle runloop keeps its handle to the original server; both wrap
+    /// the same channel store and config, and the cache only affects
+    /// challenge issuance, which always goes through `self.server`.
     pub fn with_blockhash_cache(mut self, cache: BlockhashCache) -> Self {
-        self.blockhash_cache = Some(cache);
+        let server = Arc::new(
+            SessionServer::new(
+                self.session_config.clone(),
+                Arc::clone(&self.operator_runtime.channel_store),
+            )
+            .with_blockhash_cache(cache),
+        );
+        self.server = Arc::clone(&server);
+        self.operator_runtime.server = server;
         self
     }
 
@@ -1199,14 +1214,14 @@ impl SessionMpp {
     }
 
     /// Who is authorized to sign cumulative settlement vouchers.
-    pub fn settlement_authority(&self) -> SessionSettlementAuthority {
-        self.session_config.settlement_authority
+    pub fn voucher_signer(&self) -> SessionVoucherSigner {
+        self.session_config.voucher_signer
     }
 
     /// Meter a successful response and persist an operator-signed cumulative
     /// voucher before releasing that response to the client.
     pub async fn authorize_delegated_usage(&self, channel_id: &str, amount: u64) -> Result<u64> {
-        if self.settlement_authority() != SessionSettlementAuthority::Delegated {
+        if self.voucher_signer() != SessionVoucherSigner::Operator {
             return Err(Error::Mpp(
                 "session does not delegate voucher authority to the operator".to_string(),
             ));
@@ -1251,9 +1266,8 @@ impl SessionMpp {
 
         let data = VoucherData {
             channel_id: channel_id.to_string(),
-            cumulative: cumulative.to_string(),
-            expires_at: pay_kit::mpp::DEFAULT_SESSION_EXPIRES_AT,
-            nonce: None,
+            cumulative_amount: cumulative.to_string(),
+            expires_at: Some(pay_kit::mpp::DEFAULT_SESSION_EXPIRES_AT),
         };
         let message = data
             .message_bytes()
@@ -1267,7 +1281,9 @@ impl SessionMpp {
             .verify_voucher(&VoucherPayload {
                 voucher: SignedVoucher {
                     data,
+                    signer: operator.to_string(),
                     signature: bs58::encode(signature.as_ref()).into_string(),
+                    signature_type: VoucherSignatureType::Ed25519,
                 },
             })
             .await
@@ -1336,14 +1352,6 @@ impl SessionMpp {
     /// Record channel activity so the lifecycle runloop can defer auto-close.
     pub async fn touch_channel(&self, channel_id: impl Into<String>) -> Result<()> {
         let channel_id = channel_id.into();
-        if self
-            .pull_sessions
-            .lock()
-            .map(|sessions| sessions.contains(&channel_id))
-            .unwrap_or(false)
-        {
-            return Ok(());
-        }
         if let Some(state) = self.lifecycle.touch(channel_id, unix_millis()).await?
             && (state.sealed || state.close_requested_at.is_some())
         {
@@ -1359,16 +1367,8 @@ impl SessionMpp {
     /// Redis round trip per response chunk while still extending long-lived
     /// requests.
     pub fn touch_channel_unconfirmed(&self, channel_id: impl Into<String>) {
-        let channel_id = channel_id.into();
-        if self
-            .pull_sessions
-            .lock()
-            .map(|sessions| sessions.contains(&channel_id))
-            .unwrap_or(false)
-        {
-            return;
-        }
-        self.lifecycle.touch_unconfirmed(channel_id, unix_millis());
+        self.lifecycle
+            .touch_unconfirmed(channel_id.into(), unix_millis());
     }
 
     /// Latest cumulative watermark accepted by this process for a session.
@@ -1387,26 +1387,18 @@ impl SessionMpp {
         self.operator_runtime.settlement_signature(channel_id)
     }
 
-    /// Build a [`PaymentChallenge`] for a new session with the given cap.
-    pub fn challenge(&self, cap: u64) -> Result<PaymentChallenge> {
-        let mut request = self.server.build_challenge_request(cap);
-        match self.pull_voucher_strategy {
-            PullVoucherStrategy::Disabled => {
-                request.modes.retain(|mode| mode != &SessionMode::Pull);
-                request.pull_voucher_strategy = None;
-            }
-            PullVoucherStrategy::ClientVoucher => {
-                if request.modes.contains(&SessionMode::Pull) {
-                    request.pull_voucher_strategy = Some(SessionPullVoucherStrategy::ClientVoucher);
-                }
-            }
-        }
-        if request.modes == [SessionMode::Push] {
-            request.modes.clear();
-        }
-        if let Some(hint) = self.prefetch_latest_blockhash_hint() {
-            request.recent_blockhash = Some(hint.blockhash);
-            request.recent_slot = Some(hint.slot);
+    /// Build a [`PaymentChallenge`] for a new session.
+    ///
+    /// `amount` overrides the advertised per-unit price (base units) when the
+    /// gate resolved an endpoint-specific price; `None` keeps the configured
+    /// default.
+    pub fn challenge(&self, amount: Option<u64>) -> Result<PaymentChallenge> {
+        let mut request = self
+            .server
+            .build_challenge_request()
+            .map_err(|e| Error::Mpp(format!("Failed to build session challenge: {e}")))?;
+        if let Some(amount) = amount {
+            request.amount = amount.to_string();
         }
         let encoded = Base64UrlJson::from_typed(&request)
             .map_err(|e| Error::Mpp(format!("Failed to encode session request: {e}")))?;
@@ -1420,10 +1412,41 @@ impl SessionMpp {
     }
 
     /// Format a session challenge as a `WWW-Authenticate` header value.
-    pub fn challenge_header(&self, cap: u64) -> Result<String> {
-        self.challenge(cap)?
+    pub fn challenge_header(&self, amount: Option<u64>) -> Result<String> {
+        self.challenge(amount)?
             .to_header()
             .map_err(|e| Error::Mpp(format!("Failed to format session challenge: {e}")))
+    }
+
+    /// Verify that the credential's echoed challenge was minted by this
+    /// server (HMAC challenge binding) and decode its session request.
+    ///
+    /// Opens are bound to the challenged `recentBlockhash`/`recentSlot`, so
+    /// the echo must be authenticated before any of its fields are trusted.
+    fn verify_challenge_echo(
+        &self,
+        credential: &pay_kit::mpp::PaymentCredential,
+    ) -> Result<SessionRequest> {
+        let echo = &credential.challenge;
+        let challenge = PaymentChallenge {
+            id: echo.id.clone(),
+            realm: echo.realm.clone(),
+            method: echo.method.clone(),
+            intent: echo.intent.clone(),
+            request: echo.request.clone(),
+            expires: echo.expires.clone(),
+            description: None,
+            digest: echo.digest.clone(),
+            opaque: echo.opaque.clone(),
+        };
+        if !challenge.verify(&self.challenge_binding_secret) {
+            return Err(Error::Mpp(
+                "session credential echoes a challenge this server did not issue".to_string(),
+            ));
+        }
+        echo.request
+            .decode()
+            .map_err(|e| Error::Mpp(format!("Invalid session challenge request: {e}")))
     }
 
     /// Process an `Authorization` header containing a [`SessionAction`].
@@ -1443,121 +1466,69 @@ impl SessionMpp {
             )));
         }
 
+        // Every credential echoes the challenge it answers; authenticate the
+        // echo before trusting any of its fields (opens are bound to the
+        // challenged `recentBlockhash`/`recentSlot`).
+        let request = self.verify_challenge_echo(&credential)?;
+
         let action: SessionAction = serde_json::from_value(credential.payload)
             .map_err(|e| Error::Mpp(format!("Unrecognized session action payload: {e}")))?;
 
         match &action {
             SessionAction::Open(p) => {
-                let client_voucher_pull = p.mode == SessionMode::Pull
-                    && self.pull_voucher_strategy == PullVoucherStrategy::ClientVoucher;
-                if p.mode == SessionMode::Pull {
-                    self.process_pull_open(p).await?;
-                }
-
-                let mut submitted_open = None;
-                let open_payload;
-                let submit_client_transaction =
-                    p.transaction.is_some() && (p.mode == SessionMode::Push || client_voucher_pull);
-                let payload_for_open = if submit_client_transaction || client_voucher_pull {
-                    let signature = if p.transaction.is_some() {
-                        self.submit_payment_channel_open(p).await?.ok_or_else(|| {
-                            Error::Mpp(
-                                "client-voucher pull open transaction was not submitted"
-                                    .to_string(),
-                            )
-                        })?
-                    } else {
-                        self.submit_server_payment_channel_open(p).await?
-                    };
-                    open_payload = {
-                        let mut payload = p.clone();
-                        payload.signature = signature.clone();
-                        payload
-                    };
-                    submitted_open = Some(signature);
-                    &open_payload
-                } else {
-                    p
+                let details = &request.method_details;
+                let recent_blockhash = details.recent_blockhash.as_deref().ok_or_else(|| {
+                    Error::Mpp(
+                        "session open echoes a challenge without recentBlockhash".to_string(),
+                    )
+                })?;
+                let recent_slot = details.recent_slot.ok_or_else(|| {
+                    Error::Mpp("session open echoes a challenge without recentSlot".to_string())
+                })?;
+                let context = SessionOpenContext {
+                    challenge_id: &credential.challenge.id,
+                    expires: credential.challenge.expires.as_deref(),
+                    recent_blockhash,
+                    recent_slot,
                 };
 
-                // A replayed transaction signature can remain confirmed long
-                // after its channel account has been reclaimed. Solana RPC may
-                // return "already processed" on re-submission, and signature
-                // confirmation alone cannot distinguish that stale replay
-                // from a newly landed open. Before creating durable state,
-                // require the channel itself to exist at confirmed commitment.
-                //
-                // Keep absence and RPC failure distinct: `Ok(None)` is a stale
-                // open, while `Err` is propagated so an unavailable RPC can
-                // never cause Redis state to be created or deleted.
-                let payment_channel_open = p.mode == SessionMode::Push || client_voucher_pull;
-                let (account_confirmed, client_id) = if let (true, Some(rpc_url)) =
-                    (payment_channel_open, self.rpc_url.as_deref())
-                {
-                    let client_id = self
-                        .payment_channel_open_params(payload_for_open)?
-                        .payer
-                        .to_string();
-                    let signature = payload_for_open.signature.as_str();
-                    let channel_id = payload_for_open
-                        .session_id()
-                        .map_err(|e| Error::Mpp(format!("Invalid session channel: {e}")))?;
-                    wait_for_transaction_confirmed(rpc_url, signature, "payment-channel open")
-                        .await?;
-                    if self
-                        .operator_runtime
-                        .fetch_payment_channel(channel_id)
-                        .await?
-                        .is_none()
-                    {
-                        return Err(Error::Mpp(format!(
-                            "payment-channel open transaction is confirmed, but channel {channel_id} is absent on-chain"
-                        )));
-                    }
-                    (true, Some(client_id))
-                } else {
-                    (false, None)
-                };
-
-                // The host has independently validated, co-signed, submitted,
-                // and observed a successful status for transactions it
-                // broadcasts. Persist those opens without asking a second RPC
-                // client to rediscover the same signature. Opens received by
-                // any other integration retain PayKit's standard verification.
-                let acceptance = if submitted_open.is_some() {
-                    self.server
-                        .process_preverified_open_with_outcome(payload_for_open)
-                        .await
-                } else {
-                    self.server
-                        .process_open_with_outcome(payload_for_open)
-                        .await
-                }
-                .map_err(|e| Error::Mpp(format!("Session open failed: {e}")))?;
+                // PayKit verifies the exact open instruction against the
+                // challenge, requires the challenged blockhash, broadcasts,
+                // and confirms the resulting channel account before creating
+                // durable state; a replayed open is an idempotent no-op.
+                let acceptance = self
+                    .server
+                    .process_open_with_outcome(p, context)
+                    .await
+                    .map_err(|e| Error::Mpp(format!("Session open failed: {e}")))?;
                 let state = acceptance.state;
+                let signature = open_transaction_signature(&p.transaction);
 
-                if !acceptance.replay
-                    && account_confirmed
-                    && let Some(client_id) = client_id.as_deref()
-                {
+                if !acceptance.replay {
                     telemetry::record_payment_channel_opened(
-                        &payload_for_open.signature,
-                        &state.channel_id.to_string(),
-                        client_id,
+                        signature.as_deref().unwrap_or_default(),
+                        &state.channel_id,
+                        &p.payer,
                         self.currency(),
                         self.network(),
                         state.deposit,
                     );
                 }
 
-                if p.mode == SessionMode::Pull && !client_voucher_pull {
-                    self.record_pull_session(state.channel_id.clone());
-                }
+                self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
+                self.touch_channel(state.channel_id.clone()).await?;
+                Ok(SessionOutcome::Active { state, signature })
+            }
+
+            SessionAction::Use(p) => {
+                let state = self
+                    .verify_use_authentication(p, &credential.challenge.id)
+                    .await?;
                 self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
                 self.touch_channel(state.channel_id.clone()).await?;
                 Ok(SessionOutcome::Active {
                     state,
-                    signature: Some(payload_for_open.signature.clone()),
+                    signature: None,
                 })
             }
 
@@ -1583,25 +1554,6 @@ impl SessionMpp {
                 })
             }
 
-            SessionAction::Commit(p) => {
-                let receipt = self
-                    .server
-                    .process_commit(p)
-                    .await
-                    .map_err(|e| Error::PaymentRejected(e.to_string()))?;
-                if let Ok(cumulative) = receipt.cumulative.parse::<u64>() {
-                    telemetry::record_payment_channel_voucher_cumulative(
-                        &receipt.session_id,
-                        self.currency(),
-                        self.network(),
-                        cumulative,
-                    );
-                    self.record_committed_watermark(receipt.session_id.clone(), cumulative);
-                }
-                self.touch_channel(receipt.session_id.clone()).await?;
-                Ok(SessionOutcome::Commit(receipt))
-            }
-
             SessionAction::TopUp(p) => {
                 let state = self
                     .server
@@ -1610,10 +1562,8 @@ impl SessionMpp {
                     .map_err(|e| Error::Mpp(format!("TopUp failed: {e}")))?;
                 self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
                 self.touch_channel(state.channel_id.clone()).await?;
-                Ok(SessionOutcome::Active {
-                    state,
-                    signature: Some(p.signature.clone()),
-                })
+                let signature = open_transaction_signature(&p.transaction);
+                Ok(SessionOutcome::Active { state, signature })
             }
 
             SessionAction::Close(p) => {
@@ -1628,7 +1578,7 @@ impl SessionMpp {
                     })?;
                 let params = match self.server.process_close(p).await {
                     Ok(params) => params,
-                    Err(error) if session_close_needs_reconciliation(&error) => self
+                    Err(error) if session_close_needs_reconciliation(&error.to_string()) => self
                         .server
                         .seal_params(&p.channel_id)
                         .await
@@ -1717,113 +1667,58 @@ impl SessionMpp {
             .record_committed_watermark(session_id, cumulative);
     }
 
-    fn record_pull_session(&self, session_id: impl Into<String>) {
-        if let Ok(mut sessions) = self.pull_sessions.lock() {
-            sessions.insert(session_id.into());
-        }
-    }
-
-    /// Validate and prepare a pull-mode open.
-    async fn process_pull_open(&self, payload: &OpenPayload) -> Result<()> {
-        match self.pull_voucher_strategy {
-            PullVoucherStrategy::Disabled => Err(Error::Mpp(
-                "pull-mode sessions are disabled; use push or configure pull_voucher_strategy"
-                    .to_string(),
-            )),
-            PullVoucherStrategy::ClientVoucher => self.validate_client_voucher_pull_open(payload),
-        }
-    }
-
-    fn validate_client_voucher_pull_open(&self, payload: &OpenPayload) -> Result<()> {
-        if payload.channel_id.is_none() || payload.deposit.is_none() {
+    /// Verify a `use` action's reusable payer proof against the channel
+    /// state bound at open.
+    ///
+    /// Authenticates the request only — metering happens response-side via
+    /// [`Self::authorize_delegated_usage`], which prices the delivered
+    /// service and persists the operator-signed cumulative voucher.
+    async fn verify_use_authentication(
+        &self,
+        payload: &UsePayload,
+        echoed_challenge_id: &str,
+    ) -> Result<ChannelState> {
+        if self.voucher_signer() != SessionVoucherSigner::Operator {
             return Err(Error::Mpp(
-                "client-voucher pull sessions require payment-channel channelId and deposit"
-                    .to_string(),
+                "use is only valid for operator-signed sessions".to_string(),
             ));
         }
-        if payload.token_account.is_some() || payload.approved_amount.is_some() {
-            return Err(Error::Mpp(
-                "token-account delegation pull sessions are no longer supported; use client-voucher payment channels"
-                    .to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    async fn submit_payment_channel_open(&self, payload: &OpenPayload) -> Result<Option<String>> {
-        let Some(transaction) = payload.transaction.as_deref() else {
-            return Ok(None);
-        };
-        // The client builds the open with `fee_payer = challenge.operator`, which
-        // is the channel payer (a dedicated, funded signer in sandbox; the main
-        // settlement signer otherwise). Co-sign and validate against *that* payer
-        // — not the settlement signer, which may differ from the advertised
-        // operator and would trip the fee-payer check.
-        let signer = self
+        let state = self
             .operator_runtime
-            .payment_channel_payer_signer()
-            .ok_or_else(|| {
-                Error::Mpp(
-                    "payment-channel open transaction requires an operator signer".to_string(),
-                )
-            })?;
-        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
-            Error::Mpp("payment-channel open transaction requires an RPC URL".to_string())
-        })?;
-
-        let mut tx = decode_base64_transaction(transaction)?;
-        let expected = self.expected_payment_channel_open_instruction(payload)?;
-        let operator = signer.pubkey();
-        validate_payment_channel_open_transaction(&tx, &expected, &operator)?;
-
-        // Co-sign the operator's fee-payer slot via the shared payment-channels
-        // helper (handles both legacy and v0 transactions), then broadcast.
-        pay_kit::mpp::program::payment_channels::cosign_fee_payer(
-            signer.as_ref(),
-            &operator,
-            &mut tx,
-        )
-        .await
-        .map_err(|e| Error::Mpp(e.to_string()))?;
-
-        submit_versioned_transaction(rpc_url, tx, "payment-channel open")
+            .channel_store
+            .get_channel(&payload.channel_id)
             .await
-            .map(Some)
-    }
-
-    async fn submit_server_payment_channel_open(&self, payload: &OpenPayload) -> Result<String> {
-        let signer = self
-            .operator_runtime
-            .payment_channel_payer_signer()
+            .map_err(|error| {
+                Error::Mpp(format!(
+                    "failed to read session channel {}: {error}",
+                    payload.channel_id
+                ))
+            })?
             .ok_or_else(|| {
-                Error::Mpp("server-opened payment channel requires an operator signer".to_string())
+                Error::PaymentRejected(format!("unknown session channel: {}", payload.channel_id))
             })?;
-        let rpc_url = self.rpc_url.clone().ok_or_else(|| {
-            Error::Mpp("server-opened payment channel requires an RPC URL".to_string())
-        })?;
-        let params = self.payment_channel_open_params(payload)?;
-        let fee_payer = signer.pubkey();
-        if params.payer != fee_payer {
-            return Err(Error::Mpp(
-                "server-opened payment-channel payer must match operator signer".to_string(),
+        if state.sealed || state.close_requested_at.is_some() {
+            return Err(Error::PaymentRejected(
+                "payment channel close is pending".to_string(),
             ));
         }
-
-        let instruction = pay_kit::mpp::program::payment_channels::build_open_instruction(&params);
-        let blockhash = fetch_latest_blockhash(&rpc_url)?;
-        let message = solana_message::Message::new_with_blockhash(
-            &[instruction],
-            Some(&fee_payer),
-            &blockhash,
-        );
-        let mut tx = solana_transaction::Transaction::new_unsigned(message);
-        sign_and_submit_transaction(
-            Arc::clone(&signer),
-            rpc_url,
-            &mut tx,
-            "payment-channel open",
-        )
-        .await
+        let bound = serde_json::to_string(&payload.authentication)
+            .map_err(|error| Error::Mpp(format!("serialize authentication: {error}")))?;
+        let proof = &payload.authentication;
+        if state.voucher_signer != "operator"
+            || state.authentication.as_deref() != Some(bound.as_str())
+            || proof.challenge_id != state.opening_challenge_id
+            || echoed_challenge_id != state.opening_challenge_id
+            || proof.payer != state.payer
+            || !proof
+                .verify(&state.channel_id)
+                .map_err(|error| Error::Mpp(error.to_string()))?
+        {
+            return Err(Error::PaymentRejected(
+                "use authentication does not match the proof bound at open".to_string(),
+            ));
+        }
+        Ok(state)
     }
 
     async fn submit_payment_channel_settlement(
@@ -1834,43 +1729,59 @@ impl SessionMpp {
             .submit_payment_channel_settlement(params)
             .await
     }
+}
 
-    fn expected_payment_channel_open_instruction(
-        &self,
-        payload: &OpenPayload,
-    ) -> Result<solana_instruction::Instruction> {
-        self.server
-            .payment_channel_open_instruction(payload)
-            .map_err(|e| Error::Mpp(e.to_string()))
+/// Build confirmed channel state for tests, bypassing the on-chain open path
+/// (transaction verification, broadcast, and confirmation are PayKit's and
+/// are exercised end-to-end by the surfpool tests). Seed it through the
+/// [`ChannelStore`] handed to [`SessionMpp::new_with_channel_store`].
+#[doc(hidden)]
+pub fn test_channel_state(
+    channel_id: impl Into<String>,
+    deposit: u64,
+    authorized_signer: impl Into<String>,
+    voucher_signer: &str,
+    opening_challenge_id: impl Into<String>,
+    payer: impl Into<String>,
+    authentication: Option<String>,
+) -> ChannelState {
+    let payer = payer.into();
+    ChannelState {
+        channel_id: channel_id.into(),
+        authorized_signer: authorized_signer.into(),
+        deposit,
+        cumulative: 0,
+        sealed: false,
+        highest_voucher_signature: None,
+        highest_voucher_expires_at: None,
+        close_requested_at: None,
+        open_slot: Some(42),
+        rent_payer: payer.clone(),
+        payer,
+        opening_challenge_id: opening_challenge_id.into(),
+        authentication,
+        voucher_signer: voucher_signer.to_string(),
+        idle_timeout_seconds: Some(300),
+        last_activity_at: unix_millis(),
+        spent_amount: 0,
+        settled_on_chain: 0,
+        processed_uses: vec![],
+        next_delivery_sequence: 0,
+        pending_deliveries: vec![],
+        committed_deliveries: vec![],
+        lifecycle: None,
     }
+}
 
-    fn payment_channel_open_params(
-        &self,
-        payload: &OpenPayload,
-    ) -> Result<pay_kit::mpp::program::payment_channels::OpenChannelParams> {
-        self.server
-            .payment_channel_open_params(payload)
-            .map_err(|e| Error::Mpp(e.to_string()))
-    }
-
-    /// Best-effort prefetch of the latest blockhash + slot for session
-    /// challenges.
-    fn prefetch_latest_blockhash_hint(&self) -> Option<CachedBlockhash> {
-        use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
-
-        if let Some(cached) = self.blockhash_cache.as_ref().and_then(BlockhashCache::get) {
-            return Some(cached);
-        }
-        let rpc_url = self.rpc_url.as_ref()?;
-        let rpc = RpcClient::new(rpc_url.clone());
-        match pay_kit::mpp::blockhash::fetch_blockhash_with_slot(&rpc, rpc.commitment()) {
-            Ok(hint) => Some(hint),
-            Err(error) => {
-                tracing::debug!(rpc_url, %error, "failed to prefetch session blockhash hint");
-                None
-            }
-        }
-    }
+/// Base58 transaction signature of a client-submitted base64 transaction —
+/// used as the receipt reference for opens and top-ups (the fee payer's
+/// signature in slot 0 is the transaction id).
+fn open_transaction_signature(tx_base64: &str) -> Option<String> {
+    decode_base64_transaction(tx_base64)
+        .ok()?
+        .signatures
+        .first()
+        .map(|signature| signature.to_string())
 }
 
 fn spl_token_program() -> solana_pubkey::Pubkey {
@@ -1896,146 +1807,6 @@ fn decode_voucher_signature(signature: &str) -> Result<[u8; 64]> {
     bytes
         .try_into()
         .map_err(|_| Error::Mpp("voucher signature is not 64 bytes".to_string()))
-}
-
-fn transaction_contains_instruction(
-    tx: &solana_transaction::versioned::VersionedTransaction,
-    expected: &solana_instruction::Instruction,
-) -> bool {
-    let keys = tx.message.static_account_keys();
-    tx.message.instructions().iter().any(|compiled| {
-        let Some(program_id) = keys.get(compiled.program_id_index as usize) else {
-            return false;
-        };
-        if program_id != &expected.program_id || compiled.data != expected.data {
-            return false;
-        }
-
-        let accounts = compiled
-            .accounts
-            .iter()
-            .filter_map(|index| keys.get(*index as usize).copied())
-            .collect::<Vec<_>>();
-        let expected_accounts = expected
-            .accounts
-            .iter()
-            .map(|account| account.pubkey)
-            .collect::<Vec<_>>();
-        accounts == expected_accounts
-    })
-}
-
-fn validate_payment_channel_open_transaction(
-    tx: &solana_transaction::versioned::VersionedTransaction,
-    expected: &solana_instruction::Instruction,
-    fee_payer: &solana_pubkey::Pubkey,
-) -> Result<()> {
-    if tx.message.static_account_keys().first() != Some(fee_payer) {
-        return Err(Error::Mpp(
-            "payment-channel open transaction fee payer does not match operator".to_string(),
-        ));
-    }
-
-    if tx.message.instructions().len() != 1 {
-        return Err(Error::Mpp(
-            "payment-channel open transaction must contain exactly one instruction".to_string(),
-        ));
-    }
-
-    if !transaction_contains_instruction(tx, expected) {
-        return Err(Error::Mpp(
-            "payment-channel open transaction does not match the session challenge".to_string(),
-        ));
-    }
-
-    Ok(())
-}
-
-fn fetch_latest_blockhash(rpc_url: &str) -> Result<solana_hash::Hash> {
-    use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
-
-    RpcClient::new(rpc_url.to_string())
-        .get_latest_blockhash()
-        .map_err(|e| Error::Mpp(format!("failed to fetch latest blockhash: {e}")))
-}
-
-async fn sign_and_submit_transaction(
-    signer: Arc<dyn SolanaSigner>,
-    rpc_url: String,
-    tx: &mut solana_transaction::Transaction,
-    context: &'static str,
-) -> Result<String> {
-    signer
-        .sign_transaction(tx)
-        .await
-        .map_err(|e| Error::Mpp(format!("failed to sign {context} transaction: {e}")))?;
-
-    submit_versioned_transaction(
-        rpc_url,
-        solana_transaction::versioned::VersionedTransaction::from(tx.clone()),
-        context,
-    )
-    .await
-}
-
-/// Broadcast an already-signed transaction (legacy or v0) and wait for its
-/// first successful processed status before returning.
-async fn submit_versioned_transaction(
-    rpc_url: String,
-    tx: solana_transaction::versioned::VersionedTransaction,
-    context: &'static str,
-) -> Result<String> {
-    tokio::task::spawn_blocking(move || {
-        use std::time::Instant;
-
-        use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
-        use solana_commitment_config::CommitmentConfig;
-
-        let rpc = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::processed());
-        let expected_signature =
-            tx.signatures.first().copied().ok_or_else(|| {
-                Error::Mpp(format!("{context} transaction is missing a signature"))
-            })?;
-
-        let submit_started = Instant::now();
-        match rpc.send_transaction(&tx) {
-            Ok(signature) => {
-                let rpc_send_ms = submit_started.elapsed().as_millis();
-                let wait_started = Instant::now();
-                wait_for_transaction_processed(&rpc, &signature, context)?;
-                tracing::info!(
-                    %signature,
-                    context,
-                    rpc_send_ms,
-                    processed_wait_ms = wait_started.elapsed().as_millis(),
-                    "transaction reached processed status"
-                );
-                Ok(signature.to_string())
-            }
-            Err(send_error) => {
-                let rpc_send_ms = submit_started.elapsed().as_millis();
-                let wait_started = Instant::now();
-                match wait_for_transaction_processed(&rpc, &expected_signature, context) {
-                    Ok(()) => {
-                        tracing::warn!(
-                            %expected_signature,
-                            error = %send_error,
-                            context,
-                            rpc_send_ms,
-                            processed_wait_ms = wait_started.elapsed().as_millis(),
-                            "{context} transaction confirmed after submit returned an error"
-                        );
-                        Ok(expected_signature.to_string())
-                    }
-                    Err(_) => Err(Error::Mpp(format!(
-                        "{context} transaction submission failed: {send_error}"
-                    ))),
-                }
-            }
-        }
-    })
-    .await
-    .map_err(|e| Error::Mpp(format!("spawn_blocking join error: {e}")))?
 }
 
 /// Wait for a previously broadcast transaction to succeed at confirmed
@@ -2076,40 +1847,6 @@ async fn wait_for_transaction_confirmed(
     )))
 }
 
-/// Wait for the transaction's first successful status. `get_signature_status`
-/// has no confirmation filter, so this accepts `processed` and anything above
-/// it rather than waiting for `confirmed` or `finalized`.
-fn wait_for_transaction_processed(
-    rpc: &pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient,
-    signature: &solana_signature::Signature,
-    context: &'static str,
-) -> Result<()> {
-    use std::time::{Duration, Instant};
-
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let mut last_status_error = None;
-    while Instant::now() < deadline {
-        match rpc.get_signature_status(signature) {
-            Ok(Some(Ok(()))) => return Ok(()),
-            Ok(Some(Err(error))) => {
-                return Err(Error::Mpp(format!("{context} transaction failed: {error}")));
-            }
-            Ok(None) => {}
-            Err(error) => {
-                last_status_error = Some(error.to_string());
-            }
-        }
-        std::thread::sleep(Duration::from_millis(500));
-    }
-
-    let detail = last_status_error
-        .map(|error| format!("; last status error: {error}"))
-        .unwrap_or_default();
-    Err(Error::Mpp(format!(
-        "{context} transaction was not confirmed before timeout{detail}"
-    )))
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -2117,28 +1854,37 @@ mod tests {
     use super::*;
     use crate::client::session::SessionHandle;
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
-    use pay_kit::mpp::{PaymentCredential, format_authorization};
+    use pay_kit::mpp::{PaymentCredential, SessionAuthentication, format_authorization};
     use std::sync::Arc;
 
     const CAP: u64 = 1_000_000;
+    const TEST_BLOCKHASH: &str = "SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxxxx11x";
+    const TEST_SLOT: u64 = 123;
 
     fn test_session_config() -> SessionConfig {
         SessionConfig {
             operator: solana_pubkey::Pubkey::new_unique().to_string(),
             recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-            max_cap: 5 * CAP,
+            amount: 25,
+            suggested_deposit: Some(5 * CAP),
             currency: solana_pubkey::Pubkey::new_unique().to_string(),
             network: "localnet".to_string(),
-            modes: vec![SessionMode::Push, SessionMode::Pull],
             ..SessionConfig::default()
         }
     }
 
-    fn test_session_mpp() -> SessionMpp {
-        SessionMpp::new(test_session_config(), "test-secret")
+    fn test_blockhash_cache() -> BlockhashCache {
+        let cache = BlockhashCache::new();
+        cache.set(TEST_BLOCKHASH.to_string(), 42, TEST_SLOT);
+        cache
     }
 
-    fn test_session_signer() -> Box<dyn SolanaSigner> {
+    fn test_session_mpp() -> SessionMpp {
+        SessionMpp::new(test_session_config(), "test-secret")
+            .with_blockhash_cache(test_blockhash_cache())
+    }
+
+    fn test_keypair() -> (ed25519_dalek::SigningKey, Box<dyn SolanaSigner>) {
         use ed25519_dalek::SigningKey;
 
         let sk = SigningKey::generate(&mut rand::thread_rng());
@@ -2146,43 +1892,72 @@ mod tests {
         let mut kp = [0u8; 64];
         kp[..32].copy_from_slice(sk.as_bytes());
         kp[32..].copy_from_slice(vk.as_bytes());
-        Box::new(MemorySigner::from_bytes(&kp).unwrap())
+        (sk, Box::new(MemorySigner::from_bytes(&kp).unwrap()))
+    }
+
+    fn test_session_signer() -> Box<dyn SolanaSigner> {
+        test_keypair().1
+    }
+
+    /// Insert confirmed channel state directly — see [`test_channel_state`].
+    #[allow(clippy::too_many_arguments)]
+    async fn seed_channel(
+        session: &SessionMpp,
+        channel_id: &str,
+        deposit: u64,
+        authorized_signer: &str,
+        voucher_signer: &str,
+        opening_challenge_id: &str,
+        payer: &str,
+        authentication: Option<String>,
+    ) {
+        let state = test_channel_state(
+            channel_id,
+            deposit,
+            authorized_signer,
+            voucher_signer,
+            opening_challenge_id,
+            payer,
+            authentication,
+        );
+        session
+            .operator_runtime
+            .channel_store
+            .put_channel(channel_id, state)
+            .await
+            .unwrap();
+        session.record_committed_watermark(channel_id.to_string(), 0);
     }
 
     #[test]
     fn with_realm_updates_challenge_realm() {
         let session = test_session_mpp().with_realm("Custom Realm");
-        let challenge = session.challenge(CAP).unwrap();
+        let challenge = session.challenge(None).unwrap();
         assert_eq!(challenge.realm, "Custom Realm");
     }
 
     #[test]
-    fn prefetch_latest_blockhash_without_rpc_returns_none() {
+    fn challenge_without_blockhash_source_errors() {
+        let session = SessionMpp::new(test_session_config(), "test-secret");
+        let err = session.challenge(None).unwrap_err();
         assert!(
-            test_session_mpp()
-                .prefetch_latest_blockhash_hint()
-                .is_none()
+            err.to_string().contains("recentBlockhash"),
+            "challenges must carry the open-transaction context: {err}"
         );
     }
 
     #[test]
     fn challenge_uses_cached_blockhash_and_recent_slot() {
-        let cache = BlockhashCache::new();
-        cache.set(
-            "SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxxxx11x".to_string(),
-            42,
-            123,
-        );
-
-        let session = test_session_mpp().with_blockhash_cache(cache);
-        let challenge = session.challenge(CAP).unwrap();
+        let session = test_session_mpp();
+        let challenge = session.challenge(Some(77)).unwrap();
         let request: pay_kit::mpp::SessionRequest = challenge.request.decode().unwrap();
 
         assert_eq!(
-            request.recent_blockhash.as_deref(),
-            Some("SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxxxx11x")
+            request.method_details.recent_blockhash.as_deref(),
+            Some(TEST_BLOCKHASH)
         );
-        assert_eq!(request.recent_slot, Some(123));
+        assert_eq!(request.method_details.recent_slot, Some(TEST_SLOT));
+        assert_eq!(request.amount, "77");
     }
 
     #[tokio::test]
@@ -2193,14 +1968,13 @@ mod tests {
             "test-realm",
             METHOD,
             "charge",
-            Base64UrlJson::from_typed(&session.server.build_challenge_request(CAP)).unwrap(),
+            Base64UrlJson::from_typed(&session.server.build_challenge_request().unwrap()).unwrap(),
         );
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
+        let credential = PaymentCredential::new(
+            challenge.to_echo(),
+            serde_json::json!({ "action": "close" }),
         );
-        let auth_header = handle.open_header(CAP, "open_sig").await.unwrap();
+        let auth_header = format_authorization(&credential).unwrap();
 
         let err = session
             .process(&auth_header)
@@ -2226,9 +2000,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn process_rejects_forged_challenge_echo() {
+        let session = test_session_mpp();
+        // Same request bytes, but bound with a different secret: the echoed
+        // challenge id no longer matches this server's HMAC.
+        let forged = PaymentChallenge::with_challenge_binding_secret(
+            "attacker-secret",
+            "test-realm",
+            METHOD,
+            INTENT,
+            session.challenge(None).unwrap().request,
+        );
+        let credential =
+            PaymentCredential::new(forged.to_echo(), serde_json::json!({ "action": "close" }));
+        let auth_header = format_authorization(&credential).unwrap();
+
+        let err = session
+            .process(&auth_header)
+            .await
+            .expect_err("forged echo should error");
+        assert!(err.to_string().contains("did not issue"), "got: {err}");
+    }
+
+    #[tokio::test]
     async fn process_rejects_unknown_session_action_payload() {
         let session = test_session_mpp();
-        let challenge = session.challenge(CAP).unwrap();
+        let challenge = session.challenge(None).unwrap();
         let credential = PaymentCredential::new(
             challenge.to_echo(),
             serde_json::json!({ "action": "mystery" }),
@@ -2247,26 +2044,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_supports_open_voucher_topup_and_close() {
+    async fn process_supports_voucher_and_close_on_open_channel() {
         let session = test_session_mpp();
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-
-        let SessionOutcome::Active {
-            state: opened,
-            signature: open_signature,
-        } = session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
-        assert_eq!(open_signature.as_deref(), Some("open_sig"));
-        assert_eq!(opened.deposit, CAP);
-        assert_eq!(session.committed_watermark(&opened.channel_id), Some(0));
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let (voucher_key, signer) = test_keypair();
+        let authorized_signer = signer.pubkey().to_string();
+        let handle =
+            SessionHandle::new(channel, signer, challenge.clone()).with_voucher_key(voucher_key);
+        seed_channel(
+            &session,
+            &channel.to_string(),
+            CAP,
+            &authorized_signer,
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
 
         let voucher_header = handle.voucher_header(75).await.unwrap();
         let SessionOutcome::Voucher { cumulative, .. } =
@@ -2275,22 +2071,11 @@ mod tests {
             panic!("expected voucher outcome");
         };
         assert_eq!(cumulative, 75);
-        assert_eq!(session.committed_watermark(&opened.channel_id), Some(75));
-
-        let topup_header = handle.topup_header(CAP + 500, "topup_sig").await.unwrap();
-        let SessionOutcome::Active {
-            state: topped_up,
-            signature: topup_signature,
-        } = session.process(&topup_header).await.unwrap()
-        else {
-            panic!("expected topup outcome");
-        };
-        assert_eq!(topup_signature.as_deref(), Some("topup_sig"));
-        assert_eq!(topped_up.deposit, CAP + 500);
+        assert_eq!(session.committed_watermark(&channel.to_string()), Some(75));
 
         let close_header = handle.close_header(Some(25)).await.unwrap();
         let competing_lease = session
-            .reserve_delegated_capacity(&opened.channel_id, 0)
+            .reserve_delegated_capacity(&channel.to_string(), 0)
             .await
             .unwrap()
             .expect("test should reserve the channel");
@@ -2308,125 +2093,141 @@ mod tests {
         };
         assert_eq!(params.settled, 100);
         assert_eq!(signature, None);
-        assert_eq!(session.committed_watermark(&opened.channel_id), Some(100));
+        assert_eq!(session.committed_watermark(&channel.to_string()), Some(100));
     }
 
     #[tokio::test]
-    async fn client_voucher_pull_uses_payment_channel_payload_shape() {
-        let session =
-            test_session_mpp().with_pull_voucher_strategy(PullVoucherStrategy::ClientVoucher);
-        let mut payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            42,
-        );
-        payload.mode = SessionMode::Pull;
-
-        session.process_pull_open(&payload).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn push_open_submits_the_client_transaction_before_verification() {
+    async fn use_rejected_for_client_signed_sessions() {
         let session = test_session_mpp();
-        let payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            45,
-        );
-        let challenge = session.challenge(CAP).unwrap();
-        let credential = PaymentCredential::new(
-            challenge.to_echo(),
-            serde_json::to_value(SessionAction::Open(payload)).unwrap(),
-        );
-        let auth_header = format_authorization(&credential).unwrap();
-
-        let err = session.process(&auth_header).await.unwrap_err();
-        assert!(
-            err.to_string().contains("requires an operator signer"),
-            "push transaction was not routed through server submission: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn client_voucher_pull_accepts_server_opened_payment_channel_shape() {
-        let session =
-            test_session_mpp().with_pull_voucher_strategy(PullVoucherStrategy::ClientVoucher);
-        let mut payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            43,
-        );
-        payload.mode = SessionMode::Pull;
-        payload.transaction = None;
-
-        session.process_pull_open(&payload).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn client_voucher_pull_rejects_delegated_token_payload_shape() {
-        let session =
-            test_session_mpp().with_pull_voucher_strategy(PullVoucherStrategy::ClientVoucher);
-        let payload = OpenPayload::pull(
-            solana_pubkey::Pubkey::new_unique().to_string(),
-            CAP.to_string(),
-            solana_pubkey::Pubkey::new_unique().to_string(),
-            solana_pubkey::Pubkey::new_unique().to_string(),
-            "open_sig".to_string(),
-        );
-
-        let err = session.process_pull_open(&payload).await.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("client-voucher pull sessions require payment-channel")
-        );
-    }
-
-    #[tokio::test]
-    async fn server_opened_payment_channel_requires_operator_payer() {
-        let signer: Arc<dyn SolanaSigner> = Arc::from(test_session_signer());
-        let mut config = test_session_config();
-        config.operator = signer.pubkey().to_string();
-        config.rpc_url = Some("http://127.0.0.1:8899".to_string());
-        let session = SessionMpp::new(config, "test-secret")
-            .with_pull_voucher_strategy(PullVoucherStrategy::ClientVoucher)
-            .with_payment_channel_signer(Arc::clone(&signer));
-        let mut payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            44,
-        );
-        payload.mode = SessionMode::Pull;
-        payload.transaction = None;
+        let challenge = session.challenge(None).unwrap();
+        let payer = ed25519_dalek::SigningKey::from_bytes(&[7; 32]);
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let proof = SessionAuthentication::sign(challenge.id.clone(), &channel.to_string(), &payer)
+            .unwrap();
+        let handle = SessionHandle::new(channel, test_session_signer(), challenge)
+            .with_authentication(proof);
 
         let err = session
-            .submit_server_payment_channel_open(&payload)
+            .process(&handle.use_header().await.unwrap())
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("payer must match operator signer"));
+        assert!(
+            err.to_string()
+                .contains("only valid for operator-signed sessions"),
+            "got: {err}"
+        );
+    }
+
+    async fn operator_session_with_bound_channel() -> (
+        SessionMpp,
+        PaymentChallenge,
+        solana_pubkey::Pubkey,
+        SessionAuthentication,
+        ed25519_dalek::SigningKey,
+    ) {
+        let mut config = test_session_config();
+        config.voucher_signer = SessionVoucherSigner::Operator;
+        let session =
+            SessionMpp::new(config, "test-secret").with_blockhash_cache(test_blockhash_cache());
+        let challenge = session.challenge(None).unwrap();
+        let payer = ed25519_dalek::SigningKey::from_bytes(&[9; 32]);
+        let payer_address = bs58::encode(payer.verifying_key().as_bytes()).into_string();
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let proof = SessionAuthentication::sign(challenge.id.clone(), &channel.to_string(), &payer)
+            .unwrap();
+        seed_channel(
+            &session,
+            &channel.to_string(),
+            CAP,
+            &session.session_config.operator.clone(),
+            "operator",
+            &challenge.id,
+            &payer_address,
+            Some(serde_json::to_string(&proof).unwrap()),
+        )
+        .await;
+        (session, challenge, channel, proof, payer)
+    }
+
+    #[tokio::test]
+    async fn use_authenticates_the_proof_bound_at_open() {
+        let (session, challenge, channel, proof, _payer) =
+            operator_session_with_bound_channel().await;
+        let handle = SessionHandle::new(channel, test_session_signer(), challenge)
+            .with_authentication(proof);
+
+        let SessionOutcome::Active { state, signature } = session
+            .process(&handle.use_header().await.unwrap())
+            .await
+            .unwrap()
+        else {
+            panic!("expected use to authenticate the channel");
+        };
+        assert_eq!(state.channel_id, channel.to_string());
+        assert_eq!(signature, None);
+    }
+
+    #[tokio::test]
+    async fn use_rejects_a_proof_for_another_challenge() {
+        let (session, challenge, channel, _proof, payer) =
+            operator_session_with_bound_channel().await;
+        let forged =
+            SessionAuthentication::sign("some-other-challenge", &channel.to_string(), &payer)
+                .unwrap();
+        let handle = SessionHandle::new(channel, test_session_signer(), challenge)
+            .with_authentication(forged);
+
+        let err = session
+            .process(&handle.use_header().await.unwrap())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the proof bound at open"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_close_uses_bound_proof() {
+        let (session, challenge, channel, proof, _payer) =
+            operator_session_with_bound_channel().await;
+        let handle = SessionHandle::new(channel, test_session_signer(), challenge)
+            .with_authentication(proof);
+
+        let SessionOutcome::Closed { params, signature } = session
+            .process(&handle.close_header(None).await.unwrap())
+            .await
+            .unwrap()
+        else {
+            panic!("expected close outcome");
+        };
+        assert_eq!(params.channel_id, channel);
+        assert_eq!(signature, None);
     }
 
     #[tokio::test]
     async fn lifecycle_runloop_operator_closes_idle_channel() {
         let session = Arc::new(test_session_mpp());
         session.start_lifecycle_runloop(Duration::from_millis(10));
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
-        assert_eq!(session.committed_watermark(&opened.channel_id), Some(0));
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let (voucher_key, signer) = test_keypair();
+        let authorized_signer = signer.pubkey().to_string();
+        let handle =
+            SessionHandle::new(channel, signer, challenge.clone()).with_voucher_key(voucher_key);
+        seed_channel(
+            &session,
+            &channel.to_string(),
+            CAP,
+            &authorized_signer,
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        session.touch_channel(channel.to_string()).await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(60)).await;
 
@@ -2484,6 +2285,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queued_touch_is_discarded_after_lease_cancellation() {
+        let session = Arc::new(test_session_mpp());
+        session.start_lifecycle_runloop_with_settlement_and_batching(
+            Duration::from_millis(30),
+            Duration::from_millis(1),
+            Duration::ZERO,
+            SessionLifecycleReconciliation::External,
+        );
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+
+        session.touch_channel(channel.clone()).await.unwrap();
+        let baseline = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&channel)
+            .await
+            .unwrap()
+            .unwrap()
+            .lifecycle
+            .unwrap()
+            .close_after;
+
+        // The race from pay#416's review: a heartbeat `Touch` is dequeued
+        // only after its lease has been released. Queue the command and flip
+        // its cancellation before yielding to the runloop — exactly the state
+        // `DelegatedCapacityLease::drop` leaves behind (cancel is signalled
+        // before the heartbeat task is aborted). The far-future timestamp
+        // makes any wrongly persisted deadline unmissable.
+        let (cancel, cancellation) = watch::channel(false);
+        let (response_tx, response_rx) = oneshot::channel();
+        session.lifecycle.send(SessionLifecycleCommand::Touch {
+            channel_id: channel.clone(),
+            touched_at_ms: unix_millis() + 3_600_000,
+            cancellation: Some(cancellation),
+            response: response_tx,
+        });
+        cancel.send(true).unwrap();
+
+        assert!(
+            response_rx.await.is_err(),
+            "a cancelled queued touch must be discarded, not persisted"
+        );
+        let after_discard = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&channel)
+            .await
+            .unwrap()
+            .unwrap()
+            .lifecycle
+            .unwrap()
+            .close_after;
+        assert_eq!(
+            after_discard, baseline,
+            "a touch dequeued after lease release must not advance the idle deadline"
+        );
+
+        // The discard path must keep the runloop serving later commands.
+        session.touch_channel(channel.clone()).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn external_lifecycle_persists_deadline_without_closing_locally() {
         let session = Arc::new(test_session_mpp());
         session.start_lifecycle_runloop_with_settlement_and_batching(
@@ -2492,26 +2367,27 @@ mod tests {
             Duration::ZERO,
             SessionLifecycleReconciliation::External,
         );
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        session.touch_channel(channel.clone()).await.unwrap();
 
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 let persisted = session
                     .operator_runtime
                     .channel_store
-                    .get_channel(&opened.channel_id)
+                    .get_channel(&channel)
                     .await
                     .unwrap()
                     .unwrap();
@@ -2529,7 +2405,7 @@ mod tests {
         let persisted = session
             .operator_runtime
             .channel_store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap();
@@ -2543,7 +2419,7 @@ mod tests {
             .operator_runtime
             .channel_store
             .update_channel(
-                &opened.channel_id,
+                &channel,
                 Box::new(|state| {
                     let mut state = state.unwrap();
                     state.close_requested_at = Some(1);
@@ -2553,7 +2429,7 @@ mod tests {
             .await
             .unwrap();
         let error = session
-            .touch_channel(opened.channel_id)
+            .touch_channel(channel)
             .await
             .expect_err("a worker-claimed close cannot be woken");
         assert!(error.to_string().contains("close is pending"));
@@ -2564,31 +2440,30 @@ mod tests {
         let store: Arc<dyn ChannelStore> = Arc::new(MemoryChannelStore::new());
         let config = test_session_config();
         let first =
-            SessionMpp::new_with_channel_store(config.clone(), "test-secret", Arc::clone(&store));
+            SessionMpp::new_with_channel_store(config.clone(), "test-secret", Arc::clone(&store))
+                .with_blockhash_cache(test_blockhash_cache());
         first.start_lifecycle_runloop_with_settlement_and_batching(
             Duration::from_secs(3600),
             Duration::from_secs(60),
             Duration::ZERO,
             SessionLifecycleReconciliation::External,
         );
-        let challenge = first.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            first.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = first.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &first,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        first.touch_channel(channel.clone()).await.unwrap();
 
-        let persisted = store
-            .get_channel(&opened.channel_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let persisted = store.get_channel(&channel).await.unwrap().unwrap();
         let original = persisted.lifecycle.expect("deadline should be persisted");
         drop(first);
 
@@ -2603,11 +2478,7 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
-                let persisted = store
-                    .get_channel(&opened.channel_id)
-                    .await
-                    .unwrap()
-                    .unwrap();
+                let persisted = store.get_channel(&channel).await.unwrap().unwrap();
                 let lifecycle = persisted.lifecycle.unwrap();
                 if lifecycle.owner != original.owner {
                     assert_eq!(lifecycle.close_after, original.close_after);
@@ -2627,25 +2498,28 @@ mod tests {
             test_session_config(),
             "test-secret",
             Arc::clone(&store),
-        );
+        )
+        .with_blockhash_cache(test_blockhash_cache());
         session.start_lifecycle_runloop_with_settlement_and_batching(
             Duration::from_secs(3600),
             Duration::from_secs(60),
             Duration::ZERO,
             SessionLifecycleReconciliation::External,
         );
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        session.touch_channel(channel.clone()).await.unwrap();
 
         let live_owner = "other-live-gateway";
         let live_lease = format!(
@@ -2654,7 +2528,7 @@ mod tests {
         );
         let original_deadline = store
             .update_channel(
-                &opened.channel_id,
+                &channel,
                 Box::new({
                     let live_lease = live_lease.clone();
                     move |state| {
@@ -2676,7 +2550,7 @@ mod tests {
         contender.reconcile_persisted_ownership().await;
 
         let persisted = store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap()
@@ -2690,7 +2564,7 @@ mod tests {
 
         store
             .update_channel(
-                &opened.channel_id,
+                &channel,
                 Box::new(move |state| {
                     let mut state = state.unwrap();
                     state.lifecycle.as_mut().unwrap().owner =
@@ -2703,7 +2577,7 @@ mod tests {
         contender.reconcile_persisted_ownership().await;
 
         let reclaimed = store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap()
@@ -2758,27 +2632,30 @@ mod tests {
             Duration::ZERO,
             SessionLifecycleReconciliation::External,
         );
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
         session
             .operator_runtime
             .channel_store
             .update_channel(
-                &opened.channel_id,
+                &channel,
                 Box::new(|state| {
                     let mut state = state.unwrap();
-                    state.lifecycle.as_mut().unwrap().close_after = 1;
+                    state.lifecycle = Some(ChannelLifecycle {
+                        owner: "seed".to_string(),
+                        close_after: 1,
+                    });
                     Ok(state)
                 }),
             )
@@ -2787,7 +2664,7 @@ mod tests {
 
         let touched_after = unix_millis();
         let _lease = session
-            .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .reserve_delegated_capacity(&channel, CAP)
             .await
             .unwrap()
             .expect("request should reserve channel capacity");
@@ -2795,7 +2672,7 @@ mod tests {
         let persisted = session
             .operator_runtime
             .channel_store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap();
@@ -2815,28 +2692,28 @@ mod tests {
             Duration::ZERO,
             SessionLifecycleReconciliation::External,
         );
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
         let lease = session
-            .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .reserve_delegated_capacity(&channel, CAP)
             .await
             .unwrap()
             .expect("request should reserve channel capacity");
         let initial_deadline = session
             .operator_runtime
             .channel_store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap()
@@ -2849,7 +2726,7 @@ mod tests {
         let heartbeat_deadline = session
             .operator_runtime
             .channel_store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap()
@@ -2866,7 +2743,7 @@ mod tests {
         let released_deadline = session
             .operator_runtime
             .channel_store
-            .get_channel(&opened.channel_id)
+            .get_channel(&channel)
             .await
             .unwrap()
             .unwrap()
@@ -2883,21 +2760,43 @@ mod tests {
     async fn delegated_capacity_lease_defers_idle_close() {
         let session = Arc::new(test_session_mpp());
         session.start_lifecycle_runloop(Duration::from_millis(10));
-        let challenge = session.challenge(CAP).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            test_session_signer(),
-            challenge,
-        );
-
-        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state: opened, .. } =
-            session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected open to return active session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let (voucher_key, signer) = test_keypair();
+        let authorized_signer = signer.pubkey().to_string();
+        let handle =
+            SessionHandle::new(channel, signer, challenge.clone()).with_voucher_key(voucher_key);
+        seed_channel(
+            &session,
+            &channel.to_string(),
+            CAP,
+            &authorized_signer,
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        // The kit re-arms `lifecycle.close_after` from the channel's
+        // negotiated `idle_timeout_seconds` on every accepted session action.
+        // Production derives that negotiation from `close_delay_ms` with a
+        // one-second floor; mirror the same relationship here so the kit's
+        // re-arm and this test's 10ms runloop clock stay on one schedule.
+        session
+            .operator_runtime
+            .channel_store
+            .update_channel(
+                &channel.to_string(),
+                Box::new(|state| {
+                    let mut state = state.unwrap();
+                    state.idle_timeout_seconds = Some(1);
+                    Ok(state)
+                }),
+            )
+            .await
+            .unwrap();
         let lease = session
-            .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .reserve_delegated_capacity(&channel.to_string(), CAP)
             .await
             .unwrap()
             .expect("request should reserve channel capacity");
@@ -2911,7 +2810,9 @@ mod tests {
         );
 
         drop(lease);
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Wait out the kit's one-second re-arm window plus a margin so the
+        // embedded runloop observes the lapsed deadline and closes.
+        tokio::time::sleep(Duration::from_millis(1_300)).await;
 
         let voucher_header = handle.voucher_header(75).await.unwrap();
         let error = session.process(&voucher_header).await.unwrap_err();
@@ -2922,80 +2823,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn process_supports_reserved_delivery_commit() {
-        let session = test_session_mpp();
-        let challenge = session.challenge(CAP).unwrap();
-        let channel_id = solana_pubkey::Pubkey::new_unique();
-        let active =
-            pay_kit::mpp::client::session::ActiveSession::new(channel_id, test_session_signer());
-
-        let open_action = active.open_action(CAP, "open_sig");
-        let open_header =
-            pay_kit::mpp::format_authorization(&pay_kit::mpp::PaymentCredential::new(
-                challenge.to_echo(),
-                serde_json::to_value(open_action).unwrap(),
-            ))
-            .unwrap();
-        let SessionOutcome::Active { .. } = session.process(&open_header).await.unwrap() else {
-            panic!("expected open outcome");
-        };
-
-        let directive = session
-            .server
-            .begin_delivery(pay_kit::mpp::server::session::DeliveryRequest::new(
-                active.channel_id_str(),
-                60,
-            ))
-            .await
-            .unwrap();
-        let voucher = active.prepare_increment(60).await.unwrap();
-        let commit_action = SessionAction::Commit(pay_kit::mpp::CommitPayload {
-            delivery_id: directive.delivery_id.clone(),
-            voucher,
-        });
-        let commit_header =
-            pay_kit::mpp::format_authorization(&pay_kit::mpp::PaymentCredential::new(
-                challenge.to_echo(),
-                serde_json::to_value(commit_action).unwrap(),
-            ))
-            .unwrap();
-
-        let SessionOutcome::Commit(receipt) = session.process(&commit_header).await.unwrap() else {
-            panic!("expected commit outcome");
-        };
-        assert_eq!(receipt.delivery_id, directive.delivery_id);
-        assert_eq!(receipt.amount, "60");
-        assert_eq!(receipt.cumulative, "60");
-        assert_eq!(
-            session.committed_watermark(&active.channel_id_str()),
-            Some(60)
-        );
-    }
-
-    #[tokio::test]
     async fn delegated_usage_signs_and_persists_cumulative_voucher() {
         let signer: Arc<dyn SolanaSigner> = Arc::from(test_session_signer());
         let operator = signer.pubkey();
         let mut config = test_session_config();
         config.operator = operator.to_string();
-        config.settlement_authority = SessionSettlementAuthority::Delegated;
-        let session =
-            SessionMpp::new(config, "test-secret").with_payment_channel_signer(Arc::clone(&signer));
-        let payload =
-            payment_channel_payload(&session, solana_pubkey::Pubkey::new_unique(), operator, 91);
-        let opened = tokio::time::timeout(
-            Duration::from_secs(2),
-            session.server.process_preverified_open(&payload),
+        config.voucher_signer = SessionVoucherSigner::Operator;
+        let session = SessionMpp::new(config, "test-secret")
+            .with_blockhash_cache(test_blockhash_cache())
+            .with_payment_channel_signer(Arc::clone(&signer));
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &operator.to_string(),
+            "operator",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
         )
-        .await
-        .expect("delegated open timed out")
-        .unwrap();
-        session.record_committed_watermark(opened.channel_id.clone(), opened.cumulative);
+        .await;
 
         assert_eq!(
             tokio::time::timeout(
                 Duration::from_secs(2),
-                session.authorize_delegated_usage(&opened.channel_id, 75),
+                session.authorize_delegated_usage(&channel, 75),
             )
             .await
             .expect("first delegated voucher timed out")
@@ -3010,31 +2864,28 @@ mod tests {
         assert_eq!(
             tokio::time::timeout(
                 Duration::from_secs(2),
-                session.authorize_delegated_usage(&opened.channel_id, 25),
+                session.authorize_delegated_usage(&channel, 25),
             )
             .await
             .expect("second delegated voucher timed out")
             .unwrap(),
             100
         );
-        let close_payload = pay_kit::mpp::ClosePayload {
-            channel_id: opened.channel_id.clone(),
-            voucher: None,
-        };
-        let close = tokio::time::timeout(
-            Duration::from_secs(2),
-            session.server.process_close(&close_payload),
-        )
-        .await
-        .expect("delegated close timed out")
-        .unwrap();
-        assert_eq!(close.settled, 100);
-        assert_eq!(session.committed_watermark(&opened.channel_id), Some(100));
+
+        // Server-initiated close (idle path) seals at the accepted watermark.
+        session
+            .operator_runtime
+            .request_server_close(&channel)
+            .await
+            .unwrap();
+        let params = session.server.seal_params(&channel).await.unwrap();
+        assert_eq!(params.settled, 100);
+        assert_eq!(session.committed_watermark(&channel), Some(100));
     }
 
     #[tokio::test]
     async fn challenge_header_formats_session_challenge() {
-        let header = test_session_mpp().challenge_header(CAP).unwrap();
+        let header = test_session_mpp().challenge_header(None).unwrap();
         let challenge = pay_kit::mpp::parse_www_authenticate(&header).unwrap();
         assert_eq!(challenge.intent.as_str(), INTENT);
         assert_eq!(challenge.method.as_str(), METHOD);
@@ -3049,227 +2900,6 @@ mod tests {
         assert!(err.to_string().contains("Failed to get seal params"));
     }
 
-    fn payment_channel_payload(
-        session: &SessionMpp,
-        payer: solana_pubkey::Pubkey,
-        authorized_signer: solana_pubkey::Pubkey,
-        salt: u64,
-    ) -> OpenPayload {
-        let payee = solana_pubkey::Pubkey::try_from(session.session_config.recipient.as_str())
-            .expect("valid test payee");
-        let mint = solana_pubkey::Pubkey::try_from(session.session_config.currency.as_str())
-            .expect("valid test mint");
-        let program_id = session
-            .session_config
-            .program_id
-            .unwrap_or_else(pay_kit::mpp::program::payment_channels::default_program_id);
-        let token_program = spl_token_program();
-        // The open slot is a channel-PDA seed since the epoch-addressed
-        // migration; keep it identical between the params used to derive the
-        // channel and the payload's recentSlot so the server re-derives the
-        // same PDA.
-        let open_slot = 4_242u64;
-        let params = pay_kit::mpp::program::payment_channels::OpenChannelParams {
-            payer,
-            rent_payer: payer,
-            payee,
-            mint,
-            authorized_signer,
-            salt,
-            open_slot,
-            deposit: CAP,
-            grace_period: 900,
-            recipients: vec![],
-            token_program,
-            program_id,
-        };
-        let channel = pay_kit::mpp::program::payment_channels::derive_channel_addresses(&params)
-            .channel
-            .to_string();
-
-        OpenPayload::payment_channel(
-            channel,
-            CAP.to_string(),
-            payer.to_string(),
-            payee.to_string(),
-            mint.to_string(),
-            salt,
-            900,
-            open_slot,
-            authorized_signer.to_string(),
-            "pending".to_string(),
-        )
-        .with_transaction("tx".to_string())
-    }
-
-    #[test]
-    fn payment_channel_open_params_validate_challenge_fields() {
-        let session = test_session_mpp();
-        let payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            42,
-        );
-
-        let params = session.payment_channel_open_params(&payload).unwrap();
-        assert_eq!(params.deposit, CAP);
-        assert_eq!(params.grace_period, 900);
-
-        let mut tampered = payload.clone();
-        tampered.payee = Some(solana_pubkey::Pubkey::new_unique().to_string());
-        let err = session.payment_channel_open_params(&tampered).unwrap_err();
-        assert!(err.to_string().contains("payee"));
-    }
-
-    #[test]
-    fn payment_channel_open_params_validates_stablecoin_symbols_via_sdk() {
-        let session = SessionMpp::new(
-            SessionConfig {
-                currency: "USDC".to_string(),
-                network: "localnet".to_string(),
-                ..test_session_config()
-            },
-            "test-secret",
-        );
-        let payer = solana_pubkey::Pubkey::new_unique();
-        let authorized_signer = solana_pubkey::Pubkey::new_unique();
-        let payee = solana_pubkey::Pubkey::try_from(session.session_config.recipient.as_str())
-            .expect("valid test payee");
-        let mint = solana_pubkey::Pubkey::try_from(pay_kit::mpp::mints::USDC_MAINNET)
-            .expect("valid USDC mint");
-        let program_id = session
-            .session_config
-            .program_id
-            .unwrap_or_else(pay_kit::mpp::program::payment_channels::default_program_id);
-        let open_slot = 4_242u64;
-        let params = pay_kit::mpp::program::payment_channels::OpenChannelParams {
-            payer,
-            rent_payer: payer,
-            payee,
-            mint,
-            authorized_signer,
-            salt: 99,
-            open_slot,
-            deposit: CAP,
-            grace_period: 900,
-            recipients: vec![],
-            token_program: spl_token_program(),
-            program_id,
-        };
-        let channel = pay_kit::mpp::program::payment_channels::derive_channel_addresses(&params)
-            .channel
-            .to_string();
-        let payload = OpenPayload::payment_channel(
-            channel,
-            CAP.to_string(),
-            payer.to_string(),
-            payee.to_string(),
-            mint.to_string(),
-            params.salt,
-            params.grace_period,
-            params.open_slot,
-            authorized_signer.to_string(),
-            "pending".to_string(),
-        );
-
-        let parsed = session.payment_channel_open_params(&payload).unwrap();
-        assert_eq!(parsed.mint, mint);
-
-        let mut tampered = payload;
-        tampered.mint = Some(solana_pubkey::Pubkey::new_unique().to_string());
-        let err = session.payment_channel_open_params(&tampered).unwrap_err();
-        assert!(err.to_string().contains("mint does not match"));
-    }
-
-    #[test]
-    fn transaction_contains_expected_payment_channel_open_instruction() {
-        let session = test_session_mpp();
-        let payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            7,
-        );
-        let expected = session
-            .expected_payment_channel_open_instruction(&payload)
-            .unwrap();
-        let fee_payer = solana_pubkey::Pubkey::new_unique();
-        let message = solana_message::Message::new_with_blockhash(
-            std::slice::from_ref(&expected),
-            Some(&fee_payer),
-            &solana_hash::Hash::default(),
-        );
-        let tx = solana_transaction::versioned::VersionedTransaction::from(
-            solana_transaction::Transaction::new_unsigned(message),
-        );
-        assert!(transaction_contains_instruction(&tx, &expected));
-
-        let mut tampered = expected.clone();
-        tampered.data.push(99);
-        assert!(!transaction_contains_instruction(&tx, &tampered));
-    }
-
-    #[test]
-    fn validate_payment_channel_open_transaction_rejects_extra_instructions() {
-        let session = test_session_mpp();
-        let payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            11,
-        );
-        let expected = session
-            .expected_payment_channel_open_instruction(&payload)
-            .unwrap();
-        let fee_payer = solana_pubkey::Pubkey::new_unique();
-        let extra = solana_instruction::Instruction {
-            program_id: solana_pubkey::Pubkey::new_unique(),
-            accounts: vec![],
-            data: vec![1],
-        };
-        let message = solana_message::Message::new_with_blockhash(
-            &[expected.clone(), extra],
-            Some(&fee_payer),
-            &solana_hash::Hash::default(),
-        );
-        let tx = solana_transaction::versioned::VersionedTransaction::from(
-            solana_transaction::Transaction::new_unsigned(message),
-        );
-
-        let err =
-            validate_payment_channel_open_transaction(&tx, &expected, &fee_payer).unwrap_err();
-        assert!(err.to_string().contains("exactly one instruction"));
-    }
-
-    #[test]
-    fn validate_payment_channel_open_transaction_rejects_wrong_fee_payer() {
-        let session = test_session_mpp();
-        let payload = payment_channel_payload(
-            &session,
-            solana_pubkey::Pubkey::new_unique(),
-            solana_pubkey::Pubkey::new_unique(),
-            12,
-        );
-        let expected = session
-            .expected_payment_channel_open_instruction(&payload)
-            .unwrap();
-        let fee_payer = solana_pubkey::Pubkey::new_unique();
-        let message = solana_message::Message::new_with_blockhash(
-            std::slice::from_ref(&expected),
-            Some(&fee_payer),
-            &solana_hash::Hash::default(),
-        );
-        let tx = solana_transaction::versioned::VersionedTransaction::from(
-            solana_transaction::Transaction::new_unsigned(message),
-        );
-
-        let wrong_fee_payer = solana_pubkey::Pubkey::new_unique();
-        let err = validate_payment_channel_open_transaction(&tx, &expected, &wrong_fee_payer)
-            .unwrap_err();
-        assert!(err.to_string().contains("fee payer"));
-    }
-
     #[test]
     fn close_omits_voucher_when_watermark_already_landed() {
         assert!(close_voucher_required(4_330, 4_331));
@@ -3279,12 +2909,12 @@ mod tests {
 
     #[test]
     fn close_reconciles_durable_state_after_failed_broadcast() {
-        let close_pending = pay_kit::mpp::Error::Other("Close already requested".to_string());
-        let sealed = pay_kit::mpp::Error::Other("Channel is already sealed".to_string());
-        let missing = pay_kit::mpp::Error::Other("Channel not found".to_string());
-
-        assert!(session_close_needs_reconciliation(&close_pending));
-        assert!(session_close_needs_reconciliation(&sealed));
-        assert!(!session_close_needs_reconciliation(&missing));
+        assert!(session_close_needs_reconciliation(
+            "Close already requested"
+        ));
+        assert!(session_close_needs_reconciliation(
+            "Channel is already sealed"
+        ));
+        assert!(!session_close_needs_reconciliation("Channel not found"));
     }
 }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -708,7 +708,23 @@ impl SessionLifecycleRunloop {
         let Some(close_delay) = self.close_delay else {
             return Ok(None);
         };
-        let idle_deadline = touched_at_ms.saturating_add(duration_millis(close_delay));
+        let mut effective_delay_ms = duration_millis(close_delay);
+        let negotiated_idle_timeout_seconds = self
+            .runtime
+            .channel_store
+            .get_channel(channel_id)
+            .await
+            .map_err(|error| {
+                Error::Mpp(format!(
+                    "failed to load channel {channel_id} for lifecycle touch: {error}"
+                ))
+            })?
+            .and_then(|state| state.idle_timeout_seconds);
+        if let Some(idle_timeout_seconds) = negotiated_idle_timeout_seconds {
+            effective_delay_ms =
+                effective_delay_ms.min(u64::from(idle_timeout_seconds).saturating_mul(1_000));
+        }
+        let idle_deadline = touched_at_ms.saturating_add(effective_delay_ms);
         let close_after =
             round_up_timestamp(idle_deadline, duration_millis(self.close_batch_interval));
         let owner = if self.reconciliation == SessionLifecycleReconciliation::Embedded {
@@ -2726,6 +2742,73 @@ mod tests {
             persisted.lifecycle.unwrap().close_after
                 >= touched_after.saturating_add(duration_millis(close_delay)),
             "capacity reservation must persist the request-start deadline before forwarding"
+        );
+    }
+
+    #[tokio::test]
+    async fn touch_honors_negotiated_idle_timeout_shorter_than_close_delay() {
+        let session = Arc::new(test_session_mpp());
+        let close_delay = Duration::from_secs(120);
+        let negotiated_idle_timeout_seconds = 5u32;
+        session.start_lifecycle_runloop_with_settlement_and_batching(
+            close_delay,
+            Duration::from_secs(60),
+            Duration::ZERO,
+            SessionLifecycleReconciliation::External,
+        );
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique().to_string();
+        seed_channel(
+            &session,
+            &channel,
+            CAP,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            "client",
+            &challenge.id,
+            &solana_pubkey::Pubkey::new_unique().to_string(),
+            None,
+        )
+        .await;
+        session
+            .operator_runtime
+            .channel_store
+            .update_channel(
+                &channel,
+                Box::new(move |state| {
+                    let mut state = state.unwrap();
+                    state.idle_timeout_seconds = Some(negotiated_idle_timeout_seconds);
+                    Ok(state)
+                }),
+            )
+            .await
+            .unwrap();
+
+        let touched_after = unix_millis();
+        let _lease = session
+            .reserve_delegated_capacity(&channel, CAP)
+            .await
+            .unwrap()
+            .expect("request should reserve channel capacity");
+
+        let persisted = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&channel)
+            .await
+            .unwrap()
+            .unwrap();
+        let close_after = persisted.lifecycle.unwrap().close_after;
+        let negotiated_deadline_ms =
+            u64::from(negotiated_idle_timeout_seconds).saturating_mul(1_000);
+        assert!(
+            close_after < touched_after.saturating_add(duration_millis(close_delay)),
+            "touch must not fall back to the un-negotiated close_delay when the channel \
+             selected a shorter idle_timeout_seconds"
+        );
+        assert!(
+            close_after <= touched_after.saturating_add(negotiated_deadline_ms) + 60_000,
+            "persisted deadline must be bounded by the negotiated idle timeout \
+             (plus one close-batch-interval of rounding), got {close_after}"
         );
     }
 

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -454,10 +454,12 @@ fn close_voucher_required(onchain_settled: u64, latest_accepted: u64) -> bool {
 pub struct DelegatedCapacityLease {
     runtime: SessionOperatorRuntime,
     channel_id: String,
+    heartbeat: tokio::task::JoinHandle<()>,
 }
 
 impl Drop for DelegatedCapacityLease {
     fn drop(&mut self) {
+        self.heartbeat.abort();
         self.runtime.release_capacity(&self.channel_id);
     }
 }
@@ -524,6 +526,10 @@ pub enum SessionLifecycleReconciliation {
 
 const LIFECYCLE_OWNER_LEASE_PREFIX: &str = "embedded-v1:";
 const MIN_LIFECYCLE_OWNER_LEASE: Duration = Duration::from_secs(30);
+#[cfg(not(test))]
+const DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(10);
 
 fn parse_lifecycle_owner_lease(owner: &str) -> Option<(&str, u64)> {
     let owner = owner.strip_prefix(LIFECYCLE_OWNER_LEASE_PREFIX)?;
@@ -561,7 +567,7 @@ impl SessionLifecycleRunloop {
 
     async fn run(mut self) {
         loop {
-            if let Some(delay) = self.next_wakeup_delay() {
+            if let Some((delay, close_due)) = self.next_wakeup() {
                 tokio::select! {
                     command = self.rx.recv() => {
                         if !self.handle_command(command).await {
@@ -569,7 +575,9 @@ impl SessionLifecycleRunloop {
                         }
                     }
                     _ = tokio::time::sleep(delay) => {
-                        if self.reconciliation == SessionLifecycleReconciliation::Embedded {
+                        if close_due
+                            && self.reconciliation == SessionLifecycleReconciliation::Embedded
+                        {
                             self.reconcile_persisted_ownership().await;
                             self.close_due_channels().await;
                         }
@@ -741,7 +749,7 @@ impl SessionLifecycleRunloop {
         }
     }
 
-    fn next_wakeup_delay(&self) -> Option<Duration> {
+    fn next_wakeup(&self) -> Option<(Duration, bool)> {
         let close = if self.reconciliation == SessionLifecycleReconciliation::Embedded
             && self.close_delay.is_some()
         {
@@ -752,12 +760,7 @@ impl SessionLifecycleRunloop {
         let settlement = self
             .next_settlement
             .map(|deadline| deadline.saturating_duration_since(Instant::now()));
-        match (close, settlement) {
-            (Some(close), Some(settlement)) => Some(close.min(settlement)),
-            (Some(close), None) => Some(close),
-            (None, Some(settlement)) => Some(settlement),
-            (None, None) => None,
-        }
+        next_lifecycle_wakeup(close, settlement)
     }
 
     async fn close_due_channels(&mut self) {
@@ -914,6 +917,19 @@ fn duration_until_next_boundary(interval: Duration) -> Duration {
     let now = unix_millis();
     let next = round_up_timestamp(now.saturating_add(1), duration_millis(interval));
     Duration::from_millis(next.saturating_sub(now))
+}
+
+fn next_lifecycle_wakeup(
+    close: Option<Duration>,
+    settlement: Option<Duration>,
+) -> Option<(Duration, bool)> {
+    match (close, settlement) {
+        (Some(close), Some(settlement)) if close <= settlement => Some((close, true)),
+        (Some(_), Some(settlement)) => Some((settlement, false)),
+        (Some(close), None) => Some((close, true)),
+        (None, Some(settlement)) => Some((settlement, false)),
+        (None, None) => None,
+    }
 }
 
 enum SessionCloseResult {
@@ -1232,13 +1248,36 @@ impl SessionMpp {
         amount: u64,
     ) -> Result<Option<DelegatedCapacityLease>> {
         self.touch_channel(channel_id.to_string()).await?;
-        Ok(self
-            .operator_runtime
-            .reserve_capacity(channel_id, amount)
-            .then(|| DelegatedCapacityLease {
-                runtime: self.operator_runtime.clone(),
-                channel_id: channel_id.to_string(),
-            }))
+        if !self.operator_runtime.reserve_capacity(channel_id, amount) {
+            return Ok(None);
+        }
+
+        let lifecycle = self.lifecycle.clone();
+        let heartbeat_channel_id = channel_id.to_string();
+        let heartbeat = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL);
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                if let Err(error) = lifecycle
+                    .touch(heartbeat_channel_id.clone(), unix_millis())
+                    .await
+                {
+                    tracing::warn!(
+                        channel_id = heartbeat_channel_id,
+                        %error,
+                        "failed to heartbeat active delegated session"
+                    );
+                    break;
+                }
+            }
+        });
+
+        Ok(Some(DelegatedCapacityLease {
+            runtime: self.operator_runtime.clone(),
+            channel_id: channel_id.to_string(),
+            heartbeat,
+        }))
     }
 
     /// Record channel activity so the lifecycle runloop can defer auto-close.
@@ -2354,6 +2393,22 @@ mod tests {
         assert_eq!(round_up_timestamp(123, 0), 123);
     }
 
+    #[test]
+    fn settlement_wakeup_does_not_run_close_reconciliation_early() {
+        assert_eq!(
+            next_lifecycle_wakeup(Some(Duration::from_secs(60)), Some(Duration::from_secs(5))),
+            Some((Duration::from_secs(5), false))
+        );
+        assert_eq!(
+            next_lifecycle_wakeup(Some(Duration::from_secs(5)), Some(Duration::from_secs(60))),
+            Some((Duration::from_secs(5), true))
+        );
+        assert_eq!(
+            next_lifecycle_wakeup(Some(Duration::from_secs(5)), Some(Duration::from_secs(5))),
+            Some((Duration::from_secs(5), true))
+        );
+    }
+
     #[tokio::test]
     async fn external_lifecycle_persists_deadline_without_closing_locally() {
         let session = Arc::new(test_session_mpp());
@@ -2674,6 +2729,79 @@ mod tests {
             persisted.lifecycle.unwrap().close_after
                 >= touched_after.saturating_add(duration_millis(close_delay)),
             "capacity reservation must persist the request-start deadline before forwarding"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegated_capacity_lease_heartbeats_external_idle_deadline() {
+        let session = Arc::new(test_session_mpp());
+        session.start_lifecycle_runloop_with_settlement_and_batching(
+            Duration::from_millis(30),
+            Duration::from_millis(1),
+            Duration::ZERO,
+            SessionLifecycleReconciliation::External,
+        );
+        let challenge = session.challenge(CAP).unwrap();
+        let handle = SessionHandle::new(
+            solana_pubkey::Pubkey::new_unique(),
+            test_session_signer(),
+            challenge,
+        );
+
+        let open_header = handle.open_header(CAP, "open_sig").await.unwrap();
+        let SessionOutcome::Active { state: opened, .. } =
+            session.process(&open_header).await.unwrap()
+        else {
+            panic!("expected open to return active session");
+        };
+        let lease = session
+            .reserve_delegated_capacity(&opened.channel_id, CAP)
+            .await
+            .unwrap()
+            .expect("request should reserve channel capacity");
+        let initial_deadline = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&opened.channel_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .lifecycle
+            .unwrap()
+            .close_after;
+
+        tokio::time::sleep(Duration::from_millis(35)).await;
+
+        let heartbeat_deadline = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&opened.channel_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .lifecycle
+            .unwrap()
+            .close_after;
+        assert!(
+            heartbeat_deadline > initial_deadline,
+            "an in-flight request must renew the external worker's idle deadline"
+        );
+
+        drop(lease);
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        let released_deadline = session
+            .operator_runtime
+            .channel_store
+            .get_channel(&opened.channel_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .lifecycle
+            .unwrap()
+            .close_after;
+        assert_eq!(
+            released_deadline, heartbeat_deadline,
+            "dropping the request lease must stop lifecycle heartbeats"
         );
     }
 

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1521,9 +1521,7 @@ impl SessionMpp {
             }
 
             SessionAction::Use(p) => {
-                let state = self
-                    .verify_use_authentication(p, &credential.challenge.id)
-                    .await?;
+                let state = self.verify_use_authentication(p).await?;
                 self.record_committed_watermark(state.channel_id.clone(), state.cumulative);
                 self.touch_channel(state.channel_id.clone()).await?;
                 Ok(SessionOutcome::Active {
@@ -1673,11 +1671,7 @@ impl SessionMpp {
     /// Authenticates the request only — metering happens response-side via
     /// [`Self::authorize_delegated_usage`], which prices the delivered
     /// service and persists the operator-signed cumulative voucher.
-    async fn verify_use_authentication(
-        &self,
-        payload: &UsePayload,
-        echoed_challenge_id: &str,
-    ) -> Result<ChannelState> {
+    async fn verify_use_authentication(&self, payload: &UsePayload) -> Result<ChannelState> {
         if self.voucher_signer() != SessionVoucherSigner::Operator {
             return Err(Error::Mpp(
                 "use is only valid for operator-signed sessions".to_string(),
@@ -1702,13 +1696,26 @@ impl SessionMpp {
                 "payment channel close is pending".to_string(),
             ));
         }
+        // A record with no binding at all is not a mismatch: it either
+        // predates proof binding or was rewritten by a pre-binding writer.
+        // Name it so the client knows re-opening — not retrying the proof —
+        // is the fix. Mirrors PayKit's process_use.
+        if state.opening_challenge_id.is_empty() && state.authentication.is_none() {
+            return Err(Error::PaymentRejected(
+                "session channel predates proof binding; open a new session".to_string(),
+            ));
+        }
         let bound = serde_json::to_string(&payload.authentication)
             .map_err(|error| Error::Mpp(format!("serialize authentication: {error}")))?;
         let proof = &payload.authentication;
+        // No comparison against the request's outer challenge id: per
+        // draft-solana-session-00 the same bearer proof is presented for the
+        // channel's whole lifetime while the outer challenge rotates, and
+        // PayKit's canonical check binds the proof to the opening challenge
+        // only.
         if state.voucher_signer != "operator"
             || state.authentication.as_deref() != Some(bound.as_str())
             || proof.challenge_id != state.opening_challenge_id
-            || echoed_challenge_id != state.opening_challenge_id
             || proof.payer != state.payer
             || !proof
                 .verify(&state.channel_id)
@@ -1770,6 +1777,8 @@ pub fn test_channel_state(
         pending_deliveries: vec![],
         committed_deliveries: vec![],
         lifecycle: None,
+        schema_version: pay_kit::mpp::CHANNEL_STATE_SCHEMA_VERSION,
+        extra: Default::default(),
     }
 }
 
@@ -2184,6 +2193,41 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("does not match the proof bound at open"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn use_names_a_record_that_predates_proof_binding() {
+        // A record whose binding fields were stripped by a pre-binding
+        // writer (or that predates proof binding) fails with its own error,
+        // not the generic proof mismatch.
+        let (session, challenge, _bound_channel, _proof, payer) =
+            operator_session_with_bound_channel().await;
+        let wiped = solana_pubkey::Pubkey::new_unique();
+        let payer_address = bs58::encode(payer.verifying_key().as_bytes()).into_string();
+        seed_channel(
+            &session,
+            &wiped.to_string(),
+            CAP,
+            &session.session_config.operator.clone(),
+            "",
+            "",
+            &payer_address,
+            None,
+        )
+        .await;
+        let proof =
+            SessionAuthentication::sign(challenge.id.clone(), &wiped.to_string(), &payer).unwrap();
+        let handle =
+            SessionHandle::new(wiped, test_session_signer(), challenge).with_authentication(proof);
+
+        let err = session
+            .process(&handle.use_header().await.unwrap())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("predates proof binding"),
             "got: {err}"
         );
     }

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -32,7 +32,7 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::{Duration, Instant};
 
 use crate::server::telemetry;
@@ -454,11 +454,13 @@ fn close_voucher_required(onchain_settled: u64, latest_accepted: u64) -> bool {
 pub struct DelegatedCapacityLease {
     runtime: SessionOperatorRuntime,
     channel_id: String,
+    cancel: watch::Sender<bool>,
     heartbeat: tokio::task::JoinHandle<()>,
 }
 
 impl Drop for DelegatedCapacityLease {
     fn drop(&mut self) {
+        let _ = self.cancel.send(true);
         self.heartbeat.abort();
         self.runtime.release_capacity(&self.channel_id);
     }
@@ -477,11 +479,22 @@ impl SessionLifecycleHandle {
     }
 
     async fn touch(&self, channel_id: String, touched_at_ms: u64) -> Result<Option<ChannelState>> {
+        self.touch_with_cancellation(channel_id, touched_at_ms, None)
+            .await
+    }
+
+    async fn touch_with_cancellation(
+        &self,
+        channel_id: String,
+        touched_at_ms: u64,
+        cancellation: Option<watch::Receiver<bool>>,
+    ) -> Result<Option<ChannelState>> {
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
             .send(SessionLifecycleCommand::Touch {
                 channel_id,
                 touched_at_ms,
+                cancellation,
                 response: response_tx,
             })
             .map_err(|_| Error::Mpp("session lifecycle runloop is unavailable".to_string()))?;
@@ -496,6 +509,7 @@ impl SessionLifecycleHandle {
         self.send(SessionLifecycleCommand::Touch {
             channel_id,
             touched_at_ms,
+            cancellation: None,
             response,
         });
     }
@@ -512,6 +526,7 @@ enum SessionLifecycleCommand {
     Touch {
         channel_id: String,
         touched_at_ms: u64,
+        cancellation: Option<watch::Receiver<bool>>,
         response: oneshot::Sender<std::result::Result<Option<ChannelState>, String>>,
     },
 }
@@ -530,6 +545,20 @@ const MIN_LIFECYCLE_OWNER_LEASE: Duration = Duration::from_secs(30);
 const DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL: Duration = Duration::from_millis(10);
+
+async fn run_while_lease_active<T>(
+    mut cancellation: watch::Receiver<bool>,
+    operation: impl std::future::Future<Output = T>,
+) -> Option<T> {
+    if *cancellation.borrow() {
+        return None;
+    }
+    tokio::select! {
+        biased;
+        _ = cancellation.changed() => None,
+        result = operation => Some(result),
+    }
+}
 
 fn parse_lifecycle_owner_lease(owner: &str) -> Option<(&str, u64)> {
     let owner = owner.strip_prefix(LIFECYCLE_OWNER_LEASE_PREFIX)?;
@@ -615,12 +644,24 @@ impl SessionLifecycleRunloop {
             Some(SessionLifecycleCommand::Touch {
                 channel_id,
                 touched_at_ms,
+                cancellation,
                 response,
             }) => {
-                let result = self
-                    .persist_touch(&channel_id, touched_at_ms)
-                    .await
-                    .map_err(|error| error.to_string());
+                let result = match cancellation {
+                    Some(cancellation) => {
+                        let Some(result) = run_while_lease_active(
+                            cancellation,
+                            self.persist_touch(&channel_id, touched_at_ms),
+                        )
+                        .await
+                        else {
+                            return true;
+                        };
+                        result
+                    }
+                    None => self.persist_touch(&channel_id, touched_at_ms).await,
+                }
+                .map_err(|error| error.to_string());
                 if let Err(error) = &result {
                     tracing::warn!(
                         channel_id,
@@ -1254,21 +1295,32 @@ impl SessionMpp {
 
         let lifecycle = self.lifecycle.clone();
         let heartbeat_channel_id = channel_id.to_string();
+        let (cancel, mut cancellation) = watch::channel(false);
         let heartbeat = tokio::spawn(async move {
             let mut interval = tokio::time::interval(DELEGATED_ACTIVITY_HEARTBEAT_INTERVAL);
             interval.tick().await;
             loop {
-                interval.tick().await;
+                tokio::select! {
+                    biased;
+                    _ = cancellation.changed() => break,
+                    _ = interval.tick() => {}
+                }
                 if let Err(error) = lifecycle
-                    .touch(heartbeat_channel_id.clone(), unix_millis())
+                    .touch_with_cancellation(
+                        heartbeat_channel_id.clone(),
+                        unix_millis(),
+                        Some(cancellation.clone()),
+                    )
                     .await
                 {
+                    if *cancellation.borrow() {
+                        break;
+                    }
                     tracing::warn!(
                         channel_id = heartbeat_channel_id,
                         %error,
                         "failed to heartbeat active delegated session"
                     );
-                    break;
                 }
             }
         });
@@ -1276,6 +1328,7 @@ impl SessionMpp {
         Ok(Some(DelegatedCapacityLease {
             runtime: self.operator_runtime.clone(),
             channel_id: channel_id.to_string(),
+            cancel,
             heartbeat,
         }))
     }
@@ -2406,6 +2459,27 @@ mod tests {
         assert_eq!(
             next_lifecycle_wakeup(Some(Duration::from_secs(5)), Some(Duration::from_secs(5))),
             Some((Duration::from_secs(5), true))
+        );
+    }
+
+    #[tokio::test]
+    async fn lease_cancellation_interrupts_in_flight_heartbeat() {
+        let (cancel, cancellation) = watch::channel(false);
+        let (started_tx, started_rx) = oneshot::channel();
+        let heartbeat = tokio::spawn(run_while_lease_active(cancellation, async move {
+            started_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        }));
+
+        started_rx.await.unwrap();
+        cancel.send(true).unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), heartbeat)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_none()
         );
     }
 

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -1279,6 +1279,7 @@ impl SessionMpp {
         let accepted = self
             .server
             .verify_voucher(&VoucherPayload {
+                channel_id: channel_id.to_string(),
                 voucher: SignedVoucher {
                     data,
                     signer: operator.to_string(),
@@ -1773,6 +1774,7 @@ pub fn test_channel_state(
         spent_amount: 0,
         settled_on_chain: 0,
         processed_uses: vec![],
+        processed_topup_signatures: vec![],
         next_delivery_sequence: 0,
         pending_deliveries: vec![],
         committed_deliveries: vec![],

--- a/rust/crates/core/src/server/session_stream.rs
+++ b/rust/crates/core/src/server/session_stream.rs
@@ -826,10 +826,11 @@ mod tests {
     use super::*;
     use crate::client::session::SessionHandle;
     use crate::server::metering::parse_tokens_per_quota_unit;
-    use crate::server::session::SessionOutcome;
-    use pay_kit::mpp::server::session::SessionConfig;
+    use crate::server::session::test_channel_state;
+    use pay_kit::mpp::blockhash::BlockhashCache;
+    use pay_kit::mpp::server::session::{SessionConfig, VoucherSigner};
     use pay_kit::mpp::solana_keychain::{SolanaSigner, memory::MemorySigner};
-    use pay_kit::mpp::{SessionMode, SessionSettlementAuthority};
+    use pay_kit::mpp::store::{ChannelStore, MemoryChannelStore};
     use pay_types::metering::{MeterDimension, PriceTier};
 
     fn dimension(
@@ -1146,33 +1147,57 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
         assert!(!has_stream_observable_dimension(&spec));
     }
 
+    fn stream_test_blockhash_cache() -> BlockhashCache {
+        let cache = BlockhashCache::new();
+        cache.set(
+            "SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxxxx11x".to_string(),
+            42,
+            123,
+        );
+        cache
+    }
+
     #[tokio::test]
     async fn chargeable_stream_chunk_waits_for_matching_commit() {
-        let session = Arc::new(SessionMpp::new(
-            SessionConfig {
-                operator: solana_pubkey::Pubkey::new_unique().to_string(),
-                recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-                max_cap: 1_000,
-                currency: solana_pubkey::Pubkey::new_unique().to_string(),
-                network: "localnet".to_string(),
-                min_voucher_delta: 1,
-                modes: vec![SessionMode::Push],
-                ..SessionConfig::default()
-            },
-            "stream-test-secret",
-        ));
-        let challenge = session.challenge(1_000).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            stream_test_signer(),
-            challenge,
+        let store: Arc<dyn ChannelStore> = Arc::new(MemoryChannelStore::new());
+        let session = Arc::new(
+            SessionMpp::new_with_channel_store(
+                SessionConfig {
+                    operator: solana_pubkey::Pubkey::new_unique().to_string(),
+                    recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+                    suggested_deposit: Some(1_000),
+                    currency: solana_pubkey::Pubkey::new_unique().to_string(),
+                    network: "localnet".to_string(),
+                    min_voucher_delta: 1,
+                    ..SessionConfig::default()
+                },
+                "stream-test-secret",
+                Arc::clone(&store),
+            )
+            .with_blockhash_cache(stream_test_blockhash_cache()),
         );
-        let open_header = handle.open_header(1_000, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state, .. } = session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected an active session");
-        };
-        let context = SessionStreamContext::new(session.clone(), state.channel_id, 0);
+        let challenge = session.challenge(None).unwrap();
+        let channel = solana_pubkey::Pubkey::new_unique();
+        let signer = stream_test_signer();
+        let authorized_signer = signer.pubkey().to_string();
+        let handle = SessionHandle::new(channel, signer, challenge.clone());
+        let channel_id = channel.to_string();
+        store
+            .put_channel(
+                &channel_id,
+                test_channel_state(
+                    &channel_id,
+                    1_000,
+                    &authorized_signer,
+                    "client",
+                    &challenge.id,
+                    solana_pubkey::Pubkey::new_unique().to_string(),
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
+        let context = SessionStreamContext::new(session.clone(), channel_id, 0);
         let spec = SessionMeterSpec::new([SessionMeterDimension::required(
             MeterDirection::Output,
             BillingUnit::Bytes,
@@ -1214,42 +1239,51 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
         operator_keypair[32..].copy_from_slice(verifying_key.as_bytes());
         let operator: Arc<dyn SolanaSigner> =
             Arc::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
-        let client_operator: Box<dyn SolanaSigner> =
-            Box::new(MemorySigner::from_bytes(&operator_keypair).unwrap());
-        let mut config = SessionConfig {
+        let config = SessionConfig {
             operator: operator.pubkey().to_string(),
             recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-            max_cap: 1_000,
+            suggested_deposit: Some(1_000),
             currency: solana_pubkey::Pubkey::new_unique().to_string(),
             network: "localnet".to_string(),
             min_voucher_delta: 1,
-            modes: vec![SessionMode::Push],
+            voucher_signer: VoucherSigner::Operator,
             ..SessionConfig::default()
         };
-        config.settlement_authority = SessionSettlementAuthority::Delegated;
+        let store: Arc<dyn ChannelStore> = Arc::new(MemoryChannelStore::new());
         let session = Arc::new(
-            SessionMpp::new(config, "delegated-stream-test-secret")
-                .with_payment_channel_signer(operator),
+            SessionMpp::new_with_channel_store(
+                config,
+                "delegated-stream-test-secret",
+                Arc::clone(&store),
+            )
+            .with_blockhash_cache(stream_test_blockhash_cache())
+            .with_payment_channel_signer(Arc::clone(&operator)),
         );
-        let challenge = session.challenge(1_000).unwrap();
-        let handle = SessionHandle::new(
-            solana_pubkey::Pubkey::new_unique(),
-            client_operator,
-            challenge,
-        );
-        let open_header = handle.open_header(1_000, "open_sig").await.unwrap();
-        let SessionOutcome::Active { state, .. } = session.process(&open_header).await.unwrap()
-        else {
-            panic!("expected an active delegated session");
-        };
+        let challenge = session.challenge(None).unwrap();
+        let channel_id = solana_pubkey::Pubkey::new_unique().to_string();
+        store
+            .put_channel(
+                &channel_id,
+                test_channel_state(
+                    &channel_id,
+                    1_000,
+                    operator.pubkey().to_string(),
+                    "operator",
+                    &challenge.id,
+                    solana_pubkey::Pubkey::new_unique().to_string(),
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
         let reservation = session
-            .reserve_delegated_capacity(&state.channel_id, 1_000)
+            .reserve_delegated_capacity(&channel_id, 1_000)
             .await
             .unwrap()
             .expect("session capacity should be available");
         let forward = SessionForward::delegated(
             session.clone(),
-            state.channel_id.clone(),
+            channel_id.clone(),
             0,
             crate::server::metering::UptoSettlementPlan {
                 metering: metering(vec![MeterDimension {
@@ -1315,7 +1349,7 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
                 b"data: {\"choices\":[{\"delta\":{\"content\":\"one two three\"}}]}\n\n"
             )
         );
-        assert_eq!(session.committed_watermark(&state.channel_id), Some(3));
+        assert_eq!(session.committed_watermark(&channel_id), Some(3));
 
         assert!(
             tokio::time::timeout(Duration::from_millis(50), metered.next())
@@ -1336,7 +1370,7 @@ data: {"type":"message_delta","usage":{"output_tokens":5}}
             )
         );
         assert_eq!(
-            session.committed_watermark(&state.channel_id),
+            session.committed_watermark(&channel_id),
             Some(10),
             "retroactive repricing must collect the remaining authorization without failing the stream"
         );

--- a/rust/crates/core/src/skills/config.rs
+++ b/rust/crates/core/src/skills/config.rs
@@ -238,12 +238,20 @@ impl SkillsConfig {
         dir.join(format!("skills-{ts}-{hash}.json"))
     }
 
-    /// Remove every `skills-*.json` cache file except `keep`.
+    /// Remove `skills-*.json` cache files older than `keep`.
     ///
     /// Catalog files are timestamped, so even with an unchanged source hash
     /// each successful update writes a new file. Without this prune, repeat
     /// `pay skills update` calls would accumulate one stale catalog per run.
+    ///
+    /// Only files whose filename timestamp is strictly older than `keep`'s
+    /// are removed. Many pay processes (CLI, gateways, one MCP server per
+    /// agent session) refresh this cache independently; deleting everything
+    /// except our own write lets two racing refreshes delete each other's
+    /// file and leave no catalog at all, which downstream consumers read as
+    /// "catalog unavailable" long after both refreshes succeeded.
     pub fn clean_stale_caches(&self, keep: &std::path::Path) {
+        let keep_ts = cache_file_timestamp(keep);
         let dir = cache_dir();
         let Ok(entries) = std::fs::read_dir(&dir) else {
             return;
@@ -254,11 +262,25 @@ impl SkillsConfig {
                 continue;
             }
             let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with("skills-") && name.ends_with(".json") {
+            if name.starts_with("skills-")
+                && name.ends_with(".json")
+                && cache_file_timestamp(&path) < keep_ts
+            {
                 let _ = std::fs::remove_file(&path);
             }
         }
     }
+}
+
+/// Unix timestamp embedded in a `skills-<ts>-<hash>.json` cache filename,
+/// or 0 when the name doesn't carry one (legacy files sort as oldest).
+fn cache_file_timestamp(path: &std::path::Path) -> u64 {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_prefix("skills-"))
+        .and_then(|rest| rest.split('-').next())
+        .and_then(|ts| ts.parse().ok())
+        .unwrap_or(0)
 }
 
 /// Resolve a source shorthand to a URL.
@@ -482,5 +504,23 @@ mod tests {
     #[test]
     fn default_ttl_value() {
         assert_eq!(default_ttl(), 30);
+    }
+
+    #[test]
+    fn cache_file_timestamps_order_racing_refreshes() {
+        let older = std::path::Path::new("/tmp/skills-1785600000-aaaa1111.json");
+        let newer = std::path::Path::new("/tmp/skills-1785600042-bbbb2222.json");
+        assert_eq!(cache_file_timestamp(older), 1_785_600_000);
+        assert_eq!(cache_file_timestamp(newer), 1_785_600_042);
+        // A refresh only prunes strictly-older files, so two concurrent
+        // refreshes can never delete each other's write and leave zero
+        // catalogs behind.
+        assert!(cache_file_timestamp(older) < cache_file_timestamp(newer));
+        // Legacy names without a timestamp sort as oldest and are pruned
+        // by any timestamped write; an unparseable `keep` prunes nothing.
+        assert_eq!(
+            cache_file_timestamp(std::path::Path::new("/tmp/skills-cache.json")),
+            0
+        );
     }
 }

--- a/rust/crates/core/tests/openapi_resolve_smoke.rs
+++ b/rust/crates/core/tests/openapi_resolve_smoke.rs
@@ -7,13 +7,15 @@ fn stabledomains_openapi_resolves() {
     use pay_core::skills::openapi::resolve_endpoints;
     use pay_types::registry::OpenapiSource;
 
-    let src = OpenapiSource::Path {
-        path: "openapi.json".into(),
+    let src = OpenapiSource::Url {
+        url: "https://stabledomains.dev/openapi.json".into(),
     };
     let endpoints = resolve_endpoints(&src, "https://stabledomains.dev")
         .expect("resolver should succeed against live stabledomains openapi");
-    let by_path: std::collections::HashSet<_> =
-        endpoints.iter().map(|e| (&*e.method, &*e.path)).collect();
+    let by_path: std::collections::HashSet<_> = endpoints
+        .iter()
+        .map(|e| (&*e.spec.method, &*e.spec.path))
+        .collect();
     assert!(by_path.contains(&("POST", "api/register")));
     assert!(by_path.contains(&("POST", "api/domain/dns")));
     assert!(by_path.contains(&("POST", "api/domain/renew")));

--- a/rust/crates/core/tests/server_tests.rs
+++ b/rust/crates/core/tests/server_tests.rs
@@ -247,34 +247,53 @@ async fn start_respond_server() -> (String, tokio::task::JoinHandle<()>) {
     (url, handle)
 }
 
-fn test_session_mpp_for_currency(currency: &str) -> SessionMpp {
-    SessionMpp::new(
+fn test_session_blockhash_cache() -> pay_kit::mpp::blockhash::BlockhashCache {
+    let cache = pay_kit::mpp::blockhash::BlockhashCache::new();
+    cache.set(
+        "SURFNETxSAFEHASHxxxxxxxxxxxxxxxxxxxxx11x".to_string(),
+        42,
+        123,
+    );
+    cache
+}
+
+fn test_session_mpp_with_store(
+    currency: &str,
+) -> (SessionMpp, Arc<dyn pay_kit::mpp::store::ChannelStore>) {
+    let store: Arc<dyn pay_kit::mpp::store::ChannelStore> =
+        Arc::new(pay_kit::mpp::store::MemoryChannelStore::new());
+    let session = SessionMpp::new_with_channel_store(
         SessionConfig {
             operator: solana_pubkey::Pubkey::new_unique().to_string(),
             recipient: solana_pubkey::Pubkey::new_unique().to_string(),
-            max_cap: 5_000_000,
+            suggested_deposit: Some(5_000_000),
             currency: currency.to_string(),
             network: "localnet".to_string(),
-            modes: vec![
-                pay_kit::mpp::SessionMode::Push,
-                pay_kit::mpp::SessionMode::Pull,
-            ],
             ..SessionConfig::default()
         },
         "test-secret-key-do-not-use-32b-pad",
+        Arc::clone(&store),
     )
+    .with_blockhash_cache(test_session_blockhash_cache());
+    (session, store)
 }
 
-fn test_session_mpp() -> SessionMpp {
-    test_session_mpp_for_currency(&solana_pubkey::Pubkey::new_unique().to_string())
+fn test_session_mpp_for_currency(currency: &str) -> SessionMpp {
+    test_session_mpp_with_store(currency).0
 }
 
-async fn start_session_server() -> (String, tokio::task::JoinHandle<()>) {
+async fn start_session_server() -> (
+    String,
+    tokio::task::JoinHandle<()>,
+    Arc<dyn pay_kit::mpp::store::ChannelStore>,
+) {
+    let (session, store) =
+        test_session_mpp_with_store(&solana_pubkey::Pubkey::new_unique().to_string());
     let api = load_test_api();
     let state = SessionTestState {
         apis: Arc::new(vec![api]),
         mpp: None,
-        session_mpp: Some(Arc::new(test_session_mpp())),
+        session_mpp: Some(Arc::new(session)),
     };
 
     let app = Router::new()
@@ -289,7 +308,7 @@ async fn start_session_server() -> (String, tokio::task::JoinHandle<()>) {
     let url = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
     let handle = tokio::spawn(async { axum::serve(listener, app).await.unwrap() });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    (url, handle)
+    (url, handle, store)
 }
 
 async fn start_multi_currency_session_server() -> (String, tokio::task::JoinHandle<()>) {
@@ -581,7 +600,7 @@ async fn middleware_rejects_bearer_scheme() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn middleware_returns_session_challenge_when_session_mpp_configured() {
-    let (url, _h) = start_session_server().await;
+    let (url, _h, _store) = start_session_server().await;
     let client = reqwest::Client::new();
     let resp = client
         .post(format!("{url}/v1/simple/echo"))
@@ -650,8 +669,8 @@ async fn middleware_returns_one_session_challenge_per_configured_currency() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn middleware_accepts_session_open_and_voucher_then_close() {
-    let (url, _h) = start_session_server().await;
+async fn middleware_accepts_session_voucher_then_close() {
+    let (url, _h, store) = start_session_server().await;
     let client = reqwest::Client::new();
 
     let challenge_resp = client
@@ -670,25 +689,39 @@ async fn middleware_accepts_session_open_and_voucher_then_close() {
         .to_string();
     let challenge = pay_kit::mpp::parse_www_authenticate(&www_auth).unwrap();
 
-    let challenge_for_open = challenge.clone();
-    let (handle, open_header) = tokio::task::spawn_blocking(move || {
-        pay_core::session::open_session_header(&challenge_for_open, 1_000_000)
-    })
-    .await
-    .unwrap()
-    .unwrap();
-
-    let open_resp = client
-        .post(format!("{url}/v1/simple/echo"))
-        .headers(client_with_host("testapi"))
-        .header("authorization", open_header)
-        .body("{}")
-        .send()
+    // Opens now verify, broadcast, and confirm a real transaction (covered by
+    // the surfpool e2e tests); seed the confirmed channel state directly and
+    // drive the middleware with vouchers and close.
+    let channel = solana_pubkey::Pubkey::new_unique();
+    let (voucher_key, signer) = {
+        use ed25519_dalek::SigningKey;
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let vk = sk.verifying_key();
+        let mut kp = [0u8; 64];
+        kp[..32].copy_from_slice(sk.as_bytes());
+        kp[32..].copy_from_slice(vk.as_bytes());
+        let signer: Box<dyn pay_kit::mpp::solana_keychain::SolanaSigner> =
+            Box::new(pay_kit::mpp::solana_keychain::memory::MemorySigner::from_bytes(&kp).unwrap());
+        (sk, signer)
+    };
+    let authorized_signer = signer.pubkey().to_string();
+    store
+        .put_channel(
+            &channel.to_string(),
+            pay_core::server::session::test_channel_state(
+                channel.to_string(),
+                1_000_000,
+                &authorized_signer,
+                "client",
+                &challenge.id,
+                solana_pubkey::Pubkey::new_unique().to_string(),
+                None,
+            ),
+        )
         .await
         .unwrap();
-    // Client-voucher sessions acknowledge the open before requiring the first
-    // client-signed voucher for paid service.
-    assert_eq!(open_resp.status(), 402);
+    let handle = pay_core::session::SessionHandle::new(channel, signer, challenge.clone())
+        .with_voucher_key(voucher_key);
 
     let voucher_header = handle.voucher_header(25).await.unwrap();
     let voucher_resp = client

--- a/rust/crates/core/tests/surfpool_tests.rs
+++ b/rust/crates/core/tests/surfpool_tests.rs
@@ -31,41 +31,6 @@ async fn start_surfnet() -> &'static Surfnet {
         .await
 }
 
-async fn submit_sol_transfer(
-    rpc_url: &str,
-    payer: &Keypair,
-    recipient: &str,
-    lamports: u64,
-) -> String {
-    use pay_kit::mpp::solana_keychain::SolanaSigner;
-    use pay_kit::mpp::solana_keychain::memory::MemorySigner;
-    use pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient;
-    use solana_message::Message;
-    use solana_pubkey::Pubkey;
-    use solana_signature::Signature;
-    use solana_system_interface::instruction as system_instruction;
-    use solana_transaction::Transaction;
-
-    let signer = MemorySigner::from_bytes(&payer.to_bytes()).unwrap();
-    let sender = signer.pubkey();
-    let recipient = recipient.parse::<Pubkey>().unwrap();
-    let rpc = RpcClient::new(rpc_url.to_string());
-    let blockhash = rpc.get_latest_blockhash().unwrap();
-    let ix = system_instruction::transfer(&sender, &recipient, lamports);
-    let message = Message::new_with_blockhash(&[ix], Some(&sender), &blockhash);
-    let mut tx = Transaction::new_unsigned(message);
-    let sig_bytes = signer.sign_message(&tx.message_data()).await.unwrap();
-    let sig = Signature::from(<[u8; 64]>::from(sig_bytes));
-    let signer_index = tx
-        .message
-        .account_keys
-        .iter()
-        .position(|key| key == &sender)
-        .unwrap();
-    tx.signatures[signer_index] = sig;
-    rpc.send_and_confirm_transaction(&tx).unwrap().to_string()
-}
-
 // =============================================================================
 // balance
 // =============================================================================
@@ -469,15 +434,12 @@ async fn push_session_full_flow() {
     use axum::routing::any;
     use pay_core::PaymentState;
     use pay_core::server::session::SessionMpp;
-    use pay_kit::mpp::client::session::ActiveSession;
     use pay_kit::mpp::program::payment_channels::generated::generated::{
         accounts::Channel, types::SettlementWatermarks,
     };
     use pay_kit::mpp::server::session::SessionConfig;
     use pay_kit::mpp::solana_keychain::memory::MemorySigner;
-    use pay_kit::mpp::{
-        PaymentCredential, SessionMode, format_authorization, parse_www_authenticate,
-    };
+    use pay_kit::mpp::{PaymentCredential, format_authorization, parse_www_authenticate};
     use pay_types::metering::ApiSpec;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -501,38 +463,161 @@ async fn push_session_full_flow() {
     }
 
     // ── Infrastructure ─────────────────────────────────────────────────────
-    let surfnet = start_surfnet().await;
-    let rpc_url = surfnet.rpc_url().to_string();
-
+    // The final session wire makes the server the broadcaster of the client's
+    // open transaction: `process_open` re-broadcasts the payload transaction
+    // and verifies the resulting on-chain channel account. Surfpool cannot run
+    // the payment-channels program, so this test fronts the session server
+    // with a canned JSON-RPC endpoint (the same pattern as pay-kit's own
+    // full-path open tests) while everything above it — pay's payment
+    // middleware, the challenge binding, the real client-side opener,
+    // vouchers, and close — runs for real.
     let operator = Keypair::new();
     let recipient = Keypair::new();
-
-    // Fund the client that will "deposit" into the session channel.
     let client_kp = Keypair::new();
-    surfnet
-        .cheatcodes()
-        .fund_sol(&client_kp.pubkey(), 2_000_000_000)
-        .unwrap();
+    let session_kp = Keypair::new();
 
     let api: ApiSpec =
         serde_yml::from_str(&std::fs::read_to_string("tests/fixtures/test-paywall.yml").unwrap())
             .unwrap();
 
-    // 1 USDC cap (6 decimals). rpc_url enables on-chain signature verification.
+    // Deterministic open parameters so the canned channel account below
+    // matches what the real client-side opener derives from the challenge.
+    let deposit = 1_000_000u64; // 1 USDC
+    let salt = 42u64;
+    let grace_period = 900u32;
+    let challenged_slot = 33u64;
+    let challenged_blockhash = solana_hash::Hash::new_from_array([7; 32]);
+    let mint = solana_pubkey::Pubkey::from_str(pay_kit::mpp::mints::USDC_MAINNET).unwrap();
+    let token_program =
+        solana_pubkey::Pubkey::from_str(pay_kit::mpp::programs::TOKEN_PROGRAM).unwrap();
+    let program_id = pay_kit::mpp::program::payment_channels::default_program_id();
+    let open_params = pay_kit::mpp::program::payment_channels::OpenChannelParams {
+        payer: client_kp.pubkey(),
+        // The client-side opener pins rentPayer == fee payer == payer.
+        rent_payer: client_kp.pubkey(),
+        payee: recipient.pubkey(),
+        mint,
+        authorized_signer: session_kp.pubkey(),
+        salt,
+        open_slot: challenged_slot,
+        deposit,
+        grace_period,
+        recipients: vec![],
+        token_program,
+        program_id,
+    };
+    let channel_id =
+        pay_kit::mpp::program::payment_channels::derive_channel_addresses(&open_params).channel;
+    let (_, bump) = pay_kit::mpp::program::payment_channels::find_channel_pda(
+        &open_params.payer,
+        &open_params.payee,
+        &open_params.mint,
+        &open_params.authorized_signer,
+        open_params.salt,
+        open_params.open_slot,
+        &open_params.program_id,
+    );
+    let channel = Channel {
+        discriminator: 1,
+        version: 1,
+        bump,
+        status: 0,
+        salt,
+        deposit,
+        settlement: SettlementWatermarks {
+            settled: 0,
+            payout_watermark: 0,
+        },
+        closure_started_at: 0,
+        payer_withdrawn_at: 0,
+        grace_period,
+        distribution_hash: pay_kit::mpp::program::payment_channels::distribution_hash(&[]),
+        payer: client_kp.pubkey(),
+        payee: recipient.pubkey(),
+        authorized_signer: session_kp.pubkey(),
+        mint,
+        rent_payer: client_kp.pubkey(),
+        open_slot: challenged_slot,
+    };
+    let channel_data = borsh::to_vec(&channel).unwrap();
+
+    // Canned Solana JSON-RPC: acknowledge the broadcast, report it finalized,
+    // and serve the channel account the verified open would have created.
+    let rpc_owner = program_id.to_string();
+    let rpc_channel_data = channel_data.clone();
+    let rpc_app = Router::new().route(
+        "/",
+        axum::routing::post(move |body: axum::Json<serde_json::Value>| {
+            let channel_data = rpc_channel_data.clone();
+            let owner = rpc_owner.clone();
+            async move {
+                use base64::Engine as _;
+                let result = match body["method"].as_str().unwrap_or_default() {
+                    "sendTransaction" => serde_json::json!(
+                        pay_kit::mpp::program::payment_channels::decode_transaction(
+                            body["params"][0].as_str().unwrap()
+                        )
+                        .unwrap()
+                        .signatures[0]
+                            .to_string()
+                    ),
+                    "getSignatureStatuses" => serde_json::json!({
+                        "context": { "slot": 34 },
+                        "value": [{
+                            "slot": 34,
+                            "confirmations": null,
+                            "err": null,
+                            "confirmationStatus": "finalized",
+                            "status": { "Ok": null }
+                        }]
+                    }),
+                    "getAccountInfo" => serde_json::json!({
+                        "context": { "slot": 34 },
+                        "value": {
+                            "data": [
+                                base64::engine::general_purpose::STANDARD.encode(&channel_data),
+                                "base64"
+                            ],
+                            "executable": false,
+                            "lamports": 1_000_000u64,
+                            "owner": owner,
+                            "rentEpoch": 0,
+                            "space": channel_data.len()
+                        }
+                    }),
+                    other => panic!("unexpected RPC method {other}"),
+                };
+                axum::Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": body["id"].clone(),
+                    "result": result
+                }))
+            }
+        }),
+    );
+    let rpc_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let rpc_url = format!("http://{}", rpc_listener.local_addr().unwrap());
+    tokio::spawn(async { axum::serve(rpc_listener, rpc_app).await.unwrap() });
+
+    // The challenge advertises the open-transaction context from this cache;
+    // the client binds its open transaction to the same values.
+    let blockhash_cache = pay_kit::mpp::blockhash::BlockhashCache::new();
+    blockhash_cache.set(challenged_blockhash.to_string(), 100, challenged_slot);
+
     let session_mpp = SessionMpp::new(
         SessionConfig {
             operator: operator.pubkey().to_string(),
             recipient: recipient.pubkey().to_string(),
-            max_cap: 1_000_000,
             currency: "USDC".to_string(),
             decimals: 6,
             network: "localnet".to_string(),
-            modes: vec![SessionMode::Push],
+            grace_period_seconds: grace_period,
             rpc_url: Some(rpc_url.clone()),
             ..Default::default()
         },
         "test-session-secret",
-    );
+    )
+    .with_blockhash_cache(blockhash_cache);
 
     let state = S {
         apis: Arc::new(vec![api]),
@@ -584,101 +669,38 @@ async fn push_session_full_flow() {
 
     // ── Step 2: Open session ───────────────────────────────────────────────
     // Session key: any Ed25519 keypair — signs vouchers, never touches chain.
-    let session_kp = Keypair::new();
     let session_signer: Box<dyn pay_kit::mpp::solana_keychain::SolanaSigner> =
         Box::new(MemorySigner::from_bytes(&session_kp.to_bytes()).unwrap());
+    let payer_signer = MemorySigner::from_bytes(&client_kp.to_bytes()).unwrap();
 
-    // Submit a real SOL transfer to surfpool as a stand-in for the Fiber
-    // channel open. The server verifies this tx is confirmed on-chain before
-    // accepting the open.
-    let open_tx_sig = submit_sol_transfer(
-        &rpc_url,
-        &client_kp,
-        &operator.pubkey().to_string(),
-        10_000_000,
-    )
-    .await;
-
-    // Surfpool does not load the payment-channels program for this middleware
-    // integration test, so install the account state that a confirmed open
-    // would have created. The server now requires both the confirmed open
-    // signature and the channel account before it creates session state.
-    let deposit = 1_000_000u64; // 1 USDC
-    let mint = solana_pubkey::Pubkey::from_str(pay_kit::mpp::mints::USDC_MAINNET).unwrap();
-    let token_program =
-        solana_pubkey::Pubkey::from_str(pay_kit::mpp::programs::TOKEN_PROGRAM).unwrap();
-    let salt = 42;
-    let open_slot = pay_kit::mpp::solana_rpc_client::rpc_client::RpcClient::new(rpc_url.clone())
-        .get_slot()
-        .unwrap();
-    let grace_period = 900;
-    let program_id = pay_kit::mpp::program::payment_channels::default_program_id();
-    let open_params = pay_kit::mpp::program::payment_channels::OpenChannelParams {
-        payer: client_kp.pubkey(),
-        rent_payer: operator.pubkey(),
-        payee: recipient.pubkey(),
-        mint,
-        authorized_signer: session_kp.pubkey(),
-        salt,
-        open_slot,
-        deposit,
-        grace_period,
-        recipients: vec![],
-        token_program,
-        program_id,
-    };
-    let channel_id =
-        pay_kit::mpp::program::payment_channels::derive_channel_addresses(&open_params).channel;
-    let (_, bump) = pay_kit::mpp::program::payment_channels::find_channel_pda(
-        &open_params.payer,
-        &open_params.payee,
-        &open_params.mint,
-        &open_params.authorized_signer,
-        open_params.salt,
-        open_params.open_slot,
-        &open_params.program_id,
-    );
-    let channel = Channel {
-        discriminator: 1,
-        version: 1,
-        bump,
-        status: 0,
-        salt,
-        deposit,
-        settlement: SettlementWatermarks {
-            settled: 0,
-            payout_watermark: 0,
+    // The real client-side opener: derives the channel from the challenge,
+    // builds the open transaction against the challenged `recentBlockhash`
+    // and `recentSlot`, and signs it with the payer key.
+    let challenged_request: pay_kit::mpp::SessionRequest = challenge.request.decode().unwrap();
+    let opened = pay_kit::mpp::client::create_payment_channel_session_opener(
+        &challenged_request,
+        &payer_signer,
+        session_signer,
+        None, // bind to the challenged recentBlockhash
+        pay_kit::mpp::client::PaymentChannelSessionOpenOptions {
+            open: pay_kit::mpp::client::PaymentChannelOpenOptions {
+                deposit: Some(deposit),
+                grace_period: Some(grace_period),
+                salt: Some(salt),
+                ..Default::default()
+            },
+            ..Default::default()
         },
-        closure_started_at: 0,
-        payer_withdrawn_at: 0,
-        grace_period,
-        distribution_hash: [0; 32],
-        payer: client_kp.pubkey(),
-        payee: recipient.pubkey(),
-        authorized_signer: session_kp.pubkey(),
-        mint,
-        rent_payer: operator.pubkey(),
-        open_slot,
-    };
-    let channel_data = borsh::to_vec(&channel).unwrap();
-    surfnet
-        .cheatcodes()
-        .set_account(&channel_id, 1_000_000, &channel_data, &program_id)
-        .unwrap();
-    let mut active = ActiveSession::new(channel_id, session_signer);
-
-    let open_action = active.open_payment_channel_action(
-        deposit,
-        &client_kp.pubkey().to_string(),
-        &recipient.pubkey().to_string(),
-        &mint.to_string(),
-        salt,
-        grace_period,
-        open_slot,
-        &open_tx_sig,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        opened.open.channel_id, channel_id,
+        "client-derived channel must match the canned RPC account"
     );
+    let mut active = opened.session;
     let auth =
-        format_authorization(&PaymentCredential::new(challenge.to_echo(), open_action)).unwrap();
+        format_authorization(&PaymentCredential::new(challenge.to_echo(), opened.action)).unwrap();
 
     let resp = http
         .post(format!("{url}/v1/simple/echo"))
@@ -736,7 +758,9 @@ async fn push_session_full_flow() {
     assert_eq!(resp.status(), 200, "second voucher should return 200");
 
     // ── Step 4: Close session ──────────────────────────────────────────────
-    let close_action = active.close_action(None).await.unwrap();
+    // A client-voucher close must carry the final voucher; sign one last
+    // increment covering the closing request.
+    let close_action = active.close_action(Some(1_000)).await.unwrap();
     let auth =
         format_authorization(&PaymentCredential::new(challenge.to_echo(), close_action)).unwrap();
 

--- a/rust/crates/pdb/src/correlation.rs
+++ b/rust/crates/pdb/src/correlation.rs
@@ -1459,7 +1459,7 @@ fn session_from_authorization(
     let receipt = parse_commit_receipt(entry.res_body.as_deref());
     let voucher_data = payload
         .get("voucher")
-        .and_then(|voucher| voucher.get("data"));
+        .and_then(|voucher| voucher.get("voucher").or_else(|| voucher.get("data")));
     let cumulative = receipt
         .as_ref()
         .and_then(|r| r.cumulative.clone())
@@ -1892,7 +1892,7 @@ mod tests {
                 "action": "commit",
                 "deliveryId": "delivery-1",
                 "voucher": {
-                    "data": {
+                    "voucher": {
                         "channelId": "channel-111",
                         "cumulativeAmount": "25",
                         "expiresAt": 4102444800_u64
@@ -1930,6 +1930,45 @@ mod tests {
         assert_eq!(session.delivery_id.as_deref(), Some("delivery-1"));
         assert_eq!(session.voucher_count, Some(1));
         assert_eq!(session.currency.as_deref(), Some("USDC"));
+    }
+
+    #[test]
+    fn session_voucher_parses_legacy_inner_data_key() {
+        // Captures recorded before the kit's spec-shape rename (inner key
+        // `data` -> `voucher`, mpp-specs e702dd8) must keep parsing.
+        let (tx, _rx) = broadcast::channel(16);
+        let mut engine = FlowCorrelation::new(tx);
+
+        let mut challenge = make_entry("POST", "/v1/generate", 402);
+        challenge
+            .res_headers
+            .insert("www-authenticate".into(), session_challenge_header());
+        engine.ingest(challenge);
+
+        let mut commit = make_entry("POST", "/v1/generate", 200);
+        commit.req_headers.insert(
+            "authorization".into(),
+            session_authorization(serde_json::json!({
+                "action": "commit",
+                "deliveryId": "delivery-1",
+                "voucher": {
+                    "data": {
+                        "channelId": "channel-111",
+                        "cumulativeAmount": "25",
+                        "expiresAt": 4102444800_u64
+                    },
+                    "signature": "voucher-signature"
+                }
+            })),
+        );
+        engine.ingest(commit);
+
+        let flows = engine.snapshot();
+        assert_eq!(flows.len(), 1);
+        let session = flows[0].session.as_ref().expect("session metadata");
+        assert_eq!(session.session_id.as_deref(), Some("channel-111"));
+        assert_eq!(session.cumulative.as_deref(), Some("25"));
+        assert_eq!(session.voucher_count, Some(1));
     }
 
     #[test]

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -897,18 +897,27 @@ pub enum SessionPullVoucherStrategy {
     OperatedVoucher,
 }
 
+/// Compatibility default for legacy pull-mode channel-open batching. The
+/// current server retains the setting in parsed specs but does not schedule
+/// channel opens from it.
 fn default_session_batch_open_interval_ms() -> u64 {
     400
 }
 
+/// Idle grace period restarted by each channel touch. The resulting deadline
+/// is rounded separately by `close_batch_interval_ms`.
 fn default_session_close_delay_ms() -> u64 {
     600_000
 }
 
+/// Deadline bucket width for grouping idle closes. This is neither the idle
+/// grace period nor the reconciliation worker's polling interval.
 fn default_session_close_batch_interval_ms() -> u64 {
     60_000
 }
 
+/// Cadence for pushing active-channel watermarks in embedded reconciliation
+/// mode. External reconciliation workers use their own configured cadence.
 fn default_session_settlement_interval_ms() -> u64 {
     5_000
 }

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -863,7 +863,8 @@ pub struct SessionSpec {
     pub batch_open_interval_ms: u64,
     /// Idle delay before the operator closes and settles the payment channel.
     ///
-    /// Defaults to `15000` when omitted. Set to `0` to disable automatic close.
+    /// Defaults to `600000` (ten minutes) when omitted. Set to `0` to disable
+    /// automatic close.
     #[serde(default = "default_session_close_delay_ms")]
     pub close_delay_ms: u64,
     /// Boundary used to group idle channel closes into settlement batches.
@@ -901,7 +902,7 @@ fn default_session_batch_open_interval_ms() -> u64 {
 }
 
 fn default_session_close_delay_ms() -> u64 {
-    15_000
+    600_000
 }
 
 fn default_session_close_batch_interval_ms() -> u64 {
@@ -2553,7 +2554,7 @@ mod tests {
         let session: SessionSpec = serde_json::from_str(r#"{"cap_usdc":10.0}"#).unwrap();
 
         assert_eq!(session.batch_open_interval_ms, 400);
-        assert_eq!(session.close_delay_ms, 15_000);
+        assert_eq!(session.close_delay_ms, 600_000);
         assert_eq!(session.close_batch_interval_ms, 60_000);
         assert_eq!(session.settlement_interval_ms, 5_000);
         assert_eq!(

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -383,11 +383,20 @@ pub enum AuthConfig {
     /// OAuth2 — fetch access token and inject as `Authorization: Bearer`.
     Oauth2 {
         /// Token endpoint URL (e.g. `https://oauth2.googleapis.com/token`).
-        /// Special value `"gcp_metadata"` uses the GCP metadata server.
+        /// Special value `"gcp_metadata"` uses the GCP metadata server to
+        /// mint an OAuth2 access token; `"gcp_metadata_identity"` mints an
+        /// audience-bound OIDC identity token instead (for invoking
+        /// IAM-protected services such as private Cloud Run) and requires
+        /// `audience`.
         token_url: String,
         /// OAuth2 scopes to request.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         scopes: Vec<String>,
+        /// OIDC audience for `token_url: gcp_metadata_identity` — the URL of
+        /// the IAM-protected service being invoked (e.g. the Cloud Run
+        /// service URL). Required in identity mode, rejected otherwise.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        audience: Option<String>,
         /// Env var for client_id (for client_credentials grant).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         client_id_from_env: Option<String>,
@@ -1691,6 +1700,30 @@ fn validate_auth_config(auth: &AuthConfig, context: &str, errs: &mut Vec<String>
             fetch,
             inject,
         } => validate_access_token_auth(prepare, fetch, inject, context, errs),
+        AuthConfig::Oauth2 {
+            token_url,
+            scopes,
+            audience,
+            ..
+        } => {
+            let identity = token_url == "gcp_metadata_identity";
+            let has_audience = audience.as_deref().is_some_and(|a| !a.trim().is_empty());
+            if identity && !has_audience {
+                errs.push(format!(
+                    "{context}: oauth2.token_url `gcp_metadata_identity` requires oauth2.audience — set it to the URL of the IAM-protected service being invoked (e.g. the Cloud Run service URL)"
+                ));
+            }
+            if !identity && audience.is_some() {
+                errs.push(format!(
+                    "{context}: oauth2.audience is only valid with token_url `gcp_metadata_identity` (got token_url `{token_url}`)"
+                ));
+            }
+            if identity && !scopes.is_empty() {
+                errs.push(format!(
+                    "{context}: oauth2.scopes are not supported with token_url `gcp_metadata_identity` — identity tokens are bound to an audience, not scopes"
+                ));
+            }
+        }
         _ => {}
     }
 }
@@ -4672,6 +4705,85 @@ endpoints:
             errs.iter()
                 .any(|e| e.contains("does not support nested oauth2 auth")),
             "expected nested oauth2 validation error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_oauth2_identity_requires_audience() {
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity"#,
+        ))
+        .unwrap();
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter().any(|e| e.contains("requires oauth2.audience")),
+            "expected missing-audience validation error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_oauth2_audience_requires_identity_token_url() {
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: https://oauth.example.com/token
+    audience: https://svc-xyz.a.run.app"#,
+        ))
+        .unwrap();
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("oauth2.audience is only valid with token_url")),
+            "expected audience-without-identity validation error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_oauth2_identity_rejects_scopes() {
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity
+    audience: https://svc-xyz.a.run.app
+    scopes:
+      - https://www.googleapis.com/auth/cloud-platform"#,
+        ))
+        .unwrap();
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("oauth2.scopes are not supported")),
+            "expected scopes-with-identity validation error, got: {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_oauth2_identity_with_audience_is_valid() {
+        let spec: ApiSpec = serde_yml::from_str(&access_token_auth_yaml(
+            r#"    method: oauth2
+    token_url: gcp_metadata_identity
+    audience: https://svc-xyz.a.run.app"#,
+        ))
+        .unwrap();
+
+        match spec.routing.auth() {
+            Some(AuthConfig::Oauth2 {
+                token_url,
+                audience,
+                ..
+            }) => {
+                assert_eq!(token_url, "gcp_metadata_identity");
+                assert_eq!(audience.as_deref(), Some("https://svc-xyz.a.run.app"));
+            }
+            other => panic!("expected oauth2 auth, got: {other:?}"),
+        }
+
+        let errs = validate_api_spec(&spec);
+        assert!(
+            !errs.iter().any(|e| e.contains("oauth2")),
+            "expected no oauth2 validation errors, got: {errs:?}"
         );
     }
 

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -810,13 +810,14 @@ impl SignerConfig {
 /// is configured for MPP session payments (off-chain vouchers).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum SessionSettlementAuthority {
+pub enum SessionVoucherSigner {
     /// The client owns the channel voucher key and signs each cumulative debit.
     #[default]
-    ClientVoucher,
-    /// The client delegates voucher authority to the gateway operator, which
-    /// meters successful responses and signs their cumulative settlement.
-    Delegated,
+    Client,
+    /// The client binds the gateway operator as the channel's voucher signer;
+    /// the operator meters successful responses and signs their cumulative
+    /// settlement while the client authenticates with a reusable payer proof.
+    Operator,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -828,39 +829,17 @@ pub struct SessionSpec {
     /// Prevents spam vouchers smaller than one API call's cost.
     #[serde(default)]
     pub min_voucher_delta: u64,
-    /// Who signs cumulative settlement vouchers. Independent from `modes`,
-    /// which controls how channel transactions are submitted.
+    /// Who signs cumulative settlement vouchers (`client` or `operator`).
     #[serde(default)]
-    pub settlement_authority: SessionSettlementAuthority,
-    /// Session modes this server accepts.
+    pub voucher_signer: SessionVoucherSigner,
+    /// Inactivity thresholds (seconds) offered to clients for negotiation.
     ///
-    /// Allowed values: `"push"` (payment channel, client-funded) and/or
-    /// `"pull"` (SPL token delegation, operator fee-pays the approve tx).
-    ///
-    /// Defaults to `["push"]` when omitted.
-    ///
-    /// Example YAML:
-    /// ```yaml
-    /// session:
-    ///   cap_usdc: 10.0
-    ///   modes: [push, pull]
-    /// ```
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub modes: Vec<String>,
-    /// Pull voucher strategy.
-    ///
-    /// This disambiguates pull-mode sessions:
-    /// - `disabled`: do not advertise or accept pull sessions.
-    /// - `client_voucher`: client signs vouchers; no multi-delegate setup.
-    /// - `operated_voucher`: operator signs vouchers after metering and uses
-    ///   multi-delegate setup for delegated token movement.
-    #[serde(default)]
-    pub pull_voucher_strategy: SessionPullVoucherStrategy,
-    /// Legacy pull-mode channel-open batch flush interval in milliseconds.
-    ///
-    /// Defaults to `400` when omitted.
-    #[serde(default = "default_session_batch_open_interval_ms")]
-    pub batch_open_interval_ms: u64,
+    /// When set, this must be a non-empty, strictly increasing list of
+    /// integers between 1 and 2592000 (30 days). The client may select one
+    /// value in its `open` credential; when omitted the server picks the
+    /// effective timeout from `close_delay_ms`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_options_seconds: Option<Vec<u32>>,
     /// Idle delay before the operator closes and settles the payment channel.
     ///
     /// Defaults to `600000` (ten minutes) when omitted. Set to `0` to disable
@@ -886,22 +865,6 @@ pub struct SessionSpec {
     /// converted to basis points for the payment channel distribution.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub splits: Vec<SplitRule>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum SessionPullVoucherStrategy {
-    #[default]
-    Disabled,
-    ClientVoucher,
-    OperatedVoucher,
-}
-
-/// Compatibility default for legacy pull-mode channel-open batching. The
-/// current server retains the setting in parsed specs but does not schedule
-/// channel opens from it.
-fn default_session_batch_open_interval_ms() -> u64 {
-    400
 }
 
 /// Idle grace period restarted by each channel touch. The resulting deadline
@@ -2562,14 +2525,10 @@ mod tests {
     fn session_spec_defaults_lifecycle_intervals() {
         let session: SessionSpec = serde_json::from_str(r#"{"cap_usdc":10.0}"#).unwrap();
 
-        assert_eq!(session.batch_open_interval_ms, 400);
         assert_eq!(session.close_delay_ms, 600_000);
         assert_eq!(session.close_batch_interval_ms, 60_000);
         assert_eq!(session.settlement_interval_ms, 5_000);
-        assert_eq!(
-            session.settlement_authority,
-            SessionSettlementAuthority::ClientVoucher
-        );
+        assert_eq!(session.voucher_signer, SessionVoucherSigner::Client);
     }
 
     #[test]
@@ -2592,15 +2551,10 @@ mod tests {
     }
 
     #[test]
-    fn session_spec_parses_delegated_settlement_authority() {
+    fn session_spec_parses_operator_voucher_signer() {
         let session: SessionSpec =
-            serde_json::from_str(r#"{"cap_usdc":10.0,"settlement_authority":"delegated"}"#)
-                .unwrap();
-
-        assert_eq!(
-            session.settlement_authority,
-            SessionSettlementAuthority::Delegated
-        );
+            serde_json::from_str(r#"{"cap_usdc":10.0,"voucher_signer":"operator"}"#).unwrap();
+        assert_eq!(session.voucher_signer, SessionVoucherSigner::Operator);
     }
 
     #[test]
@@ -3783,10 +3737,8 @@ value_from_env: PAY_SIGNER_KEYPAIR
         spec.session = Some(SessionSpec {
             cap_usdc: 10.0,
             min_voucher_delta: 0,
-            settlement_authority: SessionSettlementAuthority::ClientVoucher,
-            modes: vec![],
-            pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
-            batch_open_interval_ms: 400,
+            voucher_signer: SessionVoucherSigner::Client,
+            idle_timeout_options_seconds: None,
             close_delay_ms: 15_000,
             close_batch_interval_ms: 60_000,
             settlement_interval_ms: 5_000,
@@ -3950,10 +3902,8 @@ value_from_env: PAY_SIGNER_KEYPAIR
         spec.session = Some(SessionSpec {
             cap_usdc: 10.0,
             min_voucher_delta: 0,
-            settlement_authority: SessionSettlementAuthority::ClientVoucher,
-            modes: vec![],
-            pull_voucher_strategy: SessionPullVoucherStrategy::Disabled,
-            batch_open_interval_ms: 400,
+            voucher_signer: SessionVoucherSigner::Client,
+            idle_timeout_options_seconds: None,
             close_delay_ms: 15_000,
             close_batch_interval_ms: 60_000,
             settlement_interval_ms: 5_000,

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -2596,9 +2596,8 @@ mod tests {
         // A legacy/renamed key (e.g. a since-removed `settlement_authority`)
         // must be a hard parse error, not a silent no-op that leaves
         // `voucher_signer` defaulted to `client`.
-        let result: Result<SessionSpec, _> = serde_json::from_str(
-            r#"{"cap_usdc":10.0,"settlement_authority":"delegated"}"#,
-        );
+        let result: Result<SessionSpec, _> =
+            serde_json::from_str(r#"{"cap_usdc":10.0,"settlement_authority":"delegated"}"#);
         assert!(
             result.is_err(),
             "unknown field must be rejected, not silently ignored"

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -830,6 +830,7 @@ pub enum SessionVoucherSigner {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SessionSpec {
     /// Default channel cap offered to clients (USDC, human-readable).
     /// Clients may request a lower cap; the server will not exceed this.
@@ -2588,6 +2589,20 @@ mod tests {
         let session: SessionSpec =
             serde_json::from_str(r#"{"cap_usdc":10.0,"voucher_signer":"operator"}"#).unwrap();
         assert_eq!(session.voucher_signer, SessionVoucherSigner::Operator);
+    }
+
+    #[test]
+    fn session_spec_rejects_unknown_fields() {
+        // A legacy/renamed key (e.g. a since-removed `settlement_authority`)
+        // must be a hard parse error, not a silent no-op that leaves
+        // `voucher_signer` defaulted to `client`.
+        let result: Result<SessionSpec, _> = serde_json::from_str(
+            r#"{"cap_usdc":10.0,"settlement_authority":"delegated"}"#,
+        );
+        assert!(
+            result.is_err(),
+            "unknown field must be rejected, not silently ignored"
+        );
     }
 
     #[test]

--- a/rust/playground-api.yaml
+++ b/rust/playground-api.yaml
@@ -68,6 +68,10 @@ recipients:
 session:
   cap_usdc: 1.0
   close_delay_ms: 2000
+  # Inactivity thresholds (seconds) the client may pick between when opening
+  # the session; the server clamps the idle-close deadline to whichever is
+  # shorter than close_delay_ms.
+  idle_timeout_options_seconds: [30, 120, 600]
   # Settlement split: the platform takes 30% of the settled session total at
   # idle-close, the seller (operator) nets the remaining 70%. Session splits are
   # percentage-only (the channel settles a single cumulative amount).

--- a/rust/playground-api.yaml
+++ b/rust/playground-api.yaml
@@ -62,15 +62,12 @@ recipients:
 # settles and closes the channel.
 #
 # The canonical pay-kit `session()` adapter (and the JS playground client) opens
-# a payment-channel session in pull + clientVoucher mode — the client signs each
-# voucher, the operator only fee-pays/settles. Advertise that so the playground's
-# payment-channel session opener has the challenge it requires (a push-only
-# challenge makes it fail with "requires a pull-mode session challenge").
+# a payment-channel session with the client signing each voucher — the
+# operator only fee-pays/settles. `voucher_signer` defaults to `client`, which
+# matches that, so it's left unset here.
 session:
   cap_usdc: 1.0
   close_delay_ms: 2000
-  modes: [pull]
-  pull_voucher_strategy: client_voucher
   # Settlement split: the platform takes 30% of the settled session total at
   # idle-close, the seller (operator) nets the remaining 70%. Session splits are
   # percentage-only (the channel settles a single cumulative amount).

--- a/web-ui/proxy/alibaba-qwen.yml
+++ b/web-ui/proxy/alibaba-qwen.yml
@@ -30,10 +30,9 @@ recipients:
 session:
   cap_usdc: 10.0
   min_voucher_delta: 1
-  settlement_authority: delegated
+  voucher_signer: operator
   close_delay_ms: 15000
   settlement_interval_ms: 5000
-  modes: [push]
   splits:
     - recipient: gateway
       percent: 0.1

--- a/web-ui/proxy/google-gemini.yml
+++ b/web-ui/proxy/google-gemini.yml
@@ -33,7 +33,7 @@ session:
   # Clients may request a lower cap; the server will not accept higher.
   cap_usdc: 10.0
   # The gateway meters successful responses and signs cumulative vouchers.
-  settlement_authority: delegated
+  voucher_signer: operator
   # Minimum voucher increment (base units = µUSDC).
   # Official Gemini token prices can be sub-µUSDC per token. We settle in
   # 0.000001 USDC quanta (1 µUSDC) once usage has accumulated enough value.
@@ -43,7 +43,6 @@ session:
   settlement_interval_ms: 5000
   # The agent payer opens the channel and reuses its authorization while the
   # delegated gateway operator signs metered vouchers.
-  modes: [push]
   splits:
     - recipient: platform
       percent: 0.1


### PR DESCRIPTION
## Summary

- keep delegated session lifecycle deadlines alive while an upstream request is in flight
- decouple idle-close reconciliation from shorter settlement wakeups
- retry transient cached-session store conflicts without opening a replacement channel
- preserve cached sessions on non-terminal 402 responses
- default omitted `session.close_delay_ms` values to ten minutes
- pin PayKit to `dc3a36ee` (merged squash of solana-foundation/pay-kit#259: reworked MPP session API + idle-close root fix + old-writer-safe channel records) and cascade: fallible challenge build that fails the challenge instead of silently degrading, `with_blockhash_cache` pass-through, end-to-end queued-touch-discard regression test
- share metering's model-support policy with provider discovery: a `default` pricing-variant sentinel keeps the full advertised model list (runtime prices unlisted models via that sentinel); non-chat entries are dropped by capability (`supportedGenerationMethods`) instead of by pricing; providers without a sentinel intersect with named families as before
- repair the network-gated openapi smoke test, broken on main since #398 (never built by CI)

### Picker/metering policy note

`resolve_price` also falls back to top-level endpoint `dimensions` (e.g. Model Studio's conservative list-price backstop), so the runtime technically prices every model for those providers too. That fallback deliberately does **not** admit models to the picker: only the `default` sentinel is the catalog author's promise that unlisted models are first-class; the dimensions backstop is quote safety at a punitive rate, and hiding those models steers users toward correctly-priced families instead of silently billing at the backstop. Documented on `models_matching_configured_families`.

`pay-kit#259` has merged and `dc3a36ee` (`d829fa0`) is the final pin — no further re-point pending.

2026-08-01 incident follow-up (`367dd9f`): mirrors PayKit's new pre-binding row split ("session channel predates proof binding" instead of the generic mismatch for rows that predate — or were stripped of — the proof binding), and drops the extra echoed-challenge-id comparison PayKit's canonical check doesn't have. Deploy alongside agent-gateway#14 (settlement worker pin) and the four sibling gateways.

### GCP identity tokens for IAM-locked upstreams (`bc95dca`)

Folded in per pay-cli thread: `oauth2` auth gains an optional `audience` and the special `token_url: gcp_metadata_identity`, minting an audience-bound OIDC identity token from the metadata server's `/identity` endpoint (raw JWT; cache TTL from its own `exp` claim). This is what invoking IAM-protected Cloud Run services (scale-to-zero micro-agents) needs — a `gcp_metadata` access token doesn't work there. Fail-closed validation: identity mode requires `audience`; `audience` or `scopes` with the wrong `token_url` are spec errors with actionable messages. Token cache key now includes audience. No ADC fallback — user credentials cannot mint audience-bound identity tokens, and the error says so.

### Picker "unpriced" root cause: skills cache wiped by racing refreshes (`6f773a7`, `7d3e568`)

The recurring all-models-unpriced picker state had a second cause beyond the family-intersect bug fixed in `2a6b14f`: `clean_stale_caches` deleted every `skills-*.json` except the file its own process just wrote, so two concurrent catalog refreshes (there is one `pay mcp` per agent session) could delete each other's write and leave **zero** cache files. With no cached catalog, picker discovery silently fell back to the built-in `google_gemini_fallback`/`alibaba_modelstudio_fallback` providers, which deliberately carry no pricing — every model rendered "unpriced". Reproduced live (cache absent → 11 Gemini models, all unpriced) and verified fixed (same state → catalog fetched, 42 models, all priced).

- `6f773a7` (core): prune only cache files whose filename timestamp is strictly older than the kept write — racing refreshes converge on the newest file instead of an empty directory.
- `7d3e568` (cli): on cache miss, picker discovery fetches via `load_skills_for` (which rewrites the cache) before resorting to the priceless fallbacks — self-heals even against older installed binaries that still race.

### Review response (`6c9c1ea`..`adc8e4d`)

Fixes for @EfeDurmaz16's five blockers (inline replies posted on each comment):

- `6c9c1ea` — `SessionSpec` now has `deny_unknown_fields`; migrates the two live gateway configs (`alibaba-qwen.yml`, `google-gemini.yml`) off the removed `settlement_authority: delegated` key, which had been silently defaulting `voucher_signer` to `client` since this PR's own `9440d18` rename
- `bbb2ff0` — `persist_touch` now clamps the idle-close deadline to the channel's negotiated `idle_timeout_seconds`, not just the operator's `close_delay_ms`
- `1004c4b` — `enforce_session_cap` and the signing path now share one `resolve_session_deposit`, so the enforced cap can no longer diverge from what actually gets signed
- `b86e3ca` — payer proxy: five previously-unrecognized terminal session errors (pinned as shared constants in `pay_core::server::session::terminal_errors`) plus a cache-order fix so an unconfirmed credential is never adopted before its retry proves non-402

The five follow-ups are tracked as-is, not fixed in this round; each has an inline acknowledgment on the PR. Of note, the `operator_close_channel` settle-retry gap is the Rust twin of `pay-kit#259`'s close re-drive blocker and should port the same fix pattern.

## Test plan

At `adc8e4d`:

- `cargo test --workspace --all-features` — 26 targets, 1768 passed, 0 failed (includes the repaired live-network openapi smoke test)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-features --all-targets` — clean
- `cargo check -p pay` (default features) — clean
