### PR TITLE
build(docker): publish a multi-arch (amd64 + arm64) image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,20 +13,105 @@ on:
 
 env:
   IMAGE: ghcr.io/solana-foundation/pay
+  # A dry run (workflow_dispatch with push=false) still builds every
+  # architecture — that is the point of it — but nothing may reach GHCR.
+  PUSH: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  # Each architecture builds on a runner of that architecture. The alternative,
+  # one runner with QEMU, would emulate `cargo build --release` for the foreign
+  # arch — an hours-long proposition for this image. `ubuntu-24.04-arm` is free
+  # for public repositories, so the second runner costs nothing here.
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
+      - name: Prepare
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Labels only. The tag logic lives in the merge job, because tags belong
+      # to the manifest list rather than to either single-arch image.
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+
+      - uses: docker/build-push-action@v6
+        id: build
+        with:
+          context: ./rust
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # `push-by-digest` uploads an untagged single-arch image; the merge
+          # job stitches the digests into one tag. On a dry run the build still
+          # runs and the result is simply discarded.
+          outputs: ${{ env.PUSH == 'true' && 'type=image,push-by-digest=true,name-canonical=true,push=true' || 'type=cacheonly' }}
+
+      - name: Export digest
+        if: env.PUSH == 'true'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: env.PUSH == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest list
+    runs-on: ubuntu-latest
+    needs: build
+    # Same condition as env.PUSH, spelled out because a job-level `if` cannot
+    # read the `env` context.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -35,9 +120,21 @@ jobs:
             type=match,pattern=^pay-v(.*)$,group=1
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/pay-v') }}
             type=raw,value=latest
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./rust
-          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+          refs=()
+          for digest in *; do
+            refs+=("${IMAGE}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create "${tags[@]}" "${refs[@]}"
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${IMAGE}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
## Problem

`ghcr.io/solana-foundation/pay:latest` is a single-architecture amd64 image, not
a manifest list, so it cannot run on arm64 hosts — Graviton, Fargate arm64, or
Apple Silicon without emulation.

```
$ docker manifest inspect --verbose ghcr.io/solana-foundation/pay:latest
{
  "Ref": "ghcr.io/solana-foundation/pay:latest",
  "Descriptor": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:bd8bd9f94e408501d1b57f12a36908b08482faa9523663c6f911105b3aa5d1ec",
    "platform": {
      "architecture": "amd64",
      "os": "linux"
    }
  },
  ...
```

A multi-arch image would return `application/vnd.oci.image.index.v1+json` with a
`manifests` array. This returns one manifest, pinned to amd64.

The cause is that `.github/workflows/docker.yml` passes no `platforms:` to
`docker/build-push-action`, so the build inherits the `ubuntu-latest` runner's
architecture.

arm64 is clearly a supported target — `release-cli.yml` already ships
`pay-aarch64-unknown-linux-gnu.tar.gz` on every release. Only the container
misses it.

## Approach

Each architecture builds on a runner of that architecture, and a `merge` job
combines the two digests into one manifest list. This is Docker's documented
[multi-runner distributed build](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)
pattern.

The obvious one-line fix — adding `platforms: linux/amd64,linux/arm64` on a
single amd64 runner — is not viable here. `rust/Dockerfile` compiles the
workspace from source (`cargo build --release --features gcp_kms,redis-session-store`,
with cmake and libclang), and the arm64 half of that build would run under QEMU
emulation. The current native build takes ~10 minutes; the emulated one would
be measured in hours and could plausibly hit the 6-hour job ceiling.

Native runners avoid that entirely, and cost nothing here: `ubuntu-24.04-arm` is
a standard GitHub-hosted runner, and
["use of the standard GitHub-hosted runners is free and unlimited on public
repositories"](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).
The two builds run in parallel, so wall-clock time is roughly unchanged.

## Changes

`.github/workflows/docker.yml` only.

- `build` becomes a two-entry matrix: `linux/amd64` on `ubuntu-latest`,
  `linux/arm64` on `ubuntu-24.04-arm`. No QEMU, no `setup-qemu-action`.
- Each build pushes by digest (`push-by-digest=true,name-canonical=true`) and
  uploads the digest as an artifact.
- A new `merge` job runs `docker buildx imagetools create` to assemble the
  digests into one manifest list, then inspects the result.
- The `docker/metadata-action` tag configuration moves to the `merge` job
  **unchanged** — including `type=match,pattern=^pay-v(.*)$,group=1` and
  `latest`. Tags belong to the manifest list, not to either single-arch image.
  The per-arch job keeps a `metadata-action` step for labels only.
- The `workflow_dispatch` `push` input behaves as before: a dry run still builds
  both architectures (that being the point of it) and writes nothing to GHCR.
  Its `outputs` resolves to `type=cacheonly` and the `merge` job is skipped.

## Verification

- `actionlint` 1.7.7 (which runs shellcheck over `run:` blocks) reports no
  findings for the modified workflow.
- `rust/Dockerfile` builds natively for `linux/arm64` unmodified — verified
  locally on Apple Silicon with `docker build --platform linux/arm64 ./rust`,
  which is the same unemulated path `ubuntu-24.04-arm` takes. `cargo build
  --release --features gcp_kms,redis-session-store` finished in 4m32s, and the
  resulting image runs:

  ```
  $ docker run --rm --platform linux/arm64 <image> --version
  pay 0.27.0
  ```

- The `merge` job's `imagetools create` invocation was exercised against a
  recorded `DOCKER_METADATA_OUTPUT_JSON` for a `pay-v0.27.0` tag push, and
  assembles the expected command:

  ```
  docker buildx imagetools create \
    -t ghcr.io/solana-foundation/pay:0.27.0 \
    -t ghcr.io/solana-foundation/pay:pay-v0.27.0 \
    -t ghcr.io/solana-foundation/pay:latest \
    ghcr.io/solana-foundation/pay@sha256:<amd64> \
    ghcr.io/solana-foundation/pay@sha256:<arm64>
  ```

I could not do a full end-to-end dispatch on my fork: GitHub disables Actions on
forks until a maintainer enables them in the UI, and I have no way to click that
from here. Happy to run one if that would help — or a `workflow_dispatch` with
`push: false` on this branch would exercise both builds without touching the
registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
