### PR TITLE
Honor operator realm for MPP charge servers

### DIFF
--- a/rust/crates/cli/src/commands/server/payments.rs
+++ b/rust/crates/cli/src/commands/server/payments.rs
@@ -596,6 +596,7 @@ pub(crate) fn build_charge_mpps(
     recipient: &str,
     network_slug: &str,
     rpc_url: &str,
+    realm: Option<&str>,
     challenge_binding_secret: &str,
     fee_payer: bool,
     fee_payer_signer: Option<Arc<dyn SolanaSigner>>,
@@ -610,6 +611,7 @@ pub(crate) fn build_charge_mpps(
                 decimals: *decimals,
                 network: network_slug.to_string(),
                 rpc_url: Some(rpc_url.to_string()),
+                realm: realm.map(str::to_string),
                 challenge_binding_secret: Some(challenge_binding_secret.to_string()),
                 fee_payer,
                 fee_payer_signer: fee_payer_signer.clone(),
@@ -620,6 +622,36 @@ pub(crate) fn build_charge_mpps(
         })
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| pay_core::Error::Config(format!("Failed to create MPP server: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_charge_mpps;
+
+    #[test]
+    fn charge_server_uses_configured_operator_realm() {
+        let currencies = vec![(
+            "USDC".to_string(),
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            6,
+        )];
+        let cache = pay_kit::mpp::blockhash::BlockhashCache::new();
+        let servers = build_charge_mpps(
+            &currencies,
+            "CXhrFZJLKqjzmP3sjYLcF4dTeXWKCy9e2SXXZ2Yo6MPY",
+            "mainnet",
+            "https://api.mainnet-beta.solana.com",
+            Some("api.example.com"),
+            "0123456789abcdef0123456789abcdef",
+            false,
+            None,
+            &cache,
+        )
+        .expect("charge server");
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].realm(), "api.example.com");
+    }
 }
 
 /// Build the x402 `upto` backend for the sandbox charge stack.

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -955,6 +955,7 @@ impl StartCommand {
                 &recipient,
                 network.slug(),
                 &rpc_url,
+                api.operator.as_ref().and_then(|operator| operator.realm.as_deref()),
                 &challenge_binding_secret,
                 fee_payer,
                 fee_payer_signer.clone(),


### PR DESCRIPTION
## Summary

Passes `operator.realm` into ordinary MPP charge servers created by `pay server start`.

The configuration type and pay-kit charge server already support an explicit realm, but the CLI currently drops it and falls back to the recipient-derived `App Id` realm. That makes origin attribution impossible for discovery systems that require the MPP realm to match the service host.

## Reproduction

1. Set `operator.realm: api.example.com` on a paywall with `mpp-charge`.
2. Start the server and request a paid endpoint without credentials.
3. The current `WWW-Authenticate: Payment` challenge advertises a recipient-derived `App Id` realm instead of `api.example.com`.

MPPScan consequently reports that on-chain stats cannot be attributed to the origin host.

## Validation

- Added a focused regression test proving the constructed charge server uses the configured realm.
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --quiet --manifest-path rust/Cargo.toml -p pay charge_server_uses_configured_operator_realm`

The fallback remains unchanged when no realm is configured.