### PR TITLE
feat: validate buyer-owned pay fetch output contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ Anyone can contribute a provider listing, improve endpoint metadata, or add usag
 
 Good catalog entries make paid APIs easier for both humans and agents to discover, compare, and use safely.
 
+### Buyer-owned output contracts
+
+`pay fetch` can bind a local JSON Schema 2020-12 contract to a buffered JSON
+response. Pay verifies the schema's canonical SHA-256 digest before account
+setup or signing, reuses the same compiled validator across x402 and MPP
+retries, and validates delivery before writing response bytes to stdout.
+
+```sh
+pay fetch https://api.example.com/data \
+  --output-schema ./expected-output.schema.json \
+  --output-schema-sha256 sha256:<canonical-digest>
+```
+
+The schema remains local and is never sent to the server. A paid response that
+does not satisfy it is reported as a delivery-validation failure while payment
+receipt evidence is preserved. Streaming `curl`, `wget`, and `http` behavior is
+unchanged.
+
 ## Installation
 
 ### Prebuilt Binaries

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1306,6 +1307,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1478,12 @@ dependencies = [
  "serde",
  "subtle",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
@@ -1622,6 +1644,12 @@ name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -3007,6 +3035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +3200,17 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fast-math"
@@ -3354,6 +3402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding 2.3.2",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num 0.4.3",
 ]
 
 [[package]]
@@ -5114,6 +5183,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna 1.1.0",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding 2.3.2",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5669,6 +5790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6038,6 +6165,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -6497,6 +6630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6624,6 +6763,8 @@ dependencies = [
  "futures-util",
  "glob",
  "indicatif 0.17.11",
+ "jsonschema",
+ "libc",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.31.0",
@@ -6643,8 +6784,10 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
  "serde_yaml",
  "serial_test",
+ "sha2 0.10.9",
  "shellexpand",
  "solana-commitment-config",
  "solana-instruction 3.2.0",
@@ -8199,6 +8342,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot 0.12.5",
+ "percent-encoding 2.3.2",
+ "serde_json",
 ]
 
 [[package]]
@@ -14116,9 +14276,9 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6d30e733473322925a374c2603466a52c95077c574917bd02b788052d2f01d"
+checksum = "4378fa824c41a21856eb5347fbff48bc613456179de02ba51f667bce9acb18f6"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -14397,6 +14557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14414,6 +14583,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -15550,6 +15731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15719,6 +15906,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15747,6 +15944,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "waker-fn"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = { package = "serde_yaml", version = "0.9" }
 csv = "1.3"
+jsonschema = { version = "=0.49.9", default-features = false }
+serde_json_canonicalizer = "0.3.2"
 base64 = "0.22"
 crc32fast = "1.5"
 flate2 = "1.1"
@@ -103,6 +105,7 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
 bs58 = "0.5"
 blake3 = "1"
+sha2 = "0.10"
 qrcode = { version = "0.14", default-features = false }
 mime_guess = { version = "2.0", default-features = false, features = ["rev-mappings"] }
 same-file = "1.0"

--- a/rust/crates/cli/Cargo.toml
+++ b/rust/crates/cli/Cargo.toml
@@ -27,6 +27,8 @@ glob = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+jsonschema = { workspace = true }
+serde_json_canonicalizer = { workspace = true }
 schemars = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
@@ -66,6 +68,8 @@ qrcode = { workspace = true }
 pay-pdb = { workspace = true }
 urlencoding = "2.1.3"
 uuid = { workspace = true }
+sha2 = { workspace = true }
+libc = "0.2"
 webbrowser = { workspace = true }
 # Payer proxy: incremental OpenAI→Anthropic SSE translation stream.
 async-stream = "0.3"

--- a/rust/crates/cli/src/commands/fetch.rs
+++ b/rust/crates/cli/src/commands/fetch.rs
@@ -1,7 +1,74 @@
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use pay_core::client::fetch::{MultipartFile, RedirectPolicy, RequestBody};
+use sha2::{Digest, Sha256};
+
+const MAX_OUTPUT_SCHEMA_BYTES: usize = 1_048_576;
+const OUTPUT_SCHEMA_DRAFT: &str = "https://json-schema.org/draft/2020-12/schema";
+const SHA256_PREFIX: &str = "sha256:";
+
+/// One locally compiled buyer acceptance contract. The source file is read
+/// once before account setup, then this immutable validator is reused for the
+/// initial response and every paid retry.
+#[derive(Debug, Clone)]
+pub struct PreparedOutputSchema {
+    digest: String,
+    validator: jsonschema::Validator,
+}
+
+impl PreparedOutputSchema {
+    pub fn validate_response(
+        &self,
+        content_type: Option<&str>,
+        body: Option<&[u8]>,
+    ) -> pay_core::Result<()> {
+        let content_type = content_type.ok_or_else(|| {
+            pay_core::Error::DeliveryValidation(
+                "the response omitted Content-Type; the buyer contract requires JSON".to_string(),
+            )
+        })?;
+        if !is_json_content_type(content_type) {
+            return Err(pay_core::Error::DeliveryValidation(format!(
+                "the response Content-Type `{content_type}` is not JSON"
+            )));
+        }
+        let body = body.ok_or_else(|| {
+            pay_core::Error::DeliveryValidation(
+                "the buffered response body is unavailable for buyer-contract validation"
+                    .to_string(),
+            )
+        })?;
+        let value: serde_json::Value = serde_json::from_slice(body).map_err(|error| {
+            pay_core::Error::DeliveryValidation(format!(
+                "the response body is not valid JSON: {error}"
+            ))
+        })?;
+        let failures = self
+            .validator
+            .iter_errors(&value)
+            .take(3)
+            .map(|error| {
+                let instance_path = if error.instance_path().as_str().is_empty() {
+                    "/"
+                } else {
+                    error.instance_path().as_str()
+                };
+                format!("{instance_path} against {}", error.schema_path())
+            })
+            .collect::<Vec<_>>();
+        if failures.is_empty() {
+            return Ok(());
+        }
+        Err(pay_core::Error::DeliveryValidation(format!(
+            "the response does not satisfy buyer output contract {} at {}",
+            self.digest,
+            failures.join(", ")
+        )))
+    }
+}
 
 /// Fetch a URL using Pay's built-in HTTP client.
 ///
@@ -41,6 +108,17 @@ pub struct FetchCommand {
     /// MIME type for --body or --body-file. File types are inferred by default.
     #[arg(long, value_name = "MIME")]
     pub content_type: Option<String>,
+
+    /// Local JSON Schema 2020-12 file that the final response must satisfy.
+    #[arg(long, value_name = "PATH", requires = "output_schema_sha256")]
+    pub output_schema: Option<PathBuf>,
+
+    /// Expected SHA-256 of the canonical output schema JSON.
+    #[arg(long, value_name = "sha256:HEX", requires = "output_schema")]
+    pub output_schema_sha256: Option<String>,
+
+    #[arg(skip)]
+    pub(crate) prepared_output_schema: Option<PreparedOutputSchema>,
 }
 
 pub struct PreparedFetchRequest {
@@ -53,6 +131,33 @@ pub struct PreparedFetchRequest {
 }
 
 impl FetchCommand {
+    /// Validate and snapshot every local buyer-controlled acceptance input.
+    /// `main` calls this before loading config or starting account setup.
+    pub fn preflight_local_inputs(&mut self) -> pay_core::Result<()> {
+        if self.prepared_output_schema.is_some() {
+            return Ok(());
+        }
+        self.prepared_output_schema = match (
+            self.output_schema.as_deref(),
+            self.output_schema_sha256.as_deref(),
+        ) {
+            (None, None) => None,
+            (Some(path), Some(expected_digest)) => {
+                Some(prepare_output_schema(path, expected_digest)?)
+            }
+            _ => {
+                return Err(pay_core::Error::RequestValidation(
+                    "Use --output-schema and --output-schema-sha256 together.".to_string(),
+                ));
+            }
+        };
+        Ok(())
+    }
+
+    pub fn prepared_output_schema(&self) -> Option<&PreparedOutputSchema> {
+        self.prepared_output_schema.as_ref()
+    }
+
     pub fn prepare(&self) -> pay_core::Result<PreparedFetchRequest> {
         let has_multipart = !self.form_fields.is_empty() || !self.form_files.is_empty();
         let body_sources = usize::from(self.body.is_some())
@@ -160,6 +265,213 @@ impl FetchCommand {
     }
 }
 
+fn prepare_output_schema(
+    path: &Path,
+    expected_digest: &str,
+) -> pay_core::Result<PreparedOutputSchema> {
+    let expected_digest = normalize_schema_digest(expected_digest)?;
+    let bytes = read_output_schema_file(path)?;
+    let mut schema: serde_json::Value = serde_json::from_slice(&bytes).map_err(|error| {
+        pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` is not valid JSON: {error}",
+            path.display()
+        ))
+    })?;
+    normalize_ecmascript_numbers(&mut schema)?;
+
+    if let Some(declared) = schema.get("$schema")
+        && declared.as_str() != Some(OUTPUT_SCHEMA_DRAFT)
+    {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` must use JSON Schema 2020-12 (`{OUTPUT_SCHEMA_DRAFT}`).",
+            path.display()
+        )));
+    }
+    reject_external_schema_references(&schema, "")?;
+    jsonschema::draft202012::meta::validate(&schema).map_err(|error| {
+        pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` is not valid JSON Schema 2020-12 at {}.",
+            path.display(),
+            error.instance_path()
+        ))
+    })?;
+
+    let canonical = canonical_json(&schema)?;
+    let actual_digest = format!("sha256:{:x}", Sha256::digest(canonical.as_bytes()));
+    if actual_digest != expected_digest {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema digest mismatch: expected {expected_digest}, got {actual_digest}."
+        )));
+    }
+
+    let validator = jsonschema::draft202012::options()
+        .should_validate_formats(true)
+        .build(&schema)
+        .map_err(|error| {
+            pay_core::Error::RequestValidation(format!(
+                "Could not compile output schema `{}`: {error}",
+                path.display()
+            ))
+        })?;
+
+    Ok(PreparedOutputSchema {
+        digest: actual_digest,
+        validator,
+    })
+}
+
+fn normalize_schema_digest(value: &str) -> pay_core::Result<String> {
+    let value = value.trim();
+    let hex = value.strip_prefix(SHA256_PREFIX).ok_or_else(|| {
+        pay_core::Error::RequestValidation(
+            "--output-schema-sha256 must be `sha256:` followed by 64 lowercase hex characters."
+                .to_string(),
+        )
+    })?;
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(pay_core::Error::RequestValidation(
+            "--output-schema-sha256 must be `sha256:` followed by 64 lowercase hex characters."
+                .to_string(),
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn read_output_schema_file(path: &Path) -> pay_core::Result<Vec<u8>> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        pay_core::Error::RequestValidation(format!(
+            "Could not inspect output schema `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` must not be a symlink.",
+            path.display()
+        )));
+    }
+    if !metadata.file_type().is_file() {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` must be a regular file.",
+            path.display()
+        )));
+    }
+    if metadata.len() > MAX_OUTPUT_SCHEMA_BYTES as u64 {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` exceeds the 1 MiB limit.",
+            path.display()
+        )));
+    }
+
+    let file = open_output_schema_no_follow(path).map_err(|error| {
+        pay_core::Error::RequestValidation(format!(
+            "Could not open output schema `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    if !file.metadata()?.file_type().is_file() {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` must be a regular file.",
+            path.display()
+        )));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_OUTPUT_SCHEMA_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_OUTPUT_SCHEMA_BYTES {
+        return Err(pay_core::Error::RequestValidation(format!(
+            "Output schema `{}` exceeds the 1 MiB limit.",
+            path.display()
+        )));
+    }
+    Ok(bytes)
+}
+
+fn open_output_schema_no_follow(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+fn reject_external_schema_references(
+    value: &serde_json::Value,
+    path: &str,
+) -> pay_core::Result<()> {
+    match value {
+        serde_json::Value::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                reject_external_schema_references(value, &format!("{path}/{index}"))?;
+            }
+        }
+        serde_json::Value::Object(values) => {
+            for (key, value) in values {
+                let child_path = format!("{path}/{}", json_pointer_escape(key));
+                if (key == "$ref" || key == "$dynamicRef")
+                    && value
+                        .as_str()
+                        .is_some_and(|reference| !reference.starts_with('#'))
+                {
+                    return Err(pay_core::Error::RequestValidation(format!(
+                        "Output schema reference at {child_path} must be local; external schema retrieval is disabled."
+                    )));
+                }
+                reject_external_schema_references(value, &child_path)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn json_pointer_escape(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn canonical_json(value: &serde_json::Value) -> pay_core::Result<String> {
+    serde_json_canonicalizer::to_string(value).map_err(pay_core::Error::Json)
+}
+
+fn normalize_ecmascript_numbers(value: &mut serde_json::Value) -> pay_core::Result<()> {
+    match value {
+        serde_json::Value::Number(number) => {
+            let number = number.as_f64().ok_or_else(|| {
+                pay_core::Error::RequestValidation(
+                    "Output schema contains a number outside the ECMAScript JSON range."
+                        .to_string(),
+                )
+            })?;
+            *value = serde_json::Value::Number(serde_json::Number::from_f64(number).ok_or_else(
+                || {
+                    pay_core::Error::RequestValidation(
+                        "Output schema contains a non-finite number.".to_string(),
+                    )
+                },
+            )?);
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                normalize_ecmascript_numbers(value)?;
+            }
+        }
+        serde_json::Value::Object(values) => {
+            for value in values.values_mut() {
+                normalize_ecmascript_numbers(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 fn parse_headers(values: &[String]) -> pay_core::Result<Vec<(String, String)>> {
     values
         .iter()
@@ -246,8 +558,44 @@ fn is_json_content_type(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use serde_json::json;
 
     use super::*;
+
+    const TEST_SCHEMA_DIGEST: &str =
+        "sha256:b00c561bf9bc8da2bb4c8762557e2bbbdebd43dd7547a446fcb5fe5ef160b8f0";
+
+    fn test_schema() -> serde_json::Value {
+        json!({
+            "$schema": OUTPUT_SCHEMA_DRAFT,
+            "type": "object",
+            "properties": {
+                "value": { "minimum": 0.000001, "type": "number" },
+                "url": { "format": "uri", "type": "string" }
+            },
+            "required": ["url", "value"],
+            "additionalProperties": false
+        })
+    }
+
+    fn write_test_schema(directory: &tempfile::TempDir) -> PathBuf {
+        let path = directory.path().join("output.schema.json");
+        std::fs::write(&path, serde_json::to_vec_pretty(&test_schema()).unwrap()).unwrap();
+        path
+    }
+
+    fn command_with_schema(path: &Path) -> FetchCommand {
+        TestCli::try_parse_from([
+            "pay-fetch",
+            "https://example.com/data",
+            "--output-schema",
+            path.to_str().unwrap(),
+            "--output-schema-sha256",
+            TEST_SCHEMA_DIGEST,
+        ])
+        .unwrap()
+        .command
+    }
 
     #[derive(Parser)]
     struct TestCli {
@@ -353,5 +701,176 @@ mod tests {
         ])
         .unwrap();
         assert!(cli.command.prepare().is_err());
+    }
+
+    #[test]
+    fn output_schema_flags_are_required_as_a_pair() {
+        assert!(
+            TestCli::try_parse_from([
+                "pay-fetch",
+                "https://example.com/data",
+                "--output-schema",
+                "schema.json",
+            ])
+            .is_err()
+        );
+        assert!(
+            TestCli::try_parse_from([
+                "pay-fetch",
+                "https://example.com/data",
+                "--output-schema-sha256",
+                TEST_SCHEMA_DIGEST,
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn canonical_schema_digest_matches_agent_payment_policy() {
+        let canonical = canonical_json(&test_schema()).unwrap();
+        assert_eq!(
+            canonical,
+            r#"{"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":false,"properties":{"url":{"format":"uri","type":"string"},"value":{"minimum":0.000001,"type":"number"}},"required":["url","value"],"type":"object"}"#
+        );
+        assert_eq!(
+            format!("sha256:{:x}", Sha256::digest(canonical.as_bytes())),
+            TEST_SCHEMA_DIGEST
+        );
+    }
+
+    #[test]
+    fn canonical_key_order_matches_javascript_utf16_sort() {
+        let value = json!({ "\u{e000}": 1, "\u{10000}": 2 });
+        assert_eq!(canonical_json(&value).unwrap(), "{\"𐀀\":2,\"\":1}");
+    }
+
+    #[test]
+    fn canonical_numbers_match_ecmascript_json_stringify() {
+        let mut value = json!([1.0, 0.000001, 1e21, 1e-7, 9007199254740993_u64, -0.0]);
+        normalize_ecmascript_numbers(&mut value).unwrap();
+        assert_eq!(
+            canonical_json(&value).unwrap(),
+            "[1,0.000001,1e+21,1e-7,9007199254740992,0]"
+        );
+    }
+
+    #[test]
+    fn prepared_output_schema_validates_shape_and_standard_formats() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_test_schema(&directory);
+        let mut command = command_with_schema(&path);
+        command.preflight_local_inputs().unwrap();
+        let contract = command.prepared_output_schema().unwrap();
+
+        contract
+            .validate_response(
+                Some("application/json; charset=utf-8"),
+                Some(br#"{"url":"https://example.com/result","value":0.5}"#),
+            )
+            .unwrap();
+        for invalid in [
+            br#"{"url":"not a uri","value":0.5}"#.as_slice(),
+            br#"{"url":"https://example.com/result","value":"0.5"}"#.as_slice(),
+            br#"{"url":"https://example.com/result"}"#.as_slice(),
+            br#"{"url":"https://example.com/result","value":0.5,"extra":true}"#.as_slice(),
+        ] {
+            assert!(
+                contract
+                    .validate_response(Some("application/json"), Some(invalid))
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn prepared_schema_is_immutable_after_preflight() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_test_schema(&directory);
+        let mut command = command_with_schema(&path);
+        command.preflight_local_inputs().unwrap();
+        std::fs::write(&path, br#"{"type":"string"}"#).unwrap();
+
+        command
+            .prepared_output_schema()
+            .unwrap()
+            .validate_response(
+                Some("application/problem+json"),
+                Some(br#"{"url":"https://example.com/result","value":1}"#),
+            )
+            .unwrap();
+
+        command.preflight_local_inputs().unwrap();
+        command
+            .prepared_output_schema()
+            .unwrap()
+            .validate_response(
+                Some("application/json"),
+                Some(br#"{"url":"https://example.com/result","value":2}"#),
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn output_schema_rejects_bad_digest_malformed_json_and_external_refs() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_test_schema(&directory);
+        assert!(prepare_output_schema(&path, &format!("sha256:{}", "0".repeat(64))).is_err());
+
+        std::fs::write(&path, b"{").unwrap();
+        assert!(prepare_output_schema(&path, TEST_SCHEMA_DIGEST).is_err());
+
+        let external = json!({
+            "$schema": OUTPUT_SCHEMA_DRAFT,
+            "$ref": "https://example.com/remote.schema.json"
+        });
+        std::fs::write(&path, serde_json::to_vec(&external).unwrap()).unwrap();
+        let digest = format!(
+            "sha256:{:x}",
+            Sha256::digest(canonical_json(&external).unwrap().as_bytes())
+        );
+        let error = prepare_output_schema(&path, &digest).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("external schema retrieval is disabled")
+        );
+    }
+
+    #[test]
+    fn output_schema_rejects_non_json_delivery_without_echoing_body() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_test_schema(&directory);
+        let contract = prepare_output_schema(&path, TEST_SCHEMA_DIGEST).unwrap();
+        let secret_body = b"secret-response-body";
+        let error = contract
+            .validate_response(Some("text/plain"), Some(secret_body))
+            .unwrap_err();
+        assert!(!error.to_string().contains("secret-response-body"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_schema_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = write_test_schema(&directory);
+        let link = directory.path().join("linked.schema.json");
+        symlink(&path, &link).unwrap();
+        assert!(prepare_output_schema(&link, TEST_SCHEMA_DIGEST).is_err());
+    }
+
+    #[test]
+    fn output_schema_rejects_oversized_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.schema.json");
+        std::fs::write(&path, vec![b' '; MAX_OUTPUT_SCHEMA_BYTES + 1]).unwrap();
+        assert!(prepare_output_schema(&path, TEST_SCHEMA_DIGEST).is_err());
+    }
+
+    #[test]
+    fn repository_fixture_digest_stays_compatible_with_agent_payment_policy() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/output.schema.json");
+        prepare_output_schema(&path, TEST_SCHEMA_DIGEST).unwrap();
     }
 }

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -138,6 +138,15 @@ pub enum ToolKind {
 }
 
 impl Command {
+    /// Snapshot and validate buyer-controlled local inputs before config load,
+    /// account creation, payment handling, or signing.
+    pub fn preflight_local_inputs(&mut self) -> pay_core::Result<()> {
+        match self {
+            Command::Fetch(command) => command.preflight_local_inputs(),
+            _ => Ok(()),
+        }
+    }
+
     pub fn otlp_sidecar(&self) -> Option<&str> {
         match self {
             Command::Server { command } => command.otlp_sidecar(),
@@ -226,6 +235,7 @@ enum Tool<'a> {
         redirect_policy: pay_core::fetch::RedirectPolicy,
         validation_body: Option<&'a str>,
         content_type: Option<&'a str>,
+        output_schema: Option<&'a fetch::PreparedOutputSchema>,
     },
 }
 
@@ -349,6 +359,7 @@ impl Command {
                     redirect_policy: prepared.redirect_policy,
                     validation_body: prepared.validation_body.as_deref(),
                     content_type: prepared.content_type.as_deref(),
+                    output_schema: cmd.prepared_output_schema(),
                 };
                 return handle_outcome(
                     outcome,
@@ -847,9 +858,10 @@ fn handle_outcome(
         RunOutcome::Completed {
             exit_code,
             body,
+            content_type,
             response_headers,
-            ..
         } => {
+            validate_completed_output(tool, content_type.as_deref(), body.as_deref())?;
             print_verbose_receipt(
                 &response_headers,
                 network_override,
@@ -913,6 +925,21 @@ fn print_verbose_receipt(
             &rendered.body,
         );
     }
+}
+
+fn validate_completed_output(
+    tool: &Tool<'_>,
+    content_type: Option<&str>,
+    body: Option<&[u8]>,
+) -> pay_core::Result<()> {
+    let Tool::Fetch {
+        output_schema: Some(output_schema),
+        ..
+    } = tool
+    else {
+        return Ok(());
+    };
+    output_schema.validate_response(content_type, body)
 }
 
 struct ReceiptNotice {
@@ -1364,6 +1391,7 @@ fn pay_mpp_and_retry(
         retry_with_header(ctx.tool, "Authorization", &auth_header, ctx.fetch_headers)?;
     handle_retry_outcome(
         retry_outcome,
+        ctx.tool,
         is_json,
         verbose,
         receipt_network.as_deref(),
@@ -1413,7 +1441,17 @@ fn pay_subscription_and_retry(
         .map(str::to_string)
         .or_else(|| mpp_challenge_network(challenge));
 
-    // On any 2xx outcome, persist a best-effort local record. The
+    // Validate buffered fetch output before any local state records the
+    // subscription as active. The common completion handler validates again
+    // before stdout as defense in depth.
+    validate_subscription_delivery_before_persistence(
+        &retry_outcome,
+        ctx.tool,
+        is_json,
+        receipt_network.as_deref(),
+    )?;
+
+    // On any valid 2xx outcome, persist a best-effort local record. The
     // `subscription_id` is the deterministic SubscriptionDelegation PDA
     // (per spec §"Subscription Identifier"), so we can derive it without
     // round-tripping the Payment-Receipt header — which the curl/wget/httpie
@@ -1438,11 +1476,48 @@ fn pay_subscription_and_retry(
 
     handle_retry_outcome(
         retry_outcome,
+        ctx.tool,
         is_json,
         ctx.verbose,
         receipt_network.as_deref(),
         ReceiptProvenance::PaidRetry(None),
     )
+}
+
+fn validate_subscription_delivery_before_persistence(
+    outcome: &RunOutcome,
+    tool: &Tool<'_>,
+    is_json: bool,
+    receipt_network: Option<&str>,
+) -> pay_core::Result<()> {
+    let RunOutcome::Completed {
+        exit_code,
+        body,
+        content_type,
+        response_headers,
+    } = outcome
+    else {
+        return Ok(());
+    };
+    if *exit_code != 0 {
+        return Ok(());
+    }
+    if let Err(error) = validate_completed_output(tool, content_type.as_deref(), body.as_deref()) {
+        if !is_json {
+            print_verbose_receipt(
+                response_headers,
+                receipt_network,
+                ReceiptProvenance::PaidRetry(None),
+                true,
+                false,
+            );
+        }
+        return Err(delivery_error_with_receipt_evidence(
+            error,
+            response_headers,
+        ));
+    }
+    Ok(())
 }
 
 // `persist_local_subscription_after_activation` lives in
@@ -1597,6 +1672,7 @@ fn pay_x402_and_retry(
     let retry_outcome = retry_with_headers(ctx.tool, &built_payment.headers, ctx.fetch_headers)?;
     handle_retry_outcome(
         retry_outcome,
+        ctx.tool,
         is_json,
         verbose,
         Some(&receipt_network),
@@ -1652,6 +1728,7 @@ fn pay_upto_and_retry(
     let retry_outcome = retry_with_headers(ctx.tool, &built_payment.headers, ctx.fetch_headers)?;
     handle_retry_outcome(
         retry_outcome,
+        ctx.tool,
         is_json,
         verbose,
         Some(&receipt_network),
@@ -1726,6 +1803,7 @@ fn pay_x402_siwx_and_retry(
     let retry_outcome = retry_with_headers(ctx.tool, &built_payment.headers, ctx.fetch_headers)?;
     handle_retry_outcome(
         retry_outcome,
+        ctx.tool,
         is_json,
         verbose,
         receipt_network.as_deref(),
@@ -1784,6 +1862,7 @@ fn pay_session_and_retry(
     let retry_outcome = retry_with_header(tool, "Authorization", &auth_header, fetch_headers)?;
     handle_retry_outcome(
         retry_outcome,
+        tool,
         is_json,
         verbose,
         receipt_network.as_deref(),
@@ -1936,6 +2015,7 @@ fn retry_header_args_httpie(headers_to_add: &[(&str, String)]) -> Vec<String> {
 
 fn handle_retry_outcome(
     outcome: RunOutcome,
+    tool: &Tool<'_>,
     is_json: bool,
     verbose: bool,
     receipt_network: Option<&str>,
@@ -1945,9 +2025,29 @@ fn handle_retry_outcome(
         RunOutcome::Completed {
             exit_code,
             body,
+            content_type,
             response_headers,
-            ..
         } => {
+            if let Err(error) =
+                validate_completed_output(tool, content_type.as_deref(), body.as_deref())
+            {
+                if matches!(provenance, ReceiptProvenance::PaidRetry(_)) {
+                    if !is_json {
+                        print_verbose_receipt(
+                            &response_headers,
+                            receipt_network,
+                            provenance,
+                            true,
+                            false,
+                        );
+                    }
+                    return Err(delivery_error_with_receipt_evidence(
+                        error,
+                        &response_headers,
+                    ));
+                }
+                return Err(error);
+            }
             print_verbose_receipt(
                 &response_headers,
                 receipt_network,
@@ -1994,10 +2094,157 @@ fn handle_retry_outcome(
     }
 }
 
+fn delivery_error_with_receipt_evidence(
+    error: pay_core::Error,
+    response_headers: &[(String, String)],
+) -> pay_core::Error {
+    let detail = match error {
+        pay_core::Error::DeliveryValidation(detail) => detail,
+        other => return other,
+    };
+    let receipt = response_header(response_headers, "payment-receipt-url")
+        .map(str::trim)
+        .filter(|value| {
+            value.len() <= 2_048
+                && value.starts_with("https://")
+                && !value.chars().any(char::is_control)
+        })
+        .map_or_else(
+            || {
+                if receipt::decode_response_receipt(response_headers).is_some() {
+                    "payment receipt received".to_string()
+                } else {
+                    "payment completed but no decodable receipt header was returned".to_string()
+                }
+            },
+            |url| format!("payment receipt: {url}"),
+        );
+    pay_core::Error::DeliveryValidation(format!("{detail}; settlement evidence: {receipt}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use pay_kit::mpp::SessionMethodDetails;
+    use sha2::Digest;
+
+    fn prepared_output_schema() -> fetch::PreparedOutputSchema {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("output.schema.json");
+        let schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": { "ok": { "type": "boolean" } },
+            "required": ["ok"],
+            "additionalProperties": false
+        });
+        std::fs::write(&path, serde_json::to_vec(&schema).unwrap()).unwrap();
+        let canonical = r#"{"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":false,"properties":{"ok":{"type":"boolean"}},"required":["ok"],"type":"object"}"#;
+        let digest = format!("sha256:{:x}", sha2::Sha256::digest(canonical.as_bytes()));
+        let mut command = fetch::FetchCommand {
+            url: "https://example.com/data".to_string(),
+            method: None,
+            headers: Vec::new(),
+            body: None,
+            body_file: None,
+            form_fields: Vec::new(),
+            form_files: Vec::new(),
+            content_type: None,
+            output_schema: Some(path),
+            output_schema_sha256: Some(digest),
+            prepared_output_schema: None,
+        };
+        command.preflight_local_inputs().unwrap();
+        command.prepared_output_schema().unwrap().clone()
+    }
+
+    #[test]
+    fn completed_output_validation_is_fetch_only_and_suppresses_invalid_body() {
+        let contract = prepared_output_schema();
+        let tool = Tool::Fetch {
+            method: "GET",
+            url: "https://example.com/data",
+            body: None,
+            redirect_policy: pay_core::fetch::RedirectPolicy::Follow,
+            validation_body: None,
+            content_type: None,
+            output_schema: Some(&contract),
+        };
+        validate_completed_output(&tool, Some("application/json"), Some(br#"{"ok":true}"#))
+            .unwrap();
+        let error = validate_completed_output(
+            &tool,
+            Some("application/json"),
+            Some(br#"{"ok":"secret-invalid-body"}"#),
+        )
+        .unwrap_err();
+        assert!(!error.to_string().contains("secret-invalid-body"));
+
+        assert!(
+            validate_completed_output(&Tool::Curl(&[]), None, Some(b"arbitrary stream")).is_ok()
+        );
+    }
+
+    #[test]
+    fn paid_invalid_delivery_preserves_bounded_receipt_evidence() {
+        let error = delivery_error_with_receipt_evidence(
+            pay_core::Error::DeliveryValidation("invalid output".to_string()),
+            &[(
+                "Payment-Receipt-Url".to_string(),
+                "https://receipts.example/abc".to_string(),
+            )],
+        );
+        let message = error.to_string();
+        assert!(message.contains("invalid output"));
+        assert!(message.contains("https://receipts.example/abc"));
+
+        let invalid = delivery_error_with_receipt_evidence(
+            pay_core::Error::DeliveryValidation("invalid output".to_string()),
+            &[(
+                "Payment-Receipt-Url".to_string(),
+                "javascript:alert(1)".to_string(),
+            )],
+        );
+        assert!(!invalid.to_string().contains("javascript:"));
+    }
+
+    #[test]
+    fn invalid_subscription_delivery_stops_before_active_state_persistence() {
+        let contract = prepared_output_schema();
+        let tool = Tool::Fetch {
+            method: "GET",
+            url: "https://example.com/subscription",
+            body: None,
+            redirect_policy: pay_core::fetch::RedirectPolicy::Follow,
+            validation_body: None,
+            content_type: None,
+            output_schema: Some(&contract),
+        };
+        let outcome = RunOutcome::Completed {
+            exit_code: 0,
+            body: Some(br#"{"ok":"wrong-type"}"#.to_vec()),
+            content_type: Some("application/json".to_string()),
+            response_headers: vec![(
+                "Payment-Receipt-Url".to_string(),
+                "https://receipts.example/subscription".to_string(),
+            )],
+        };
+
+        let error = validate_subscription_delivery_before_persistence(
+            &outcome,
+            &tool,
+            true,
+            Some("mainnet"),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, pay_core::Error::DeliveryValidation(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("https://receipts.example/subscription")
+        );
+    }
 
     fn test_session_request_with_deposits(
         minimum_deposit: Option<&str>,

--- a/rust/crates/cli/src/main.rs
+++ b/rust/crates/cli/src/main.rs
@@ -106,10 +106,15 @@ fn main() {
         no_dna::enable_for_process();
     }
 
-    let Some(command) = opts.command.take() else {
+    let Some(mut command) = opts.command.take() else {
         handle_missing_command();
         return;
     };
+
+    if let Err(err) = command.preflight_local_inputs() {
+        print_command_error(&err);
+        std::process::exit(1);
+    }
 
     let config = Config::load().unwrap_or_else(|err| {
         eprintln!("{}", format!("Error: {err}").dimmed());

--- a/rust/crates/cli/tests/fixtures/invalid-output.json
+++ b/rust/crates/cli/tests/fixtures/invalid-output.json
@@ -1,0 +1,1 @@
+{"url":"https://example.com/result","value":"secret-invalid-body"}

--- a/rust/crates/cli/tests/fixtures/output.schema.json
+++ b/rust/crates/cli/tests/fixtures/output.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "value": {
+      "minimum": 0.000001,
+      "type": "number"
+    },
+    "url": {
+      "format": "uri",
+      "type": "string"
+    }
+  },
+  "required": [
+    "url",
+    "value"
+  ],
+  "additionalProperties": false
+}

--- a/rust/crates/cli/tests/fixtures/valid-output.json
+++ b/rust/crates/cli/tests/fixtures/valid-output.json
@@ -1,0 +1,1 @@
+{"url":"https://example.com/result","value":0.5}

--- a/rust/crates/core/src/error.rs
+++ b/rust/crates/core/src/error.rs
@@ -27,4 +27,7 @@ pub enum Error {
 
     #[error("Request validation error: {0}")]
     RequestValidation(String),
+
+    #[error("Delivery validation error: {0}")]
+    DeliveryValidation(String),
 }


### PR DESCRIPTION
## Summary

- add optional buyer-owned JSON Schema 2020-12 validation to buffered `pay fetch` responses
- preflight and snapshot the schema before config load or first-run account setup
- bind the exact contract through a canonical SHA-256 digest and reuse one compiled validator for direct, x402, MPP charge, subscription, and session completion paths
- preserve payment receipt evidence while classifying a paid schema mismatch as delivery failure
- leave `curl`, `wget`, `http`, and every no-schema call unchanged

Closes #431.

## Safety boundary

The schema must be a regular non-symlink file under 1 MiB. External `$ref` and `$dynamicRef` retrieval is disabled. The schema and validation failure stay local and are never sent to the seller. Response bytes are written only after validation passes.

Canonicalization uses RFC 8785 / ECMAScript number and UTF-16 key semantics, with a cross-language digest vector matching `agent-payment-policy`. JSON Schema is pinned with its HTTP and file resolver features disabled.

Subscription delivery is validated before local activation state is persisted. The same completed-output gate runs again before stdout. A paid invalid body keeps the available payment receipt evidence and does not trigger another payment.

## Verification on current main

- focused output-contract suite: 14/14
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`: 2,078 passed, 4 ignored
- `pnpm --filter @solana/pay` lint, typecheck, test, and build: 161 tests
- web UI Vite production build and `tsc --noEmit`
- `cargo build --release -p pay`

Current source commit `aae988dc407391e656325382d8d3cfd17bc54714` is signed and GitHub-verified. Exact tree: `64baa376874e0a4602afa5f4a3b5fb74cbc6f6b4`.