### PR TITLE
chore(release): bump version to 0.27.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6343,7 +6343,7 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pay"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "pay-acp"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "pay-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "pay-integration"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64 0.22.1",
  "pay-core",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "pay-keystore"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bs58",
  "secret-service",
@@ -6495,7 +6495,7 @@ dependencies = [
 
 [[package]]
 name = "pay-mcp"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64 0.22.1",
  "crc32fast",
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "pay-pdb"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "pay-proxy"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6563,7 +6563,7 @@ dependencies = [
 
 [[package]]
 name = "pay-types"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.26.0"
+version = "0.27.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/typescript/packages/solana-pay/core/package.json
+++ b/typescript/packages/solana-pay/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solana/pay",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-foundation/pay",
     "license": "MIT",


### PR DESCRIPTION
Bumps the Rust workspace to 0.27.0 and @solana/pay to 1.0.27.\n\nLocal validation: @solana/pay tests (150), lint, and cargo fmt --all --check. CI is running.