### PR TITLE
fix(solana-pay): encode amount at its own precision instead of toFixed(10)

### DIFF
--- a/typescript/packages/solana-pay/core/src/encodeURL.ts
+++ b/typescript/packages/solana-pay/core/src/encodeURL.ts
@@ -1,5 +1,6 @@
 import { SOLANA_PROTOCOL } from './constants.js';
 import type { Amount, Label, Memo, Message, Recipient, References, SPLToken } from './types.js';
+import { decimalPlaces } from './utils/amount.js';
 import { normalizeReferences } from './utils/reference.js';
 
 /**
@@ -74,7 +75,14 @@ function encodeTransferRequestURL({
     const url = new URL(SOLANA_PROTOCOL + pathname);
 
     if (amount != null) {
-        url.searchParams.append('amount', amount.toFixed(10).replace(/0+$/, '').replace(/\.$/, ''));
+        // Encode at the value's own precision. `toFixed` renders the float64
+        // rounding error at 10 places and switches to scientific notation for
+        // values >= 1e21; formatting integers via BigInt keeps the amount
+        // decimal-only and exact across the whole range.
+        const encodedAmount = Number.isInteger(amount)
+            ? BigInt(amount).toString()
+            : amount.toFixed(decimalPlaces(amount));
+        url.searchParams.append('amount', encodedAmount);
     }
 
     if (splToken) {

--- a/typescript/packages/solana-pay/core/test/encodeURL.test.ts
+++ b/typescript/packages/solana-pay/core/test/encodeURL.test.ts
@@ -41,6 +41,24 @@ describe('encodeURL', () => {
             expect(String(url)).toBe(`solana:${recipient}?amount=1`);
         });
 
+        it('encodes a fractional amount without float64 corruption', () => {
+            const recipient = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
+            const amount = 716844.32;
+
+            const url = encodeURL({ recipient, amount });
+
+            expect(String(url)).toBe(`solana:${recipient}?amount=716844.32`);
+        });
+
+        it('encodes a large integer amount as decimals, not scientific notation', () => {
+            const recipient = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
+            const amount = 1e21;
+
+            const url = encodeURL({ recipient, amount });
+
+            expect(String(url)).toBe(`solana:${recipient}?amount=1000000000000000000000`);
+        });
+
         it('encodes a url with recipient, amount and token', () => {
             const recipient = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
             const amount = 1.01;


### PR DESCRIPTION
## What

`encodeURL` formats the transfer amount with `amount.toFixed(10)`, which renders the float64 rounding error of many valid amounts and can emit more than 9 decimal places or scientific notation.

## Why

`Amount` is a `number`. `toFixed(10)` prints the float64 representation to 10 places, so for an amount whose rounding error surfaces at the 10th decimal the encoded value is both numerically wrong and has 10 decimals:

- `encodeURL({ recipient, amount: 716844.32 })` produces `amount=716844.3199999999`
- `550899.68` produces `550899.6800000001`

The trailing-zero strip cannot fix this because the final digit is not `0`. Separately, `toFixed` switches to scientific notation for values `>= 1e21`, so a large amount produces `amount=1e%2B21`.

This output is malformed on three counts:

1. `spec/SPEC.md` limits SOL amounts to at most 9 decimal places and requires wallets to reject more.
2. The repo's own `createTransfer` throws `amount decimals invalid` when `decimalPlaces(amount) > SOL_DECIMALS`, so `createTransfer` rejects the URL that `encodeURL` just produced from a valid input.
3. The amount grammar is decimal-only, so scientific notation is not a valid amount.

A fuzz over random amounts with at most 9 decimals corrupts roughly 5.5% of them.

## Change

Encode the amount at its own precision. Integer amounts are formatted with `BigInt(amount).toString()` and fractional amounts with `amount.toFixed(decimalPlaces(amount))` (the `decimalPlaces` helper is the same one `createTransfer` validates against). This preserves the caller's value exactly, never exceeds the supplied number of decimals, and never uses scientific notation. The integer path via `BigInt` matters because `toFixed` switches to scientific at `>= 1e21`. Verified for `716844.32`, `1e-9`, and `1e21`, and `NaN` / `Infinity` still format without throwing.

## Validation

- `npx vitest run encodeURL` in `packages/solana-pay/core` passes (12 tests), including the two added regression tests.
- `encodes a fractional amount without float64 corruption` asserts `encodeURL({ amount: 716844.32 })` yields `amount=716844.32`. It fails before the change (`amount=716844.3199999999`) and passes after.
- `encodes a large integer amount as decimals, not scientific notation` asserts `encodeURL({ amount: 1e21 })` yields `amount=1000000000000000000000` rather than `amount=1e+21`.
