### PR TITLE
Fix server scaffold to use current routing schema

### DIFF
--- a/rust/crates/cli/src/commands/server/scaffold.rs
+++ b/rust/crates/cli/src/commands/server/scaffold.rs
@@ -14,7 +14,9 @@ title: "My API"
 description: "API description"
 category: ai_ml
 version: v1
-forward_url: https://api.example.com
+routing:
+  type: proxy
+  url: https://api.example.com
 accounting: pooled
 
 endpoints:
@@ -56,5 +58,20 @@ impl ScaffoldCommand {
         eprintln!();
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TEMPLATE;
+    use pay_types::metering::{ApiSpec, RoutingConfig};
+
+    #[test]
+    fn scaffold_template_uses_the_current_routing_schema() {
+        let spec: ApiSpec = serde_yml::from_str(TEMPLATE).expect("template must parse as ApiSpec");
+        assert!(matches!(
+            spec.routing,
+            RoutingConfig::Proxy { ref url, .. } if url == "https://api.example.com"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- update `pay server scaffold` to emit the current `routing` proxy schema
- add a regression test that parses the generated template as `ApiSpec`
- verify the parsed route is `RoutingConfig::Proxy`

## Reproduction

With pay CLI 0.27.0:

```sh
pay server scaffold /tmp/paywall.yml
pay server start /tmp/paywall.yml --no-register
```

The generated file uses the retired top-level `forward_url` field, so the server cannot parse its own scaffold. This change emits:

```yaml
routing:
  type: proxy
  url: https://api.example.com
```

## Verification

- `cargo fmt --check`
- `cargo test -p pay-cli scaffold_template_uses_the_current_routing_schema`

The targeted test passes.
