### PR TITLE
build(deps): bump pay-kit to 16777d46

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5904,7 +5904,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -7250,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.5.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=dc3a36ee8ad93bb4dcf6de8f5a03091518a539db#dc3a36ee8ad93bb4dcf6de8f5a03091518a539db"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=16777d465f4446c7ac519378663d6d4bbf394877#16777d465f4446c7ac519378663d6d4bbf394877"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15401,7 +15401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,7 +111,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "dc3a36ee8ad93bb4dcf6de8f5a03091518a539db", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "16777d465f4446c7ac519378663d6d4bbf394877", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -359,6 +359,7 @@ pub fn build_upto_payment_with_override(
             default_rpc_url(&network).to_string()
         }
     });
+    let rpc = RpcClient::new(rpc_url.clone());
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -389,6 +390,7 @@ pub fn build_upto_payment_with_override(
     let header = rt
         .block_on(pay_kit::x402::client::upto::build_upto_header(
             &signer,
+            &rpc,
             requirements,
             expires_at,
             nonce,


### PR DESCRIPTION
Bumps pay-kit pin `dc3a36ee` → `16777d46` (one commit ahead: #265, `fix(rust/x402)!: fetch blockhash + openSlot via RPC when upto challenge omits hints`).

Breaking change: `build_upto_payload`/`build_upto_header` gained a required `&RpcClient` param (fallback when the 402 challenge omits `recentBlockhash`/`recentSlot` hints). Updated the one caller in `core/src/client/x402.rs` to pass the `RpcClient` already constructed for the upto path — same pattern the `exact` scheme in the same file already uses.

**Test plan**: `cargo test --workspace --all-features` → 1762 pass; `cargo clippy --workspace --all-targets --all-features` clean; `cargo fmt --check` clean.