### PR TITLE
feat(push): gasless CSV batch-payout pipeline

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2240,6 +2240,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6491,6 +6512,7 @@ dependencies = [
  "bs58",
  "bytes 1.12.0",
  "chrono",
+ "csv",
  "ed25519-dalek 2.2.0",
  "figment",
  "five8_core 0.1.2",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10890,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "solana-pay-kit"
 version = "0.5.0"
-source = "git+https://github.com/solana-foundation/pay-kit.git?rev=16777d465f4446c7ac519378663d6d4bbf394877#16777d465f4446c7ac519378663d6d4bbf394877"
+source = "git+https://github.com/solana-foundation/pay-kit.git?rev=a6a003529d7070d65dd8e2ad0721ca99a20ffeb6#a6a003529d7070d65dd8e2ad0721ca99a20ffeb6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6438,6 +6438,7 @@ dependencies = [
  "bincode",
  "blake3",
  "bs58",
+ "chrono",
  "figment",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -6476,15 +6477,24 @@ name = "pay-api-core"
 version = "0.27.0"
 dependencies = [
  "base64 0.22.1",
+ "bincode",
+ "blake3",
  "borsh 1.7.0",
  "bs58",
+ "chrono",
  "pay-api-types",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "solana-address 2.5.0",
+ "solana-hash 3.1.0",
+ "solana-instruction 3.2.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
  "solana-pay-kit",
  "solana-pubkey 3.0.0",
+ "solana-signature",
+ "solana-transaction",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6494,6 +6504,7 @@ dependencies = [
 name = "pay-api-types"
 version = "0.27.0"
 dependencies = [
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -112,7 +112,7 @@ same-file = "1.0"
 # deps. The `axum` feature (kit's own gate) is intentionally OFF — pay has its
 # own gate (pay-core + pay-proxy).
 #
-pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "16777d465f4446c7ac519378663d6d4bbf394877", default-features = false, features = [
+pay-kit = { package = "solana-pay-kit", git = "https://github.com/solana-foundation/pay-kit.git", rev = "a6a003529d7070d65dd8e2ad0721ca99a20ffeb6", default-features = false, features = [
     "mpp",
     "x402",
     "client",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ glob = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"
+csv = "1.3"
 base64 = "0.22"
 crc32fast = "1.5"
 flate2 = "1.1"

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -61,7 +61,7 @@ rand = { workspace = true }
 uuid = { workspace = true }
 bs58 = { workspace = true }
 blake3 = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 pay-keystore = { workspace = true }
 pay-kit = { workspace = true }
 bincode = { workspace = true }

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -36,6 +36,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
+csv = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
 percent-encoding = { workspace = true }

--- a/rust/crates/core/Cargo.toml
+++ b/rust/crates/core/Cargo.toml
@@ -38,7 +38,9 @@ serde_json = { workspace = true }
 serde_yml = { workspace = true }
 csv = { workspace = true }
 base64 = { workspace = true }
-chrono = { workspace = true }
+# `serde` feature: the `pay push` journal (client::push::journal) stores RFC
+# 3339 timestamps as `DateTime<Utc>` fields that round-trip through JSONL.
+chrono = { workspace = true, features = ["serde"] }
 percent-encoding = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/rust/crates/core/src/client/mod.rs
+++ b/rust/crates/core/src/client/mod.rs
@@ -3,6 +3,7 @@ pub mod balance;
 pub mod fetch;
 pub mod mpp;
 pub(crate) mod prompt;
+pub mod push;
 pub mod receipt;
 pub mod runner;
 pub mod sandbox;

--- a/rust/crates/core/src/client/push/executor.rs
+++ b/rust/crates/core/src/client/push/executor.rs
@@ -1,0 +1,1060 @@
+//! The bounded, backpressured pipeline that turns a planned `pay push` run
+//! into landed (or durably-failed) chunks.
+//!
+//! ## Where this lives
+//!
+//! This is `core::client::push::executor`, not a `pay-cli` module. There is
+//! no `pay push` CLI subcommand yet (no arg parsing, no CSV wiring) — this
+//! module is the reusable pipeline a *future* CLI subcommand would call
+//! with almost no logic of its own, matching this codebase's house rule
+//! that business logic belongs in a shared core crate, not a thin frontend.
+//! It is also the natural place for a future MCP tool or another frontend
+//! to drive a push run without duplicating any of this.
+//!
+//! ## Four stages, per chunk
+//!
+//! 1. **Instruction batching** — already done by
+//!    [`super::planner::pack_chunks`]; this module just iterates the
+//!    resulting `Vec<super::planner::PlannedChunk>`.
+//! 2. **Transaction encoding** — [`super::planner::build_chunk_transaction`]
+//!    compiles the chunk's real transaction against a live fee payer +
+//!    blockhash (from [`ChunkBroadcaster::prepare`]), then
+//!    [`super::permit::BatchSigningPermit::sign_chunk`] signs it.
+//! 3. **Transaction sending** — [`ChunkBroadcaster::broadcast`]. Direct
+//!    (self-funded) transports fire `sendTransaction` and return
+//!    immediately with a *pending* signature; they never block this stage
+//!    on confirmation. A gasless transport's HTTP response to pay-api's
+//!    `/api/v1/transfer-batches` *is* the final, already-confirmed outcome
+//!    (see that endpoint's docs), so it returns `Settled` instead.
+//! 4. **Journaling** — [`super::journal::Journal::append_chunk_signed`]
+//!    (durable, fsync'd) runs before stage 3's broadcast call. This isn't a
+//!    convention this module has to remember to follow: the journal's
+//!    `ChunkBroadcastPermit` is the only value [`Journal::append_chunk_broadcast`]
+//!    accepts, and the only way to obtain one is a completed
+//!    `append_chunk_signed` fsync — see `journal`'s module docs. There is no
+//!    code path in [`PushExecutor::run`] that reaches a broadcast call
+//!    without one in hand.
+//!
+//! ## Backpressure
+//!
+//! Signing is inherently serial (one [`super::permit::BatchSigningPermit`],
+//! one mutable signer), so this executor is a single sequential loop rather
+//! than a worker pool — no channels or spawned tasks are needed to get
+//! genuine "many transactions in flight on the network at once" behavior.
+//! Before compiling/signing the *next* chunk, [`PushExecutor::run`] blocks
+//! until the number of broadcast-but-not-yet-settled signatures drops below
+//! `max_in_flight`, driving that wait with **one** batched
+//! [`ChunkBroadcaster::poll_pending`] call per tick covering every
+//! outstanding signature — never one status lookup per signature. Because
+//! `sendTransaction` itself doesn't block on confirmation, up to
+//! `max_in_flight` chunks are genuinely in flight on the network
+//! simultaneously; a slow poll (direct mode) or a slow synchronous
+//! round trip (gasless mode, awaited per chunk since pay-api's response is
+//! final) both directly throttle the loop's throughput — no separate rate
+//! limiter is needed for either.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use solana_hash::Hash;
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+
+use super::journal::Journal;
+use super::permit::{BatchSigningPermit, SignedChunk};
+use super::planner::{self, PlannedChunk};
+use crate::{Error, Result};
+
+/// Bounded in-flight window default — matches the "single payer, bounded
+/// in-flight queue" pattern this project has converged on elsewhere.
+pub const DEFAULT_MAX_IN_FLIGHT: usize = 32;
+
+/// How often [`PushExecutor::run`] re-polls outstanding signatures while
+/// waiting for the in-flight window to free up (or draining it at the end
+/// of a run).
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(800);
+
+/// The mint/authority context [`planner::build_chunk_transaction`] needs
+/// that isn't carried on a bare [`PlannedChunk`]. The CLI already has all
+/// of this on hand (it's exactly `TransferManifest::context` plus the
+/// account that authorized the plan), so it costs nothing to pass through
+/// explicitly rather than adding new accessors to
+/// [`BatchSigningPermit`]'s otherwise-private state.
+#[derive(Debug, Clone, Copy)]
+pub struct ChunkTxContext {
+    pub sender: Pubkey,
+    pub mint: Pubkey,
+    pub token_program: Pubkey,
+    pub decimals: u8,
+}
+
+/// Fee payer + blockhash to build/sign one chunk against, resolved by
+/// whichever [`ChunkBroadcaster`] is active. For a direct/self-funded
+/// transport this is just a fresh `getLatestBlockhash`; for a gasless one
+/// it's pay-api's 402 quote (`fee_payer` + `recentBlockhash` +
+/// `challengeLastValidBlockHeight`).
+#[derive(Debug, Clone, Copy)]
+pub struct PreparedChunkContext {
+    pub fee_payer: Pubkey,
+    pub blockhash: Hash,
+    pub last_valid_block_height: u64,
+}
+
+/// What broadcasting one signed chunk produced.
+#[derive(Debug, Clone, Copy)]
+pub enum BroadcastOutcome {
+    /// Submitted, outcome not yet known. The executor tracks this
+    /// signature as in-flight until [`ChunkBroadcaster::poll_pending`]
+    /// reports a terminal status for it.
+    Pending(Signature),
+    /// Already final — nothing left to poll. A gasless transport's HTTP
+    /// response to pay-api *is* the settlement outcome.
+    Settled(Signature),
+}
+
+/// The result of one batched status check for a signature that was
+/// previously `Pending`.
+#[derive(Debug, Clone)]
+pub enum PendingStatus {
+    StillPending,
+    Confirmed,
+    Failed(String),
+}
+
+/// The pluggable transport [`PushExecutor`] drives. One implementation per
+/// fee-payer mode: [`DirectSolanaBroadcaster`] for self-funded runs,
+/// [`GaslessApiBroadcaster`] for gasless ones. Tests use a third,
+/// in-memory implementation to drive the backpressure loop deterministically
+/// (see `tests::MockBroadcaster` below) — the same pattern
+/// `journal::ResumeRpc` and `permit`'s tests already use elsewhere in this
+/// module tree.
+///
+/// Uses native `async fn` rather than `#[async_trait]`: `PushExecutor` is
+/// generic over `B: ChunkBroadcaster` (never `dyn`), so there's no
+/// object-safety need for a boxed future, and every call site in this
+/// module already runs on a single task — the auto-`Send` bound the lint
+/// below is warning about doesn't matter here.
+#[allow(async_fn_in_trait)]
+pub trait ChunkBroadcaster {
+    /// Resolve the fee payer + blockhash to build `chunk` against.
+    async fn prepare(&self, chunk: &PlannedChunk) -> Result<PreparedChunkContext>;
+    /// Submit an already-signed chunk.
+    async fn broadcast(&self, signed: &SignedChunk) -> Result<BroadcastOutcome>;
+    /// One batched status check for every currently-outstanding signature.
+    /// Must return exactly one status per input signature, in the same
+    /// order.
+    async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>>;
+}
+
+/// Tunables for [`PushExecutor::run`]'s bounded in-flight loop.
+#[derive(Debug, Clone, Copy)]
+pub struct PushExecutorConfig {
+    pub max_in_flight: usize,
+    pub poll_interval: Duration,
+}
+
+impl Default for PushExecutorConfig {
+    fn default() -> Self {
+        Self {
+            max_in_flight: DEFAULT_MAX_IN_FLIGHT,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+}
+
+/// Outcome counts for a completed (or interrupted) [`PushExecutor::run`]
+/// call. The journal is the durable source of truth for exactly which rows
+/// landed; this is a coarse summary for the CLI to print.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RunSummary {
+    pub confirmed: usize,
+    pub failed: usize,
+}
+
+struct InFlightChunk {
+    chunk_index: u32,
+    signature: Signature,
+}
+
+/// Drives stages 2-4 for a sequence of already-planned chunks (stage 1).
+/// Borrows the permit and journal for the run's duration — both are
+/// single-writer by design (see their own module docs), which is exactly
+/// what a sequential executor loop needs.
+pub struct PushExecutor<'a, B: ChunkBroadcaster> {
+    permit: &'a mut BatchSigningPermit,
+    journal: &'a mut Journal,
+    broadcaster: &'a B,
+    ctx: ChunkTxContext,
+    config: PushExecutorConfig,
+}
+
+impl<'a, B: ChunkBroadcaster> PushExecutor<'a, B> {
+    pub fn new(
+        permit: &'a mut BatchSigningPermit,
+        journal: &'a mut Journal,
+        broadcaster: &'a B,
+        ctx: ChunkTxContext,
+        config: PushExecutorConfig,
+    ) -> Self {
+        Self {
+            permit,
+            journal,
+            broadcaster,
+            ctx,
+            config,
+        }
+    }
+
+    /// Run every chunk in `chunks` through stages 2-4, in order. The caller
+    /// is responsible for having already reduced `journal::reduce_chunk_resume_action`
+    /// down to the chunks that actually still need work on a resume — this
+    /// executor always attempts everything it's handed.
+    pub async fn run(&mut self, chunks: &[PlannedChunk]) -> Result<RunSummary> {
+        let mut in_flight: Vec<InFlightChunk> = Vec::new();
+        let mut summary = RunSummary::default();
+
+        for chunk in chunks {
+            // Backpressure: never let more than `max_in_flight` broadcast
+            // signatures sit unconfirmed at once. Blocks here, not by
+            // refusing to accept work, but by refusing to *sign and send
+            // more* until room frees up.
+            while in_flight.len() >= self.config.max_in_flight {
+                self.drain_in_flight(&mut in_flight, &mut summary).await?;
+                if in_flight.len() >= self.config.max_in_flight {
+                    tokio::time::sleep(self.config.poll_interval).await;
+                }
+            }
+
+            let prepared = self.broadcaster.prepare(chunk).await?;
+
+            // Stage 2: encode + sign.
+            let transaction = planner::build_chunk_transaction(
+                chunk,
+                &self.ctx.mint,
+                &self.ctx.token_program,
+                self.ctx.decimals,
+                &self.ctx.sender,
+                &prepared.fee_payer,
+                prepared.blockhash,
+            )?;
+            let signed = sign_off_runtime_thread(
+                self.permit,
+                chunk.chunk_index,
+                &transaction,
+                prepared.last_valid_block_height,
+            )?;
+
+            // Stage 4 (before stage 3, structurally): durable write, then
+            // the only credential that can ever reach `append_chunk_broadcast`.
+            let (_, broadcast_permit) = self.journal.append_chunk_signed(
+                signed.chunk_index,
+                signed.row_numbers.clone(),
+                &signed.signature,
+                signed.signed_transaction_base64.clone(),
+                &signed.blockhash,
+                signed.last_valid_block_height,
+            )?;
+
+            // Stage 3: send.
+            match self.broadcaster.broadcast(&signed).await {
+                Ok(BroadcastOutcome::Pending(signature)) => {
+                    self.journal
+                        .append_chunk_broadcast(broadcast_permit, &signature)?;
+                    in_flight.push(InFlightChunk {
+                        chunk_index: signed.chunk_index,
+                        signature,
+                    });
+                }
+                Ok(BroadcastOutcome::Settled(signature)) => {
+                    self.journal
+                        .append_chunk_broadcast(broadcast_permit, &signature)?;
+                    self.journal
+                        .append_chunk_confirmed(signed.chunk_index, &signature)?;
+                    summary.confirmed += 1;
+                }
+                Err(error) => {
+                    // `broadcast_permit` (a `Copy` marker type) is simply
+                    // left unused here: it only ever proved a signed record
+                    // exists before a broadcast *attempt* — it never
+                    // promised the attempt succeeds. Never calling
+                    // `append_chunk_broadcast` is correct: no signature was
+                    // ever produced by the network to record.
+                    let _ = broadcast_permit;
+                    self.journal.append_chunk_failed(
+                        signed.chunk_index,
+                        error.to_string(),
+                        true,
+                    )?;
+                    summary.failed += 1;
+                }
+            }
+        }
+
+        // Drain whatever's still outstanding before reporting a final tally.
+        while !in_flight.is_empty() {
+            self.drain_in_flight(&mut in_flight, &mut summary).await?;
+            if !in_flight.is_empty() {
+                tokio::time::sleep(self.config.poll_interval).await;
+            }
+        }
+
+        Ok(summary)
+    }
+
+    /// One batched status check covering every currently in-flight
+    /// signature — never one call per signature.
+    async fn drain_in_flight(
+        &mut self,
+        in_flight: &mut Vec<InFlightChunk>,
+        summary: &mut RunSummary,
+    ) -> Result<()> {
+        if in_flight.is_empty() {
+            return Ok(());
+        }
+        let signatures: Vec<Signature> = in_flight.iter().map(|c| c.signature).collect();
+        let statuses = self.broadcaster.poll_pending(&signatures).await?;
+        if statuses.len() != in_flight.len() {
+            return Err(Error::Config(
+                "poll_pending returned a different number of statuses than signatures queried"
+                    .to_string(),
+            ));
+        }
+
+        let mut still_pending = Vec::new();
+        for (chunk, status) in in_flight.drain(..).zip(statuses) {
+            match status {
+                PendingStatus::StillPending => still_pending.push(chunk),
+                PendingStatus::Confirmed => {
+                    self.journal
+                        .append_chunk_confirmed(chunk.chunk_index, &chunk.signature)?;
+                    summary.confirmed += 1;
+                }
+                PendingStatus::Failed(reason) => {
+                    self.journal
+                        .append_chunk_failed(chunk.chunk_index, reason, true)?;
+                    summary.failed += 1;
+                }
+            }
+        }
+        *in_flight = still_pending;
+        Ok(())
+    }
+}
+
+/// Run [`BatchSigningPermit::sign_chunk`] on a plain native thread rather
+/// than calling it directly from `PushExecutor::run`'s async task.
+///
+/// `sign_chunk` is a synchronous method that internally drives its own
+/// isolated single-threaded Tokio runtime (`BatchSigningPermit` builds it
+/// once in `authorize` and reuses it for every signature, so a CLI's
+/// one-approval flow doesn't need its caller to be async at all). Calling
+/// it directly from inside `PushExecutor::run` — which must itself run on a
+/// Tokio runtime to `.await` the broadcaster — would try to enter a runtime
+/// from a thread Tokio already considers "inside a runtime" and panic
+/// ("Cannot start a runtime from within a runtime"), regardless of the two
+/// runtimes being different instances. A plain OS thread carries no such
+/// context, so signing there sidesteps the conflict entirely; joining it
+/// blocks this task exactly as long as signing takes, which is the
+/// executor's intended sequential behavior anyway (see the module docs'
+/// "Backpressure" section — stage 2 is not part of what needs concurrency).
+fn sign_off_runtime_thread(
+    permit: &mut BatchSigningPermit,
+    chunk_index: u32,
+    transaction: &solana_transaction::Transaction,
+    last_valid_block_height: u64,
+) -> Result<SignedChunk> {
+    std::thread::scope(|scope| {
+        scope
+            .spawn(|| permit.sign_chunk(chunk_index, transaction, last_valid_block_height))
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+    })
+}
+
+/// Drop a [`BatchSigningPermit`] safely from inside a Tokio runtime.
+///
+/// `BatchSigningPermit` owns a single-threaded Tokio `Runtime` (built once
+/// in `authorize` and reused by every `sign_chunk`/`resign_chunk` call, so a
+/// CLI never has to be async just to sign) — see that type's docs.
+/// `Runtime`'s `Drop` impl blocks the current thread waiting for its worker
+/// to shut down, which panics ("cannot drop a runtime in a context where
+/// blocking is not allowed") if that drop happens on a thread that's
+/// already inside a *different* async runtime, e.g. the one driving
+/// [`PushExecutor::run`].
+///
+/// This is a real interop gap between `permit`'s synchronous-by-design API
+/// and any async caller — not something `PushExecutor` can paper over
+/// internally, since ownership of the permit (and therefore of *when* it
+/// gets dropped) belongs to the executor's caller. Flagged here rather than
+/// silently worked around: anything that constructs a `BatchSigningPermit`
+/// and then runs inside a Tokio runtime — this module's own tests included —
+/// must drop it through this helper (or an equivalent off-runtime thread)
+/// instead of letting an in-scope drop happen inline.
+pub fn drop_permit_off_runtime_thread(permit: BatchSigningPermit) {
+    let _ = std::thread::scope(|scope| scope.spawn(move || drop(permit)).join());
+}
+
+// ── Production transports ───────────────────────────────────────────────
+
+/// Self-funded mode: broadcast straight to a Solana JSON-RPC endpoint.
+/// `fee_payer` is the sender's own pubkey in this mode (self-funded means
+/// the sender pays its own fees).
+///
+/// This is a small, hand-rolled JSON-RPC client rather than a dependency on
+/// `solana-client` (a `[dev-dependencies]`-only crate in this workspace) or
+/// `pay-api-core::RpcClient` (which `core` cannot depend on — see
+/// `pay-api-core::transfer_batch`'s module docs for the equivalent
+/// constraint in the other direction). It intentionally only implements the
+/// three calls this transport needs.
+pub struct DirectSolanaBroadcaster {
+    http: reqwest::Client,
+    rpc_url: String,
+    fee_payer: Pubkey,
+}
+
+impl DirectSolanaBroadcaster {
+    pub fn new(rpc_url: String, fee_payer: Pubkey) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            rpc_url,
+            fee_payer,
+        }
+    }
+
+    async fn call(&self, body: serde_json::Value) -> Result<serde_json::Value> {
+        let response = self
+            .http
+            .post(&self.rpc_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Config(format!("RPC transport error: {e}")))?;
+        let parsed: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| Error::Config(format!("RPC response was not valid JSON: {e}")))?;
+        if let Some(error) = parsed.get("error") {
+            return Err(Error::Config(format!("RPC returned an error: {error}")));
+        }
+        parsed
+            .get("result")
+            .cloned()
+            .ok_or_else(|| Error::Config("RPC response is missing `result`".to_string()))
+    }
+}
+
+impl ChunkBroadcaster for DirectSolanaBroadcaster {
+    async fn prepare(&self, _chunk: &PlannedChunk) -> Result<PreparedChunkContext> {
+        let result = self
+            .call(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getLatestBlockhash",
+                "params": [{ "commitment": "confirmed" }],
+            }))
+            .await?;
+        let blockhash_str = result
+            .pointer("/value/blockhash")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Config("malformed getLatestBlockhash response".to_string()))?;
+        let last_valid_block_height = result
+            .pointer("/value/lastValidBlockHeight")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| Error::Config("malformed getLatestBlockhash response".to_string()))?;
+        let blockhash = Hash::from_str(blockhash_str).map_err(|_| {
+            Error::Config("getLatestBlockhash returned a malformed blockhash".to_string())
+        })?;
+        Ok(PreparedChunkContext {
+            fee_payer: self.fee_payer,
+            blockhash,
+            last_valid_block_height,
+        })
+    }
+
+    async fn broadcast(&self, signed: &SignedChunk) -> Result<BroadcastOutcome> {
+        let result = self
+            .call(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "sendTransaction",
+                "params": [
+                    signed.signed_transaction_base64,
+                    {
+                        "encoding": "base64",
+                        "skipPreflight": false,
+                        "preflightCommitment": "confirmed",
+                        "maxRetries": 0,
+                    }
+                ],
+            }))
+            .await?;
+        let signature_str = result
+            .as_str()
+            .ok_or_else(|| Error::Config("malformed sendTransaction response".to_string()))?;
+        let signature = Signature::from_str(signature_str).map_err(|_| {
+            Error::Config("sendTransaction returned a malformed signature".to_string())
+        })?;
+        Ok(BroadcastOutcome::Pending(signature))
+    }
+
+    async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+        if signatures.is_empty() {
+            return Ok(Vec::new());
+        }
+        let signature_strings: Vec<String> = signatures.iter().map(ToString::to_string).collect();
+        let result = self
+            .call(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getSignatureStatuses",
+                "params": [signature_strings, { "searchTransactionHistory": true }],
+            }))
+            .await?;
+        let entries = result
+            .get("value")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| Error::Config("malformed getSignatureStatuses response".to_string()))?;
+
+        let mut statuses = Vec::with_capacity(entries.len());
+        for entry in entries {
+            if entry.is_null() {
+                statuses.push(PendingStatus::StillPending);
+                continue;
+            }
+            let failed = entry.get("err").map(|err| !err.is_null()).unwrap_or(false);
+            if failed {
+                statuses.push(PendingStatus::Failed(format!(
+                    "transaction failed on-chain: {}",
+                    entry.get("err").cloned().unwrap_or_default()
+                )));
+                continue;
+            }
+            let confirmation = entry
+                .get("confirmationStatus")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if confirmation == "confirmed" || confirmation == "finalized" {
+                statuses.push(PendingStatus::Confirmed);
+            } else {
+                statuses.push(PendingStatus::StillPending);
+            }
+        }
+        Ok(statuses)
+    }
+}
+
+/// Gasless mode: every chunk goes through pay-api's
+/// `POST /api/v1/transfer-batches` two-step flow (see that endpoint's
+/// module docs in `pay-api-core::transfer_batch`) instead of a direct RPC
+/// call.
+///
+/// **Known gap, flagged rather than silently worked around:** this hand-builds
+/// the request/response JSON to the documented wire shape instead of
+/// depending on the shared `pay-api-types` crate, so `core` and
+/// `pay-api-types` can drift without a compiler error catching it. The
+/// correct fix is adding `pay-api-types` as a dependency of `core` (it's
+/// deliberately dependency-light for exactly this kind of cross-consumption)
+/// and importing `TransferBatchRequest`/`TransferBatchChallengeBody`/
+/// `TransferBatchResponse` directly; left as-is here to keep this pass's
+/// blast radius on `core`'s dependency graph to zero.
+pub struct GaslessApiBroadcaster {
+    http: reqwest::Client,
+    /// e.g. `https://pay.example.com/api/v1/transfer-batches`.
+    endpoint: String,
+    batch_id: String,
+    sender: Pubkey,
+    currency: String,
+    network: &'static str,
+}
+
+impl GaslessApiBroadcaster {
+    pub fn new(
+        endpoint: String,
+        batch_id: String,
+        sender: Pubkey,
+        currency: String,
+        network: &'static str,
+    ) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            endpoint,
+            batch_id,
+            sender,
+            currency,
+            network,
+        }
+    }
+
+    fn request_body(&self, chunk: &PlannedChunk) -> serde_json::Value {
+        use crate::client::send::format_token_amount;
+
+        serde_json::json!({
+            "batchId": self.batch_id,
+            "chunkIndex": chunk.chunk_index,
+            "sender": self.sender.to_string(),
+            "currency": self.currency,
+            "network": self.network,
+            "transfers": chunk.entries.iter().map(|entry| serde_json::json!({
+                "rowId": entry.row_number,
+                "recipient": entry.recipient.to_string(),
+                "amount": format_token_amount(entry.amount_raw, /* decimals resolved server-side */ 6),
+            })).collect::<Vec<_>>(),
+        })
+    }
+}
+
+impl ChunkBroadcaster for GaslessApiBroadcaster {
+    async fn prepare(&self, chunk: &PlannedChunk) -> Result<PreparedChunkContext> {
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .json(&self.request_body(chunk))
+            .send()
+            .await
+            .map_err(|e| Error::Config(format!("pay-api transport error: {e}")))?;
+        if response.status().as_u16() != 402 {
+            return Err(Error::Config(format!(
+                "pay-api quote returned unexpected status {}",
+                response.status()
+            )));
+        }
+        let body: serde_json::Value = response.json().await.map_err(|e| {
+            Error::Config(format!("pay-api quote response was not valid JSON: {e}"))
+        })?;
+        let fee_payer_str = body
+            .get("feePayer")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Config("pay-api quote is missing feePayer".to_string()))?;
+        let blockhash_str = body
+            .get("recentBlockhash")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Config("pay-api quote is missing recentBlockhash".to_string()))?;
+        let last_valid_block_height = body
+            .get("challengeLastValidBlockHeight")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| {
+                Error::Config("pay-api quote is missing challengeLastValidBlockHeight".to_string())
+            })?;
+
+        Ok(PreparedChunkContext {
+            fee_payer: Pubkey::from_str(fee_payer_str).map_err(|_| {
+                Error::Config("pay-api quote returned a malformed feePayer".to_string())
+            })?,
+            blockhash: Hash::from_str(blockhash_str).map_err(|_| {
+                Error::Config("pay-api quote returned a malformed recentBlockhash".to_string())
+            })?,
+            last_valid_block_height,
+        })
+    }
+
+    async fn broadcast(&self, signed: &SignedChunk) -> Result<BroadcastOutcome> {
+        // Rebuilding the exact submitted body isn't possible from
+        // `SignedChunk` alone (it doesn't carry `chunk_index`'s original
+        // `PlannedChunk`); a real integration keeps the last `prepare`d
+        // chunk around. Recomputing via `row_numbers` here would drop the
+        // recipient/amount fields pay-api's re-validation needs, so this is
+        // deliberately left to construct the body from the caller's
+        // retained chunk — see the doc comment above about the
+        // `pay-api-types` dependency this should really use.
+        let response = self
+            .http
+            .post(&self.endpoint)
+            .header(
+                "Authorization",
+                format!("Bearer {}", signed.signed_transaction_base64),
+            )
+            .json(&serde_json::json!({
+                "batchId": self.batch_id,
+                "chunkIndex": signed.chunk_index,
+                "sender": self.sender.to_string(),
+                "currency": self.currency,
+                "network": self.network,
+                "transfers": signed.row_numbers.iter().map(|row_id| serde_json::json!({
+                    "rowId": row_id,
+                })).collect::<Vec<_>>(),
+            }))
+            .send()
+            .await
+            .map_err(|e| Error::Config(format!("pay-api transport error: {e}")))?;
+        if !response.status().is_success() {
+            return Err(Error::Config(format!(
+                "pay-api submit returned unexpected status {}",
+                response.status()
+            )));
+        }
+        let body: serde_json::Value = response.json().await.map_err(|e| {
+            Error::Config(format!("pay-api submit response was not valid JSON: {e}"))
+        })?;
+        let signature_str = body
+            .get("signature")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                Error::Config("pay-api submit response is missing signature".to_string())
+            })?;
+        let signature = Signature::from_str(signature_str).map_err(|_| {
+            Error::Config("pay-api submit returned a malformed signature".to_string())
+        })?;
+        Ok(BroadcastOutcome::Settled(signature))
+    }
+
+    async fn poll_pending(&self, _signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+        // `broadcast` never returns `Pending` for this transport (pay-api's
+        // response is always final), so the executor should never call
+        // this. Fail loudly rather than silently reporting a wrong status
+        // if that assumption is ever broken.
+        Err(Error::Config(
+            "GaslessApiBroadcaster::poll_pending should never be called: broadcast() never returns Pending".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accounts::{Account, AccountsFile, Keystore, MemoryAccountsStore};
+    use crate::client::push::manifest::{ManifestContext, parse_manifest_csv};
+    use crate::client::push::planner::{
+        AtaSnapshot, DestinationAtaStatus, FeePayerMode, pack_chunks,
+    };
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn fresh_account_and_store() -> (MemoryAccountsStore, Pubkey) {
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let verifying_key = signing_key.verifying_key();
+        let mut full = Vec::with_capacity(64);
+        full.extend_from_slice(&signing_key.to_bytes());
+        full.extend_from_slice(&verifying_key.to_bytes());
+
+        let account = Account {
+            keystore: Keystore::Ephemeral,
+            active: false,
+            auth_required: Some(false),
+            pubkey: Some(bs58::encode(verifying_key.to_bytes()).into_string()),
+            vault: None,
+            account: None,
+            path: None,
+            secret_key_b58: Some(bs58::encode(&full).into_string()),
+            created_at: Some("2026-08-12T00:00:00Z".to_string()),
+            subscriptions: std::collections::BTreeMap::new(),
+        };
+
+        let mut file = AccountsFile::default();
+        file.upsert("localnet", "default", account);
+        let store = MemoryAccountsStore::with_file(file);
+        let pubkey = Pubkey::new_from_array(verifying_key.to_bytes());
+        (store, pubkey)
+    }
+
+    /// Builds a fresh keystore-backed account, plans `rows` gasless
+    /// transfers against it, and authorizes a permit for the plan. The
+    /// returned `Pubkey` is the plan's authority (`sender`) — it comes from
+    /// the store's actual loaded keypair, not an arbitrary caller-supplied
+    /// value, since the permit internally re-derives its own `source_ata`
+    /// from whichever key it loaded and every `sign_chunk` call re-checks
+    /// that the transaction's authority matches it exactly.
+    fn plan_and_permit(
+        rows: usize,
+    ) -> (
+        BatchSigningPermit,
+        Vec<PlannedChunk>,
+        ChunkTxContext,
+        Pubkey,
+    ) {
+        let (store, sender) = fresh_account_and_store();
+        let mut csv = String::from("recipient,amount\n");
+        for i in 0..rows {
+            let recipient = Pubkey::new_from_array([(i + 10) as u8; 32]);
+            csv.push_str(&format!("{recipient},1\n"));
+        }
+        let context = ManifestContext {
+            network_genesis_hash: [3; 32],
+            mint: Pubkey::new_from_array([77; 32]),
+            token_program: super::planner::token_program_id(),
+            decimals: 6,
+        };
+        let manifest = parse_manifest_csv(csv.as_bytes(), context).unwrap();
+        let ata = AtaSnapshot {
+            sender_ata: Pubkey::new_unique(),
+            sender_ata_exists: true,
+            destinations: manifest
+                .rows
+                .iter()
+                .map(|row| DestinationAtaStatus {
+                    recipient: row.recipient,
+                    ata: Pubkey::new_unique(),
+                    exists: true,
+                })
+                .collect(),
+        };
+        let fee_payer = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::Gasless,
+            &sender,
+            &fee_payer,
+            1,
+        )
+        .unwrap();
+        let max_total_raw = plan.total_token_raw().unwrap();
+        let summary = super::super::permit::BatchAuthorizationSummary {
+            account: "default",
+            currency: "USDG",
+            currency_decimals: 6,
+            network: "localnet",
+            recipient_total_raw: max_total_raw,
+            max_total_raw,
+        };
+        let permit = BatchSigningPermit::authorize(
+            "localnet",
+            &store,
+            Some("default"),
+            manifest.context.network_genesis_hash,
+            &manifest,
+            plan.clone(),
+            summary,
+            chrono::Duration::hours(1),
+            None,
+        )
+        .unwrap();
+        let ctx = ChunkTxContext {
+            sender,
+            mint: manifest.context.mint,
+            token_program: manifest.context.token_program,
+            decimals: manifest.context.decimals,
+        };
+        (permit, plan.chunks, ctx, sender)
+    }
+
+    /// An in-memory transport that always returns `Pending`, confirms a
+    /// signature only after it has been polled `confirm_after_polls` times,
+    /// and records the maximum number of signatures ever passed to one
+    /// `poll_pending` call — the thing every backpressure test asserts on.
+    struct MockBroadcaster {
+        fee_payer: Pubkey,
+        confirm_after_polls: u32,
+        poll_counts: Mutex<HashMap<Signature, u32>>,
+        max_batch_seen: Mutex<usize>,
+        prepare_calls: Mutex<usize>,
+    }
+
+    impl MockBroadcaster {
+        fn new(fee_payer: Pubkey, confirm_after_polls: u32) -> Self {
+            Self {
+                fee_payer,
+                confirm_after_polls,
+                poll_counts: Mutex::new(HashMap::new()),
+                max_batch_seen: Mutex::new(0),
+                prepare_calls: Mutex::new(0),
+            }
+        }
+
+        fn max_batch_seen(&self) -> usize {
+            *self.max_batch_seen.lock().unwrap()
+        }
+
+        fn prepare_calls(&self) -> usize {
+            *self.prepare_calls.lock().unwrap()
+        }
+    }
+
+    impl ChunkBroadcaster for MockBroadcaster {
+        async fn prepare(&self, _chunk: &PlannedChunk) -> Result<PreparedChunkContext> {
+            *self.prepare_calls.lock().unwrap() += 1;
+            Ok(PreparedChunkContext {
+                fee_payer: self.fee_payer,
+                blockhash: Hash::new_unique(),
+                last_valid_block_height: 1_000_000,
+            })
+        }
+
+        async fn broadcast(&self, signed: &SignedChunk) -> Result<BroadcastOutcome> {
+            Ok(BroadcastOutcome::Pending(signed.signature))
+        }
+
+        async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+            let mut counts = self.poll_counts.lock().unwrap();
+            let mut max_batch_seen = self.max_batch_seen.lock().unwrap();
+            *max_batch_seen = (*max_batch_seen).max(signatures.len());
+
+            let mut out = Vec::with_capacity(signatures.len());
+            for signature in signatures {
+                let count = counts.entry(*signature).or_insert(0);
+                *count += 1;
+                if *count >= self.confirm_after_polls {
+                    out.push(PendingStatus::Confirmed);
+                } else {
+                    out.push(PendingStatus::StillPending);
+                }
+            }
+            Ok(out)
+        }
+    }
+
+    #[tokio::test]
+    async fn run_confirms_every_chunk_and_journals_signed_before_broadcast() {
+        let (mut permit, chunks, ctx, _sender) = plan_and_permit(5);
+        let broadcaster = MockBroadcaster::new(permit.fee_payer(), 1); // confirms on first poll
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::create_new(dir.path().join("run.jsonl")).unwrap();
+        let config = PushExecutorConfig {
+            max_in_flight: 2,
+            poll_interval: Duration::from_millis(1),
+        };
+        let mut executor = PushExecutor::new(&mut permit, &mut journal, &broadcaster, ctx, config);
+
+        let summary = executor.run(&chunks).await.unwrap();
+        assert_eq!(summary.confirmed, chunks.len());
+        assert_eq!(summary.failed, 0);
+        assert_eq!(broadcaster.prepare_calls(), chunks.len());
+
+        let events =
+            super::super::journal::load_events(dir.path().join("run.jsonl").as_path()).unwrap();
+        let mut last_signed_sequence: HashMap<u32, u64> = HashMap::new();
+        for event in &events {
+            match &event.kind {
+                super::super::journal::JournalEventKind::ChunkSigned { chunk_index, .. } => {
+                    last_signed_sequence.insert(*chunk_index, event.sequence);
+                }
+                super::super::journal::JournalEventKind::ChunkBroadcast { chunk_index, .. } => {
+                    let signed_at = last_signed_sequence
+                        .get(chunk_index)
+                        .expect("a chunk_broadcast event must always be preceded by chunk_signed");
+                    assert!(
+                        *signed_at < event.sequence,
+                        "chunk {chunk_index}: chunk_signed ({signed_at}) must precede chunk_broadcast ({})",
+                        event.sequence
+                    );
+                }
+                _ => {}
+            }
+        }
+        drop_permit_off_runtime_thread(permit);
+    }
+
+    #[tokio::test]
+    async fn run_never_exceeds_the_configured_in_flight_window() {
+        // 40 rows, gasless-capped at MAX_SPLITS=8 transfers per chunk with
+        // pre-existing ATAs, packs as 8+8+8+8+8 = 5 chunks — plenty to
+        // exercise a max_in_flight=3 window.
+        let (mut permit, chunks, ctx, _sender) = plan_and_permit(40);
+        assert!(
+            chunks.len() >= 4,
+            "need several chunks to exercise the window"
+        );
+
+        // Never confirms: every broadcast chunk stays pending forever, which
+        // is exactly the "slow RPC" scenario backpressure has to survive
+        // without ever letting more than `max_in_flight` signatures pile up.
+        // `run` would then never return, so it's bounded by a timeout and
+        // never expected to complete — what's under test is what the mock
+        // observed before the timeout fired.
+        let broadcaster = MockBroadcaster::new(permit.fee_payer(), u32::MAX);
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::create_new(dir.path().join("run.jsonl")).unwrap();
+        let config = PushExecutorConfig {
+            max_in_flight: 3,
+            poll_interval: Duration::from_millis(1),
+        };
+        let mut executor = PushExecutor::new(&mut permit, &mut journal, &broadcaster, ctx, config);
+
+        let result = tokio::time::timeout(Duration::from_millis(200), executor.run(&chunks)).await;
+        assert!(
+            result.is_err(),
+            "run should still be blocked on confirmations that never arrive"
+        );
+
+        // The window must have filled (proving the bound is actually
+        // reached, not just never violated because nothing ran) and must
+        // never have been exceeded.
+        assert_eq!(broadcaster.max_batch_seen(), 3);
+        drop_permit_off_runtime_thread(permit);
+    }
+
+    #[tokio::test]
+    async fn poll_pending_is_always_called_with_every_outstanding_signature_at_once() {
+        // 20 rows packs as 8+8+4 = 3 chunks (see
+        // `planner::tests::gasless_chunks_cap_at_eight_transfers`).
+        let (mut permit, chunks, ctx, _sender) = plan_and_permit(20);
+        assert!(
+            chunks.len() > 1,
+            "need multiple chunks for a batched poll to be meaningful"
+        );
+        let broadcaster = MockBroadcaster::new(permit.fee_payer(), 2); // confirms on 2nd poll
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::create_new(dir.path().join("run.jsonl")).unwrap();
+        let config = PushExecutorConfig {
+            max_in_flight: 10, // large enough that every chunk is in flight together
+            poll_interval: Duration::from_millis(1),
+        };
+        let mut executor = PushExecutor::new(&mut permit, &mut journal, &broadcaster, ctx, config);
+
+        let summary = executor.run(&chunks).await.unwrap();
+        assert_eq!(summary.confirmed, chunks.len());
+        // Every chunk should have been outstanding simultaneously by the
+        // time the final drain loop polls them, proving `poll_pending` is
+        // called with a batch, not once per signature.
+        assert_eq!(broadcaster.max_batch_seen(), chunks.len());
+        drop_permit_off_runtime_thread(permit);
+    }
+
+    struct FailingBroadcaster {
+        fee_payer: Pubkey,
+    }
+
+    impl ChunkBroadcaster for FailingBroadcaster {
+        async fn prepare(&self, _chunk: &PlannedChunk) -> Result<PreparedChunkContext> {
+            Ok(PreparedChunkContext {
+                fee_payer: self.fee_payer,
+                blockhash: Hash::new_unique(),
+                last_valid_block_height: 1_000_000,
+            })
+        }
+
+        async fn broadcast(&self, _signed: &SignedChunk) -> Result<BroadcastOutcome> {
+            Err(Error::Config("simulated broadcast failure".to_string()))
+        }
+
+        async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+            Ok(signatures
+                .iter()
+                .map(|_| PendingStatus::StillPending)
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_broadcast_error_is_journaled_as_failed_without_a_broadcast_event() {
+        let (mut permit, chunks, ctx, _sender) = plan_and_permit(1);
+        let broadcaster = FailingBroadcaster {
+            fee_payer: permit.fee_payer(),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = Journal::create_new(dir.path().join("run.jsonl")).unwrap();
+        let mut executor = PushExecutor::new(
+            &mut permit,
+            &mut journal,
+            &broadcaster,
+            ctx,
+            PushExecutorConfig::default(),
+        );
+
+        let summary = executor.run(&chunks).await.unwrap();
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.confirmed, 0);
+
+        let events =
+            super::super::journal::load_events(dir.path().join("run.jsonl").as_path()).unwrap();
+        assert!(events.iter().any(|e| matches!(
+            e.kind,
+            super::super::journal::JournalEventKind::ChunkFailed { .. }
+        )));
+        assert!(!events.iter().any(|e| matches!(
+            e.kind,
+            super::super::journal::JournalEventKind::ChunkBroadcast { .. }
+        )));
+        drop_permit_off_runtime_thread(permit);
+    }
+}

--- a/rust/crates/core/src/client/push/executor.rs
+++ b/rust/crates/core/src/client/push/executor.rs
@@ -121,6 +121,18 @@ pub enum PendingStatus {
     Failed(String),
 }
 
+/// One in-flight signature plus the expiry it was signed against, so a
+/// [`ChunkBroadcaster::poll_pending`] implementation can tell "RPC doesn't
+/// see it yet, still within its validity window" apart from "RPC doesn't see
+/// it and it can no longer land" — an unconfirmed signature past its
+/// `last_valid_block_height` must resolve to a terminal status instead of
+/// polling forever.
+#[derive(Debug, Clone, Copy)]
+pub struct PendingSignature {
+    pub signature: Signature,
+    pub last_valid_block_height: u64,
+}
+
 /// The pluggable transport [`PushExecutor`] drives. One implementation per
 /// fee-payer mode: [`DirectSolanaBroadcaster`] for self-funded runs,
 /// [`GaslessApiBroadcaster`] for gasless ones. Tests use a third,
@@ -143,7 +155,7 @@ pub trait ChunkBroadcaster {
     /// One batched status check for every currently-outstanding signature.
     /// Must return exactly one status per input signature, in the same
     /// order.
-    async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>>;
+    async fn poll_pending(&self, pending: &[PendingSignature]) -> Result<Vec<PendingStatus>>;
 }
 
 /// Tunables for [`PushExecutor::run`]'s bounded in-flight loop.
@@ -174,6 +186,7 @@ pub struct RunSummary {
 struct InFlightChunk {
     chunk_index: u32,
     signature: Signature,
+    last_valid_block_height: u64,
 }
 
 /// Drives stages 2-4 for a sequence of already-planned chunks (stage 1).
@@ -263,6 +276,7 @@ impl<'a, B: ChunkBroadcaster> PushExecutor<'a, B> {
                     in_flight.push(InFlightChunk {
                         chunk_index: signed.chunk_index,
                         signature,
+                        last_valid_block_height: signed.last_valid_block_height,
                     });
                 }
                 Ok(BroadcastOutcome::Settled(signature)) => {
@@ -311,8 +325,14 @@ impl<'a, B: ChunkBroadcaster> PushExecutor<'a, B> {
         if in_flight.is_empty() {
             return Ok(());
         }
-        let signatures: Vec<Signature> = in_flight.iter().map(|c| c.signature).collect();
-        let statuses = self.broadcaster.poll_pending(&signatures).await?;
+        let pending: Vec<PendingSignature> = in_flight
+            .iter()
+            .map(|c| PendingSignature {
+                signature: c.signature,
+                last_valid_block_height: c.last_valid_block_height,
+            })
+            .collect();
+        let statuses = self.broadcaster.poll_pending(&pending).await?;
         if statuses.len() != in_flight.len() {
             return Err(Error::Config(
                 "poll_pending returned a different number of statuses than signatures queried"
@@ -441,6 +461,39 @@ impl DirectSolanaBroadcaster {
             .cloned()
             .ok_or_else(|| Error::Config("RPC response is missing `result`".to_string()))
     }
+
+    async fn fetch_block_height(&self) -> Result<u64> {
+        let result = self
+            .call(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "getBlockHeight",
+                "params": [{ "commitment": "confirmed" }],
+            }))
+            .await?;
+        result
+            .as_u64()
+            .ok_or_else(|| Error::Config("malformed getBlockHeight response".to_string()))
+    }
+}
+
+/// What a `null` `getSignatureStatuses` entry means once the current
+/// confirmed block height is known: still within the signed blockhash's
+/// validity window (RPC just hasn't seen it, or hasn't indexed it, yet), or
+/// past it (the transaction can never land, on-chain or off — the loop that
+/// keeps polling this signature must stop, not spin forever).
+fn classify_missing_signature(
+    current_block_height: u64,
+    last_valid_block_height: u64,
+) -> PendingStatus {
+    if current_block_height > last_valid_block_height {
+        PendingStatus::Failed(format!(
+            "signature not found and its blockhash expired (current height \
+             {current_block_height} > last valid height {last_valid_block_height})"
+        ))
+    } else {
+        PendingStatus::StillPending
+    }
 }
 
 impl ChunkBroadcaster for DirectSolanaBroadcaster {
@@ -497,11 +550,12 @@ impl ChunkBroadcaster for DirectSolanaBroadcaster {
         Ok(BroadcastOutcome::Pending(signature))
     }
 
-    async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
-        if signatures.is_empty() {
+    async fn poll_pending(&self, pending: &[PendingSignature]) -> Result<Vec<PendingStatus>> {
+        if pending.is_empty() {
             return Ok(Vec::new());
         }
-        let signature_strings: Vec<String> = signatures.iter().map(ToString::to_string).collect();
+        let signature_strings: Vec<String> =
+            pending.iter().map(|p| p.signature.to_string()).collect();
         let result = self
             .call(serde_json::json!({
                 "jsonrpc": "2.0",
@@ -514,11 +568,34 @@ impl ChunkBroadcaster for DirectSolanaBroadcaster {
             .get("value")
             .and_then(|v| v.as_array())
             .ok_or_else(|| Error::Config("malformed getSignatureStatuses response".to_string()))?;
+        if entries.len() != pending.len() {
+            return Err(Error::Config(
+                "getSignatureStatuses returned a different number of entries than signatures queried"
+                    .to_string(),
+            ));
+        }
+
+        // Fetched lazily and at most once per call: a `null` status entry
+        // needs the current block height to tell "still within its
+        // validity window" apart from "expired, and will never confirm" —
+        // most polls see no `null` entries at all and never pay for it.
+        let mut current_block_height: Option<u64> = None;
 
         let mut statuses = Vec::with_capacity(entries.len());
-        for entry in entries {
+        for (entry, pending_signature) in entries.iter().zip(pending) {
             if entry.is_null() {
-                statuses.push(PendingStatus::StillPending);
+                let height = match current_block_height {
+                    Some(height) => height,
+                    None => {
+                        let height = self.fetch_block_height().await?;
+                        current_block_height = Some(height);
+                        height
+                    }
+                };
+                statuses.push(classify_missing_signature(
+                    height,
+                    pending_signature.last_valid_block_height,
+                ));
                 continue;
             }
             let failed = entry.get("err").map(|err| !err.is_null()).unwrap_or(false);
@@ -697,7 +774,7 @@ impl ChunkBroadcaster for GaslessApiBroadcaster {
         Ok(BroadcastOutcome::Settled(signature))
     }
 
-    async fn poll_pending(&self, _signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+    async fn poll_pending(&self, _pending: &[PendingSignature]) -> Result<Vec<PendingStatus>> {
         // `broadcast` never returns `Pending` for this transport (pay-api's
         // response is always final), so the executor should never call
         // this. Fail loudly rather than silently reporting a wrong status
@@ -873,14 +950,14 @@ mod tests {
             Ok(BroadcastOutcome::Pending(signed.signature))
         }
 
-        async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
+        async fn poll_pending(&self, pending: &[PendingSignature]) -> Result<Vec<PendingStatus>> {
             let mut counts = self.poll_counts.lock().unwrap();
             let mut max_batch_seen = self.max_batch_seen.lock().unwrap();
-            *max_batch_seen = (*max_batch_seen).max(signatures.len());
+            *max_batch_seen = (*max_batch_seen).max(pending.len());
 
-            let mut out = Vec::with_capacity(signatures.len());
-            for signature in signatures {
-                let count = counts.entry(*signature).or_insert(0);
+            let mut out = Vec::with_capacity(pending.len());
+            for p in pending {
+                let count = counts.entry(p.signature).or_insert(0);
                 *count += 1;
                 if *count >= self.confirm_after_polls {
                     out.push(PendingStatus::Confirmed);
@@ -1017,8 +1094,8 @@ mod tests {
             Err(Error::Config("simulated broadcast failure".to_string()))
         }
 
-        async fn poll_pending(&self, signatures: &[Signature]) -> Result<Vec<PendingStatus>> {
-            Ok(signatures
+        async fn poll_pending(&self, pending: &[PendingSignature]) -> Result<Vec<PendingStatus>> {
+            Ok(pending
                 .iter()
                 .map(|_| PendingStatus::StillPending)
                 .collect())
@@ -1056,5 +1133,29 @@ mod tests {
             super::super::journal::JournalEventKind::ChunkBroadcast { .. }
         )));
         drop_permit_off_runtime_thread(permit);
+    }
+
+    #[test]
+    fn missing_signature_within_validity_window_stays_pending() {
+        assert!(matches!(
+            classify_missing_signature(999, 1_000),
+            PendingStatus::StillPending
+        ));
+        // Still valid at the exact boundary height.
+        assert!(matches!(
+            classify_missing_signature(1_000, 1_000),
+            PendingStatus::StillPending
+        ));
+    }
+
+    #[test]
+    fn missing_signature_past_its_expiry_is_a_terminal_failure_not_still_pending() {
+        // This is the exact bug Greptile flagged: a `null` status entry
+        // must not be treated as `StillPending` forever once the signed
+        // blockhash can no longer land.
+        match classify_missing_signature(1_001, 1_000) {
+            PendingStatus::Failed(reason) => assert!(reason.contains("expired")),
+            other => panic!("expected a terminal Failed status, got {other:?}"),
+        }
     }
 }

--- a/rust/crates/core/src/client/push/journal.rs
+++ b/rust/crates/core/src/client/push/journal.rs
@@ -1,0 +1,958 @@
+//! The durable, append-only `pay push` journal and its resume reducer.
+//!
+//! Two independent halves live here:
+//!
+//! - [`Journal`]: an append-only JSONL writer. Every write is flushed and
+//!   `sync_data`'d before the call returns. [`Journal::append_chunk_signed`]
+//!   is the *only* way to obtain a [`ChunkBroadcastPermit`], and
+//!   [`Journal::append_chunk_broadcast`] requires one — so a durable
+//!   `chunk_signed` record is structurally required before any broadcast
+//!   step can run, not just a convention callers are trusted to follow.
+//! - [`reduce_chunk_resume_action`]: pure resume logic. It takes an
+//!   [`ResumeRpc`] trait object rather than a live RPC client, so the exact
+//!   decision matrix in the plan's "Journal and resume" section is
+//!   unit-testable without a network.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use solana_hash::Hash;
+use solana_signature::Signature;
+
+use super::planner::FeePayerMode;
+use crate::{Error, Result};
+
+/// `~/.config/pay/push/<UTC timestamp>-<manifest-prefix>.jsonl`.
+pub fn default_journal_path(manifest_hash_prefix: &str) -> PathBuf {
+    let timestamp = Utc::now().format("%Y%m%dT%H%M%SZ");
+    PathBuf::from(
+        shellexpand::tilde(&format!(
+            "~/.config/pay/push/{timestamp}-{manifest_hash_prefix}.jsonl"
+        ))
+        .into_owned(),
+    )
+}
+
+// ── Event log ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum JournalEventKind {
+    RunCreated {
+        manifest_hash_hex: String,
+        network: String,
+        currency: String,
+        mint: String,
+        token_program: String,
+        decimals: u8,
+        row_count: usize,
+        total_amount_raw: u64,
+        requested_fee_mode: String,
+    },
+    PreflightCompleted {
+        fee_payer_mode: String,
+        estimated_fee_lamports: u64,
+        missing_ata_rent_lamports: u64,
+        reserve_lamports: u64,
+        chunk_count: usize,
+        max_token_raw: u64,
+    },
+    AuthorizationGranted {
+        account_pubkey: String,
+        max_token_raw: u64,
+        max_transactions: usize,
+        expires_at: DateTime<Utc>,
+    },
+    ChunkPrepared {
+        chunk_index: u32,
+        row_numbers: Vec<u64>,
+        memo: String,
+    },
+    ChunkSigned {
+        chunk_index: u32,
+        row_numbers: Vec<u64>,
+        signature: String,
+        signed_transaction_base64: String,
+        blockhash: String,
+        last_valid_block_height: u64,
+    },
+    ChunkBroadcast {
+        chunk_index: u32,
+        signature: String,
+    },
+    ChunkConfirmed {
+        chunk_index: u32,
+        signature: String,
+    },
+    ChunkFailed {
+        chunk_index: u32,
+        reason: String,
+        retryable: bool,
+    },
+    RunInterrupted {
+        reason: String,
+        confirmed: usize,
+        failed: usize,
+        remaining: usize,
+    },
+    RunCompleted {
+        confirmed: usize,
+        failed: usize,
+        unknown: usize,
+    },
+}
+
+impl JournalEventKind {
+    fn chunk_index(&self) -> Option<u32> {
+        match self {
+            Self::ChunkPrepared { chunk_index, .. }
+            | Self::ChunkSigned { chunk_index, .. }
+            | Self::ChunkBroadcast { chunk_index, .. }
+            | Self::ChunkConfirmed { chunk_index, .. }
+            | Self::ChunkFailed { chunk_index, .. } => Some(*chunk_index),
+            _ => None,
+        }
+    }
+}
+
+/// One durable line: a monotonic sequence number, an RFC 3339 UTC
+/// timestamp, and the event payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JournalEvent {
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    #[serde(flatten)]
+    pub kind: JournalEventKind,
+}
+
+/// Proof that a `chunk_signed` event has been durably appended — written,
+/// flushed, and `sync_data`'d — to the journal. The only way to construct
+/// one is [`Journal::append_chunk_signed`], and
+/// [`Journal::append_chunk_broadcast`] requires one: there is no code path
+/// that reaches "broadcast" without first passing through a completed
+/// fsync of the signed transaction.
+#[derive(Debug, Clone, Copy)]
+// `#[non_exhaustive]` only blocks *other crates* from constructing this
+// struct literal — within `pay-core` it would have no effect, and any
+// other module could then forge a permit without ever calling
+// `append_chunk_signed`. The private field is deliberate: it is the actual
+// enforcement mechanism (construction is only possible from this module),
+// not just an API-evolution nicety.
+#[allow(clippy::manual_non_exhaustive)]
+pub struct ChunkBroadcastPermit {
+    pub chunk_index: u32,
+    _private: (),
+}
+
+/// An append-only JSONL writer for one `pay push` run. A single writer
+/// should own the file for the run's lifetime; the plan's "single writer
+/// task serializes events" requirement is the caller's responsibility (this
+/// type is not internally synchronized across threads).
+pub struct Journal {
+    file: File,
+    path: PathBuf,
+    next_sequence: u64,
+}
+
+impl Journal {
+    /// Create a brand-new journal file at `path`, mode `0600`, failing if it
+    /// already exists (a fresh run must never silently continue someone
+    /// else's journal).
+    pub fn create_new(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| Error::Config(format!("failed to create journal directory: {e}")))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+
+        let mut options = OpenOptions::new();
+        options.create_new(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&path).map_err(|e| {
+            Error::Config(format!("failed to create journal {}: {e}", path.display()))
+        })?;
+
+        Ok(Self {
+            file,
+            path,
+            next_sequence: 1,
+        })
+    }
+
+    /// Re-open an existing journal for a resumed run. `next_sequence` picks
+    /// up after the highest sequence number [`load_events`] can recover
+    /// (tolerating one truncated final line).
+    pub fn open_existing(path: PathBuf) -> Result<(Self, Vec<JournalEvent>)> {
+        let events = load_events(&path)?;
+        let next_sequence = events.last().map(|e| e.sequence + 1).unwrap_or(1);
+        let file = OpenOptions::new().append(true).open(&path).map_err(|e| {
+            Error::Config(format!("failed to open journal {}: {e}", path.display()))
+        })?;
+        Ok((
+            Self {
+                file,
+                path,
+                next_sequence,
+            },
+            events,
+        ))
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn append_event(&mut self, kind: JournalEventKind) -> Result<JournalEvent> {
+        let event = JournalEvent {
+            sequence: self.next_sequence,
+            timestamp: Utc::now(),
+            kind,
+        };
+        let mut line = serde_json::to_string(&event)
+            .map_err(|e| Error::Config(format!("failed to serialize journal event: {e}")))?;
+        line.push('\n');
+        self.file
+            .write_all(line.as_bytes())
+            .map_err(|e| Error::Config(format!("failed to write journal event: {e}")))?;
+        self.file
+            .flush()
+            .map_err(|e| Error::Config(format!("failed to flush journal event: {e}")))?;
+        self.file
+            .sync_data()
+            .map_err(|e| Error::Config(format!("failed to fsync journal event: {e}")))?;
+        self.next_sequence += 1;
+        Ok(event)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_run_created(
+        &mut self,
+        manifest_hash_hex: String,
+        network: String,
+        currency: String,
+        mint: String,
+        token_program: String,
+        decimals: u8,
+        row_count: usize,
+        total_amount_raw: u64,
+        requested_fee_mode: String,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::RunCreated {
+            manifest_hash_hex,
+            network,
+            currency,
+            mint,
+            token_program,
+            decimals,
+            row_count,
+            total_amount_raw,
+            requested_fee_mode,
+        })
+    }
+
+    pub fn append_preflight_completed(
+        &mut self,
+        fee_payer_mode: FeePayerMode,
+        estimated_fee_lamports: u64,
+        missing_ata_rent_lamports: u64,
+        reserve_lamports: u64,
+        chunk_count: usize,
+        max_token_raw: u64,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::PreflightCompleted {
+            fee_payer_mode: fee_payer_mode_label(fee_payer_mode).to_string(),
+            estimated_fee_lamports,
+            missing_ata_rent_lamports,
+            reserve_lamports,
+            chunk_count,
+            max_token_raw,
+        })
+    }
+
+    pub fn append_authorization_granted(
+        &mut self,
+        account_pubkey: String,
+        max_token_raw: u64,
+        max_transactions: usize,
+        expires_at: DateTime<Utc>,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::AuthorizationGranted {
+            account_pubkey,
+            max_token_raw,
+            max_transactions,
+            expires_at,
+        })
+    }
+
+    pub fn append_chunk_prepared(
+        &mut self,
+        chunk_index: u32,
+        row_numbers: Vec<u64>,
+        memo: String,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::ChunkPrepared {
+            chunk_index,
+            row_numbers,
+            memo,
+        })
+    }
+
+    /// Durably record a signature before any broadcast can occur. Returns
+    /// both the event and a [`ChunkBroadcastPermit`] — the only credential
+    /// [`Self::append_chunk_broadcast`] accepts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_chunk_signed(
+        &mut self,
+        chunk_index: u32,
+        row_numbers: Vec<u64>,
+        signature: &Signature,
+        signed_transaction_base64: String,
+        blockhash: &Hash,
+        last_valid_block_height: u64,
+    ) -> Result<(JournalEvent, ChunkBroadcastPermit)> {
+        let event = self.append_event(JournalEventKind::ChunkSigned {
+            chunk_index,
+            row_numbers,
+            signature: signature.to_string(),
+            signed_transaction_base64,
+            blockhash: blockhash.to_string(),
+            last_valid_block_height,
+        })?;
+        Ok((
+            event,
+            ChunkBroadcastPermit {
+                chunk_index,
+                _private: (),
+            },
+        ))
+    }
+
+    /// Record that a signed chunk was submitted to the network. Requires the
+    /// [`ChunkBroadcastPermit`] produced by the matching
+    /// [`Self::append_chunk_signed`] call for the same chunk.
+    pub fn append_chunk_broadcast(
+        &mut self,
+        permit: ChunkBroadcastPermit,
+        signature: &Signature,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::ChunkBroadcast {
+            chunk_index: permit.chunk_index,
+            signature: signature.to_string(),
+        })
+    }
+
+    pub fn append_chunk_confirmed(
+        &mut self,
+        chunk_index: u32,
+        signature: &Signature,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::ChunkConfirmed {
+            chunk_index,
+            signature: signature.to_string(),
+        })
+    }
+
+    pub fn append_chunk_failed(
+        &mut self,
+        chunk_index: u32,
+        reason: String,
+        retryable: bool,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::ChunkFailed {
+            chunk_index,
+            reason,
+            retryable,
+        })
+    }
+
+    pub fn append_run_interrupted(
+        &mut self,
+        reason: String,
+        confirmed: usize,
+        failed: usize,
+        remaining: usize,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::RunInterrupted {
+            reason,
+            confirmed,
+            failed,
+            remaining,
+        })
+    }
+
+    pub fn append_run_completed(
+        &mut self,
+        confirmed: usize,
+        failed: usize,
+        unknown: usize,
+    ) -> Result<JournalEvent> {
+        self.append_event(JournalEventKind::RunCompleted {
+            confirmed,
+            failed,
+            unknown,
+        })
+    }
+}
+
+fn fee_payer_mode_label(mode: FeePayerMode) -> &'static str {
+    match mode {
+        FeePayerMode::SelfFunded => "self_funded",
+        FeePayerMode::Gasless => "gasless",
+    }
+}
+
+/// Load every event from a journal file, tolerating exactly one truncated
+/// final line (the crash-mid-write case) but rejecting any parse failure
+/// that is not the last line, and rejecting non-monotonic sequence numbers
+/// anywhere in the file.
+pub fn load_events(path: &Path) -> Result<Vec<JournalEvent>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = File::open(path)
+        .map_err(|e| Error::Config(format!("failed to open journal {}: {e}", path.display())))?;
+    let lines: Vec<String> = std::io::BufReader::new(file)
+        .lines()
+        .collect::<std::io::Result<_>>()
+        .map_err(|e| Error::Config(format!("failed to read journal {}: {e}", path.display())))?;
+
+    let mut events = Vec::with_capacity(lines.len());
+    let last_index = lines.len().saturating_sub(1);
+    for (index, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<JournalEvent>(line) {
+            Ok(event) => events.push(event),
+            Err(e) => {
+                if index == last_index {
+                    // Tolerate a crash mid-write: the last line may be a
+                    // partial JSON record that never finished fsync'ing.
+                    break;
+                }
+                return Err(Error::Config(format!(
+                    "journal {} is corrupted at line {}: {e}",
+                    path.display(),
+                    index + 1
+                )));
+            }
+        }
+    }
+
+    for pair in events.windows(2) {
+        if pair[1].sequence <= pair[0].sequence {
+            return Err(Error::Config(format!(
+                "journal {} has non-monotonic sequence numbers ({} then {})",
+                path.display(),
+                pair[0].sequence,
+                pair[1].sequence
+            )));
+        }
+    }
+
+    Ok(events)
+}
+
+// ── Resume reduction ─────────────────────────────────────────────────────
+
+/// What the exact on-chain/off-chain status of a signature is, as observed
+/// by a live RPC/pay-api lookup. Injected via [`ResumeRpc`] so
+/// [`reduce_chunk_resume_action`] is unit-testable without a network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcSignatureStatus {
+    Confirmed,
+    Failed,
+    NotFound,
+    /// RPC could not determine the answer (timeout, ambiguous response,
+    /// etc.). This must never be treated as "safe to rebuild."
+    Unknown,
+}
+
+/// The one RPC capability resume needs: signature status, and the current
+/// confirmed block height (to decide blockhash expiry). A later slice wires
+/// this to a live RPC client; tests wire it to a fixed fixture.
+pub trait ResumeRpc {
+    fn signature_status(&self, signature: &str) -> RpcSignatureStatus;
+    fn current_block_height(&self) -> u64;
+}
+
+/// What the executor should do next for one chunk, derived purely from the
+/// event log plus one RPC lookup. See the plan's "Journal and resume"
+/// section for the exact rule this implements per branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChunkResumeAction {
+    /// Already confirmed in the log — nothing to do.
+    Skip,
+    /// Direct mode: the signed bytes are still within their blockhash's
+    /// validity window and RPC does not see the signature yet. Rebroadcast
+    /// the exact same bytes; never rebuild while they remain valid.
+    RebroadcastIdenticalBytes { signed_transaction_base64: String },
+    /// Gasless mode: re-present the exact saved credential so pay-api's
+    /// durable idempotency record returns the same final signature,
+    /// regardless of how much time has passed.
+    RepresentGaslessCredential { signed_transaction_base64: String },
+    /// RPC now reports the previously unconfirmed signature as confirmed —
+    /// record it and treat the chunk as done.
+    RecordConfirmedThenSkip { signature: String },
+    /// An on-chain or journal-recorded failure — a fresh attempt is allowed
+    /// under policy (a later slice's retry budget), not indefinitely.
+    RetryAfterFailure,
+    /// The signed transaction's blockhash has proven expired and RPC does
+    /// not see the signature: safe to rebuild the same logical chunk fresh.
+    RebuildWithFreshBlockhash,
+    /// No `chunk_signed` event exists yet for this chunk: it was never
+    /// attempted, so it is safe to plan and sign it under the new permit.
+    NeedsSigning,
+    /// RPC could not determine the signature's status. Stop; never sign a
+    /// replacement while the answer is unknown.
+    StopUnknown { signature: String },
+}
+
+/// Reduce the event log into the single next action for `chunk_index`, per
+/// the plan's resume rules.
+pub fn reduce_chunk_resume_action(
+    chunk_index: u32,
+    events: &[JournalEvent],
+    fee_payer_mode: FeePayerMode,
+    rpc: &dyn ResumeRpc,
+) -> ChunkResumeAction {
+    let mut last_signed: Option<(String, String, u64)> = None;
+    let mut confirmed = false;
+    let mut failed = false;
+
+    for event in events {
+        if event.kind.chunk_index() != Some(chunk_index) {
+            continue;
+        }
+        match &event.kind {
+            JournalEventKind::ChunkSigned {
+                signature,
+                signed_transaction_base64,
+                last_valid_block_height,
+                ..
+            } => {
+                // A fresh `chunk_signed` (e.g. after a resign) supersedes
+                // any earlier terminal state recorded for this chunk.
+                last_signed = Some((
+                    signature.clone(),
+                    signed_transaction_base64.clone(),
+                    *last_valid_block_height,
+                ));
+                confirmed = false;
+                failed = false;
+            }
+            JournalEventKind::ChunkConfirmed { .. } => confirmed = true,
+            JournalEventKind::ChunkFailed { .. } => failed = true,
+            JournalEventKind::ChunkBroadcast { .. } => {}
+            _ => {}
+        }
+    }
+
+    if confirmed {
+        return ChunkResumeAction::Skip;
+    }
+
+    let Some((signature, signed_transaction_base64, last_valid_block_height)) = last_signed else {
+        return ChunkResumeAction::NeedsSigning;
+    };
+
+    if failed {
+        return ChunkResumeAction::RetryAfterFailure;
+    }
+
+    match fee_payer_mode {
+        // pay-api owns the authoritative status for a gasless chunk; there
+        // is no client-signature-based RPC lookup that means anything here
+        // (the client is not the fee payer, so its signature is not the
+        // transaction id). Always re-present the saved credential.
+        FeePayerMode::Gasless => ChunkResumeAction::RepresentGaslessCredential {
+            signed_transaction_base64,
+        },
+        FeePayerMode::SelfFunded => match rpc.signature_status(&signature) {
+            RpcSignatureStatus::Confirmed => {
+                ChunkResumeAction::RecordConfirmedThenSkip { signature }
+            }
+            RpcSignatureStatus::Failed => ChunkResumeAction::RetryAfterFailure,
+            RpcSignatureStatus::Unknown => ChunkResumeAction::StopUnknown { signature },
+            RpcSignatureStatus::NotFound => {
+                if rpc.current_block_height() <= last_valid_block_height {
+                    ChunkResumeAction::RebroadcastIdenticalBytes {
+                        signed_transaction_base64,
+                    }
+                } else {
+                    ChunkResumeAction::RebuildWithFreshBlockhash
+                }
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FixedRpc {
+        status: RpcSignatureStatus,
+        current_block_height: u64,
+    }
+
+    impl ResumeRpc for FixedRpc {
+        fn signature_status(&self, _signature: &str) -> RpcSignatureStatus {
+            self.status
+        }
+        fn current_block_height(&self) -> u64 {
+            self.current_block_height
+        }
+    }
+
+    fn signed_event(chunk_index: u32, sequence: u64, last_valid_block_height: u64) -> JournalEvent {
+        JournalEvent {
+            sequence,
+            timestamp: Utc::now(),
+            kind: JournalEventKind::ChunkSigned {
+                chunk_index,
+                row_numbers: vec![2, 3],
+                signature: "sig-1".to_string(),
+                signed_transaction_base64: "YmFzZTY0".to_string(),
+                blockhash: "hash-1".to_string(),
+                last_valid_block_height,
+            },
+        }
+    }
+
+    // ── Journal writer / fsync-before-broadcast ──
+
+    #[test]
+    fn create_new_writes_mode_0600_and_appends_monotonic_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        let mut journal = Journal::create_new(path.clone()).unwrap();
+
+        let e1 = journal
+            .append_run_created(
+                "abc".into(),
+                "mainnet".into(),
+                "USDG".into(),
+                "mint".into(),
+                "token".into(),
+                6,
+                10,
+                1_000,
+                "auto".into(),
+            )
+            .unwrap();
+        let e2 = journal
+            .append_chunk_prepared(0, vec![2, 3], "memo".into())
+            .unwrap();
+        assert_eq!(e1.sequence, 1);
+        assert_eq!(e2.sequence, 2);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+
+        let events = load_events(&path).unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn append_chunk_broadcast_requires_a_signed_permit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        let mut journal = Journal::create_new(path.clone()).unwrap();
+
+        let signature = Signature::default();
+        let blockhash = Hash::default();
+        let (_signed_event, permit) = journal
+            .append_chunk_signed(0, vec![2], &signature, "YmFzZTY0".into(), &blockhash, 1_000)
+            .unwrap();
+
+        // The only way to reach this call is with the permit `sign_chunk`
+        // produced above, and that permit is only returned *after* the
+        // fsync in `append_chunk_signed` has already completed — by the
+        // time this line runs, the chunk_signed event is already durable.
+        let broadcast_event = journal.append_chunk_broadcast(permit, &signature).unwrap();
+        assert!(matches!(
+            broadcast_event.kind,
+            JournalEventKind::ChunkBroadcast { .. }
+        ));
+
+        let events = load_events(&path).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            events[0].kind,
+            JournalEventKind::ChunkSigned { .. }
+        ));
+        assert!(matches!(
+            events[1].kind,
+            JournalEventKind::ChunkBroadcast { .. }
+        ));
+    }
+
+    #[test]
+    fn load_events_tolerates_one_truncated_final_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        let mut journal = Journal::create_new(path.clone()).unwrap();
+        journal
+            .append_chunk_prepared(0, vec![2], "memo".into())
+            .unwrap();
+        journal
+            .append_chunk_prepared(1, vec![3], "memo".into())
+            .unwrap();
+        drop(journal);
+
+        // Simulate a crash mid-write: append a syntactically broken partial line.
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"{\"sequence\":3,\"timestamp\":\"2026-01")
+            .unwrap();
+
+        let events = load_events(&path).unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[test]
+    fn load_events_rejects_corruption_before_the_last_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        let mut journal = Journal::create_new(path.clone()).unwrap();
+        journal
+            .append_chunk_prepared(0, vec![2], "memo".into())
+            .unwrap();
+        drop(journal);
+
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"not json at all\n").unwrap();
+        file.write_all(b"{\"sequence\":3,\"timestamp\":\"2026-01-01T00:00:00Z\",\"kind\":\"chunk_prepared\",\"chunk_index\":1,\"row_numbers\":[3],\"memo\":\"m\"}\n").unwrap();
+
+        let err = load_events(&path).unwrap_err();
+        assert!(err.to_string().contains("corrupted at line 2"), "{err}");
+    }
+
+    #[test]
+    fn load_events_rejects_non_monotonic_sequences() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        std::fs::write(
+            &path,
+            "{\"sequence\":2,\"timestamp\":\"2026-01-01T00:00:00Z\",\"kind\":\"chunk_prepared\",\"chunk_index\":0,\"row_numbers\":[2],\"memo\":\"m\"}\n\
+             {\"sequence\":1,\"timestamp\":\"2026-01-01T00:00:01Z\",\"kind\":\"chunk_prepared\",\"chunk_index\":1,\"row_numbers\":[3],\"memo\":\"m\"}\n",
+        )
+        .unwrap();
+
+        let err = load_events(&path).unwrap_err();
+        assert!(err.to_string().contains("non-monotonic"), "{err}");
+    }
+
+    #[test]
+    fn open_existing_resumes_sequence_after_truncated_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("run.jsonl");
+        let mut journal = Journal::create_new(path.clone()).unwrap();
+        journal
+            .append_chunk_prepared(0, vec![2], "memo".into())
+            .unwrap();
+        drop(journal);
+
+        let (mut resumed, events) = Journal::open_existing(path.clone()).unwrap();
+        assert_eq!(events.len(), 1);
+        let next = resumed
+            .append_chunk_prepared(1, vec![3], "memo".into())
+            .unwrap();
+        assert_eq!(next.sequence, 2);
+    }
+
+    // ── Resume reduction ──
+
+    #[test]
+    fn confirmed_chunk_is_skipped() {
+        let events = vec![
+            signed_event(0, 1, 1_000),
+            JournalEvent {
+                sequence: 2,
+                timestamp: Utc::now(),
+                kind: JournalEventKind::ChunkConfirmed {
+                    chunk_index: 0,
+                    signature: "sig-1".into(),
+                },
+            },
+        ];
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 0,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::Skip
+        );
+    }
+
+    #[test]
+    fn never_signed_chunk_needs_signing() {
+        let events = vec![signed_event(1, 1, 1_000)]; // different chunk
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::NotFound,
+            current_block_height: 0,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::NeedsSigning
+        );
+    }
+
+    #[test]
+    fn self_funded_within_blockheight_and_not_found_rebroadcasts_identical_bytes() {
+        let events = vec![signed_event(0, 1, 1_000)];
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::NotFound,
+            current_block_height: 500,
+        };
+        let action = reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc);
+        assert_eq!(
+            action,
+            ChunkResumeAction::RebroadcastIdenticalBytes {
+                signed_transaction_base64: "YmFzZTY0".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn self_funded_past_blockheight_and_not_found_rebuilds_fresh() {
+        let events = vec![signed_event(0, 1, 1_000)];
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::NotFound,
+            current_block_height: 1_001,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::RebuildWithFreshBlockhash
+        );
+    }
+
+    #[test]
+    fn never_rebuilds_a_replacement_for_an_unknown_still_valid_signature() {
+        let events = vec![signed_event(0, 1, 1_000)];
+        // Blockhash is still valid (current height < last valid height) AND
+        // RPC can't determine status: must stop, never rebuild.
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 1,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::StopUnknown {
+                signature: "sig-1".to_string()
+            }
+        );
+
+        // Also true once the blockhash *has* expired: Unknown still wins.
+        let rpc_expired = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 5_000,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc_expired),
+            ChunkResumeAction::StopUnknown {
+                signature: "sig-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn self_funded_confirmed_by_rpc_after_lost_response() {
+        let events = vec![signed_event(0, 1, 1_000)];
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Confirmed,
+            current_block_height: 999,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::RecordConfirmedThenSkip {
+                signature: "sig-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_failure_allows_retry_regardless_of_rpc() {
+        let mut events = vec![signed_event(0, 1, 1_000)];
+        events.push(JournalEvent {
+            sequence: 2,
+            timestamp: Utc::now(),
+            kind: JournalEventKind::ChunkFailed {
+                chunk_index: 0,
+                reason: "insufficient funds".into(),
+                retryable: false,
+            },
+        });
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 0,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::RetryAfterFailure
+        );
+    }
+
+    #[test]
+    fn gasless_always_represents_the_saved_credential_until_terminal() {
+        let events = vec![signed_event(0, 1, 1_000)];
+        // Even with a very stale blockhash, gasless resume never touches
+        // direct-RPC signature lookups — pay-api's idempotency store is
+        // authoritative.
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 999_999,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::Gasless, &rpc),
+            ChunkResumeAction::RepresentGaslessCredential {
+                signed_transaction_base64: "YmFzZTY0".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn a_resign_event_supersedes_the_prior_terminal_state() {
+        // First attempt failed, then a resign (fresh chunk_signed) happened
+        // — the failure must not still gate the newer signature.
+        let events = vec![
+            signed_event(0, 1, 1_000),
+            JournalEvent {
+                sequence: 2,
+                timestamp: Utc::now(),
+                kind: JournalEventKind::ChunkFailed {
+                    chunk_index: 0,
+                    reason: "blockhash not found".into(),
+                    retryable: true,
+                },
+            },
+            signed_event(0, 3, 2_000),
+        ];
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::NotFound,
+            current_block_height: 1_500,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::RebroadcastIdenticalBytes {
+                signed_transaction_base64: "YmFzZTY0".to_string()
+            }
+        );
+    }
+}

--- a/rust/crates/core/src/client/push/journal.rs
+++ b/rust/crates/core/src/client/push/journal.rs
@@ -529,7 +529,6 @@ pub fn reduce_chunk_resume_action(
 ) -> ChunkResumeAction {
     let mut last_signed: Option<(String, String, u64)> = None;
     let mut confirmed = false;
-    let mut failed = false;
 
     for event in events {
         if event.kind.chunk_index() != Some(chunk_index) {
@@ -550,10 +549,18 @@ pub fn reduce_chunk_resume_action(
                     *last_valid_block_height,
                 ));
                 confirmed = false;
-                failed = false;
             }
             JournalEventKind::ChunkConfirmed { .. } => confirmed = true,
-            JournalEventKind::ChunkFailed { .. } => failed = true,
+            // A recorded failure never short-circuits straight to a fresh
+            // attempt: the chunk's deterministic signature was journaled
+            // before the broadcast that produced this failure (see the
+            // module docs' fsync-before-broadcast invariant), so the
+            // failure may describe a lost response to a submission that
+            // still landed. The mode-specific reconciliation below always
+            // re-checks that signature's real status before permitting a
+            // replacement transfer — a `ChunkFailed` event by itself proves
+            // nothing about whether the network ever saw the transaction.
+            JournalEventKind::ChunkFailed { .. } => {}
             JournalEventKind::ChunkBroadcast { .. } => {}
             _ => {}
         }
@@ -566,10 +573,6 @@ pub fn reduce_chunk_resume_action(
     let Some((signature, signed_transaction_base64, last_valid_block_height)) = last_signed else {
         return ChunkResumeAction::NeedsSigning;
     };
-
-    if failed {
-        return ChunkResumeAction::RetryAfterFailure;
-    }
 
     match fee_payer_mode {
         // pay-api owns the authoritative status for a gasless chunk; there
@@ -888,7 +891,62 @@ mod tests {
     }
 
     #[test]
-    fn explicit_failure_allows_retry_regardless_of_rpc() {
+    fn explicit_failure_still_reconciles_against_rpc_before_retrying() {
+        // A `ChunkFailed` event (e.g. a lost `sendTransaction` response)
+        // does not by itself prove the network never saw the transaction.
+        // An `Unknown` RPC answer must still block a fresh attempt, exactly
+        // as it would with no failure recorded at all.
+        let mut events = vec![signed_event(0, 1, 1_000)];
+        events.push(JournalEvent {
+            sequence: 2,
+            timestamp: Utc::now(),
+            kind: JournalEventKind::ChunkFailed {
+                chunk_index: 0,
+                reason: "lost sendTransaction response".into(),
+                retryable: true,
+            },
+        });
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Unknown,
+            current_block_height: 0,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::StopUnknown {
+                signature: "sig-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_failure_is_confirmed_instead_of_retried_if_rpc_later_sees_it_landed() {
+        // The exact double-submission risk Greptile flagged: a failed
+        // broadcast attempt must not permit a fresh signature while RPC
+        // shows the original signed transaction already confirmed.
+        let mut events = vec![signed_event(0, 1, 1_000)];
+        events.push(JournalEvent {
+            sequence: 2,
+            timestamp: Utc::now(),
+            kind: JournalEventKind::ChunkFailed {
+                chunk_index: 0,
+                reason: "lost sendTransaction response".into(),
+                retryable: true,
+            },
+        });
+        let rpc = FixedRpc {
+            status: RpcSignatureStatus::Confirmed,
+            current_block_height: 999,
+        };
+        assert_eq!(
+            reduce_chunk_resume_action(0, &events, FeePayerMode::SelfFunded, &rpc),
+            ChunkResumeAction::RecordConfirmedThenSkip {
+                signature: "sig-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_failure_confirmed_on_chain_still_retries() {
         let mut events = vec![signed_event(0, 1, 1_000)];
         events.push(JournalEvent {
             sequence: 2,
@@ -900,7 +958,7 @@ mod tests {
             },
         });
         let rpc = FixedRpc {
-            status: RpcSignatureStatus::Unknown,
+            status: RpcSignatureStatus::Failed,
             current_block_height: 0,
         };
         assert_eq!(

--- a/rust/crates/core/src/client/push/manifest.rs
+++ b/rust/crates/core/src/client/push/manifest.rs
@@ -1,0 +1,402 @@
+//! Strict CSV parsing and canonical manifests for `pay push`.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use std::str::FromStr;
+
+use solana_pubkey::Pubkey;
+
+use crate::client::send::parse_token_amount;
+use crate::{Error, Result};
+
+/// Upper bound on a single batch. This prevents a malformed input from using
+/// unbounded memory before the user has reviewed or authorized the payout.
+pub const MAX_TRANSFER_ROWS: usize = 100_000;
+
+/// A valid 100k-row CSV is well below this limit. Keep the pre-authorization
+/// parser bounded even when a malformed input contains one enormous record.
+pub const MAX_CSV_BYTES: usize = 16 * 1024 * 1024;
+
+const MANIFEST_VERSION: &[u8] = b"pay-push:v1";
+
+/// On-chain properties that bind a parsed CSV to one precise payout plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestContext {
+    /// The network's genesis hash, not a human-readable network alias.
+    pub network_genesis_hash: [u8; 32],
+    pub mint: Pubkey,
+    pub token_program: Pubkey,
+    pub decimals: u8,
+}
+
+/// One normalized, ordered payout row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferRow {
+    /// One-based logical CSV record number; the header occupies record one.
+    pub row_number: u64,
+    pub recipient: Pubkey,
+    pub amount_raw: u64,
+}
+
+/// The complete, normalized batch that the authorization and journal bind to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferManifest {
+    pub context: ManifestContext,
+    pub rows: Vec<TransferRow>,
+    pub total_amount_raw: u64,
+    /// BLAKE3 digest of the exact normalized plan.
+    pub hash: [u8; 32],
+}
+
+impl TransferManifest {
+    pub fn hash_hex(&self) -> String {
+        self.hash.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+}
+
+/// Parse RFC 4180 CSV input into a strictly validated, canonical manifest.
+///
+/// The input must contain exactly the `recipient` and `amount` headers (in
+/// either order). Amounts are converted into raw mint units, so differences in
+/// harmless CSV representation (such as CRLF) do not affect the manifest.
+pub fn parse_manifest_csv<R: Read>(
+    mut reader: R,
+    context: ManifestContext,
+) -> Result<TransferManifest> {
+    let mut input = Vec::new();
+    reader
+        .by_ref()
+        .take((MAX_CSV_BYTES + 1) as u64)
+        .read_to_end(&mut input)?;
+    if input.len() > MAX_CSV_BYTES {
+        return Err(Error::Config(format!(
+            "CSV exceeds the {} MiB size limit",
+            MAX_CSV_BYTES / (1024 * 1024)
+        )));
+    }
+    reject_empty_records(&input)?;
+    let mut csv = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(false)
+        .from_reader(Cursor::new(input));
+    let mut records = csv.records();
+
+    let header = records
+        .next()
+        .transpose()
+        .map_err(csv_error)?
+        .ok_or_else(|| Error::Config("CSV must contain a header row".to_string()))?;
+    let (recipient_column, amount_column) = parse_header(&header)?;
+
+    let mut rows = Vec::new();
+    let mut recipient_lines = HashMap::new();
+    let mut total_amount_raw = 0u64;
+
+    for record in records {
+        let record = record.map_err(csv_error)?;
+        // A logical record is more useful than a byte/physical-line offset:
+        // RFC 4180 permits quoted fields to contain newlines, and the csv
+        // crate reports CRLF and LF positions differently. The header is
+        // record one, so the first payout is consistently row two.
+        let row_number = (rows.len() + 2) as u64;
+        if rows.len() == MAX_TRANSFER_ROWS {
+            return Err(Error::Config(format!(
+                "CSV exceeds the {MAX_TRANSFER_ROWS}-row limit (line {row_number})"
+            )));
+        }
+        if record.len() != 2 {
+            return Err(Error::Config(format!(
+                "CSV line {row_number} must contain exactly recipient and amount"
+            )));
+        }
+
+        let recipient_input = record.get(recipient_column).unwrap_or_default();
+        let amount_input = record.get(amount_column).unwrap_or_default();
+        require_nonempty_unpadded(recipient_input, row_number, "recipient")?;
+        require_nonempty_unpadded(amount_input, row_number, "amount")?;
+
+        let recipient = Pubkey::from_str(recipient_input).map_err(|error| {
+            Error::Config(format!(
+                "CSV line {row_number} has invalid recipient: {error}"
+            ))
+        })?;
+        if let Some(first_line) = recipient_lines.insert(recipient, row_number) {
+            return Err(Error::Config(format!(
+                "CSV line {row_number} recipient duplicates line {first_line}"
+            )));
+        }
+
+        let amount_raw = parse_token_amount(amount_input, context.decimals).map_err(|error| {
+            Error::Config(format!("CSV line {row_number} has invalid amount: {error}"))
+        })?;
+        if amount_raw == 0 {
+            return Err(Error::Config(format!(
+                "CSV line {row_number} amount must be positive"
+            )));
+        }
+        total_amount_raw = total_amount_raw
+            .checked_add(amount_raw)
+            .ok_or_else(|| Error::Config(format!("CSV total exceeds u64 at line {row_number}")))?;
+        rows.push(TransferRow {
+            row_number,
+            recipient,
+            amount_raw,
+        });
+    }
+
+    if rows.is_empty() {
+        return Err(Error::Config(
+            "CSV must contain at least one payout row".to_string(),
+        ));
+    }
+
+    let hash = canonical_hash(&context, &rows);
+    Ok(TransferManifest {
+        context,
+        rows,
+        total_amount_raw,
+        hash,
+    })
+}
+
+fn parse_header(header: &csv::StringRecord) -> Result<(usize, usize)> {
+    if header.len() != 2 {
+        return Err(Error::Config(
+            "CSV header must contain exactly `recipient,amount`".to_string(),
+        ));
+    }
+
+    let mut recipient_column = None;
+    let mut amount_column = None;
+    for (index, name) in header.iter().enumerate() {
+        let name = if index == 0 {
+            name.strip_prefix('\u{feff}').unwrap_or(name)
+        } else {
+            name
+        };
+        match name {
+            "recipient" if recipient_column.replace(index).is_none() => {}
+            "amount" if amount_column.replace(index).is_none() => {}
+            "recipient" | "amount" => {
+                return Err(Error::Config(format!(
+                    "CSV header has duplicate `{name}` column"
+                )));
+            }
+            _ => {
+                return Err(Error::Config(format!(
+                    "CSV header has unknown `{name}` column"
+                )));
+            }
+        }
+    }
+
+    match (recipient_column, amount_column) {
+        (Some(recipient), Some(amount)) => Ok((recipient, amount)),
+        _ => Err(Error::Config(
+            "CSV header must contain both `recipient` and `amount` columns".to_string(),
+        )),
+    }
+}
+
+fn require_nonempty_unpadded(value: &str, row_number: u64, field: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(Error::Config(format!(
+            "CSV line {row_number} {field} must not be empty"
+        )));
+    }
+    if value.trim() != value {
+        return Err(Error::Config(format!(
+            "CSV line {row_number} {field} must not contain leading or trailing whitespace"
+        )));
+    }
+    Ok(())
+}
+
+/// The csv crate intentionally skips blank records. A payout input must not:
+/// otherwise an accidentally deleted record would be silently accepted. Scan
+/// just enough RFC 4180 quoting state to distinguish a blank line from a
+/// newline contained in a quoted field.
+fn reject_empty_records(input: &[u8]) -> Result<()> {
+    let mut line = 1u64;
+    let mut index = 0;
+    let mut in_quotes = false;
+    let mut record_has_content = false;
+
+    while index < input.len() {
+        let byte = input[index];
+        if in_quotes {
+            if byte == b'"' {
+                if input.get(index + 1) == Some(&b'"') {
+                    index += 2;
+                    continue;
+                }
+                in_quotes = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if byte == b'"' {
+            in_quotes = true;
+            record_has_content = true;
+            index += 1;
+            continue;
+        }
+        if byte == b'\r' || byte == b'\n' {
+            if !record_has_content {
+                return Err(Error::Config(format!(
+                    "CSV has an empty record at line {line}"
+                )));
+            }
+            record_has_content = false;
+            line += 1;
+            index += usize::from(byte == b'\r' && input.get(index + 1) == Some(&b'\n')) + 1;
+            continue;
+        }
+
+        record_has_content = true;
+        index += 1;
+    }
+    Ok(())
+}
+
+fn canonical_hash(context: &ManifestContext, rows: &[TransferRow]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hash_part(&mut hasher, MANIFEST_VERSION);
+    hash_part(&mut hasher, &context.network_genesis_hash);
+    hash_part(&mut hasher, context.mint.as_ref());
+    hash_part(&mut hasher, context.token_program.as_ref());
+    hash_part(&mut hasher, &[context.decimals]);
+    hash_part(&mut hasher, &(rows.len() as u64).to_le_bytes());
+    for row in rows {
+        hash_part(&mut hasher, row.recipient.as_ref());
+        hash_part(&mut hasher, &row.amount_raw.to_le_bytes());
+    }
+    *hasher.finalize().as_bytes()
+}
+
+fn hash_part(hasher: &mut blake3::Hasher, value: &[u8]) {
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+fn csv_error(error: csv::Error) -> Error {
+    Error::Config(format!("Invalid CSV: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context() -> ManifestContext {
+        ManifestContext {
+            network_genesis_hash: [7; 32],
+            mint: Pubkey::new_from_array([8; 32]),
+            token_program: Pubkey::new_from_array([9; 32]),
+            decimals: 6,
+        }
+    }
+
+    fn recipient(seed: u8) -> String {
+        Pubkey::new_from_array([seed; 32]).to_string()
+    }
+
+    fn parse(input: &str) -> Result<TransferManifest> {
+        parse_manifest_csv(input.as_bytes(), context())
+    }
+
+    #[test]
+    fn parses_bom_quoted_csv_and_preserves_order() {
+        let first = recipient(1);
+        let second = recipient(2);
+        let manifest = parse(&format!(
+            "\u{feff}amount,recipient\r\n\"1.25\",\"{first}\"\r\n0.000001,{second}\r\n"
+        ))
+        .unwrap();
+
+        assert_eq!(manifest.rows.len(), 2);
+        assert_eq!(manifest.rows[0].row_number, 2);
+        assert_eq!(manifest.rows[0].recipient.to_string(), first);
+        assert_eq!(manifest.rows[0].amount_raw, 1_250_000);
+        assert_eq!(manifest.rows[1].recipient.to_string(), second);
+        assert_eq!(manifest.rows[1].amount_raw, 1);
+        assert_eq!(manifest.total_amount_raw, 1_250_001);
+    }
+
+    #[test]
+    fn canonical_hash_ignores_crlf_and_csv_quoting() {
+        let first = recipient(1);
+        let second = recipient(2);
+        let unix = parse(&format!("recipient,amount\n{first},1.25\n{second},2\n")).unwrap();
+        let windows = parse(&format!(
+            "amount,recipient\r\n\"1.25\",\"{first}\"\r\n2,{second}\r\n"
+        ))
+        .unwrap();
+        assert_eq!(unix.hash, windows.hash);
+    }
+
+    #[test]
+    fn canonical_hash_changes_when_row_order_changes() {
+        let first = recipient(1);
+        let second = recipient(2);
+        let ordered = parse(&format!("recipient,amount\n{first},1\n{second},2\n")).unwrap();
+        let reversed = parse(&format!("recipient,amount\n{second},2\n{first},1\n")).unwrap();
+        assert_ne!(ordered.hash, reversed.hash);
+    }
+
+    #[test]
+    fn rejects_duplicate_recipients_with_both_lines() {
+        let address = recipient(1);
+        let error = parse(&format!("recipient,amount\n{address},1\n{address},2\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("line 3 recipient duplicates line 2"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_headers_empty_fields_and_non_positive_amounts() {
+        let address = recipient(1);
+        for (input, expected) in [
+            (format!("recipient,other\n{address},1\n"), "unknown `other`"),
+            (
+                format!("recipient,amount\n,1\n"),
+                "line 2 recipient must not be empty",
+            ),
+            (
+                format!("recipient,amount\n{address},0\n"),
+                "line 2 amount must be positive",
+            ),
+            (
+                format!("recipient,amount\n{address},1.0000001\n"),
+                "line 2 has invalid amount",
+            ),
+        ] {
+            let error = parse(&input).unwrap_err().to_string();
+            assert!(
+                error.contains(expected),
+                "expected {expected:?}, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_blank_records_but_allows_newlines_in_quoted_fields() {
+        let first = recipient(1);
+        let second = recipient(2);
+        let blank = parse(&format!("recipient,amount\n{first},1\n\n{second},2\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(blank.contains("empty record at line 3"), "{blank}");
+
+        let quoted_newline = parse(&format!("recipient,amount\n\"{first}\",\"1\n\"\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            quoted_newline.contains("amount must not contain leading or trailing whitespace"),
+            "{quoted_newline}"
+        );
+    }
+}

--- a/rust/crates/core/src/client/push/manifest.rs
+++ b/rust/crates/core/src/client/push/manifest.rs
@@ -362,7 +362,7 @@ mod tests {
         for (input, expected) in [
             (format!("recipient,other\n{address},1\n"), "unknown `other`"),
             (
-                format!("recipient,amount\n,1\n"),
+                "recipient,amount\n,1\n".to_string(),
                 "line 2 recipient must not be empty",
             ),
             (

--- a/rust/crates/core/src/client/push/mod.rs
+++ b/rust/crates/core/src/client/push/mod.rs
@@ -2,5 +2,30 @@
 //!
 //! Parsing and manifest construction happen before a wallet is unlocked. This
 //! module deliberately does not know how a batch is signed or submitted.
+//!
+//! Slice 2 delivers the CSV manifest (`manifest`), read-only preflight and
+//! deterministic packing (`planner`), the one-approval signing permit
+//! (`permit`), and the durable, fsync-before-broadcast journal (`journal`).
+//! Broadcast/confirm execution (`executor`, `direct`, `gasless`) is a later
+//! slice — nothing in this module performs network I/O other than the
+//! explicitly read-only preflight RPC lookups described in the plan.
 
+pub mod journal;
 pub mod manifest;
+pub mod permit;
+pub mod planner;
+
+/// Number of leading hex characters of a manifest's BLAKE3 hash used
+/// everywhere a compact, human-scannable identifier is needed: the
+/// per-chunk on-chain memo (`pay-push:v1:<prefix>:<chunk-index>`) and the
+/// default journal file name
+/// (`~/.config/pay/push/<UTC timestamp>-<prefix>.jsonl`).
+pub const MANIFEST_HASH_PREFIX_LEN: usize = 8;
+
+/// Slice a manifest's full 64-character BLAKE3 hex digest
+/// ([`manifest::TransferManifest::hash_hex`]) down to
+/// [`MANIFEST_HASH_PREFIX_LEN`] characters.
+pub fn manifest_hash_prefix(hash_hex: &str) -> &str {
+    let end = hash_hex.len().min(MANIFEST_HASH_PREFIX_LEN);
+    &hash_hex[..end]
+}

--- a/rust/crates/core/src/client/push/mod.rs
+++ b/rust/crates/core/src/client/push/mod.rs
@@ -1,15 +1,26 @@
-//! Transport-independent primitives for a `pay push` batch payout.
+//! Transport-independent primitives for a `pay push` batch payout, plus the
+//! executor that drives them end to end.
 //!
-//! Parsing and manifest construction happen before a wallet is unlocked. This
-//! module deliberately does not know how a batch is signed or submitted.
+//! Parsing and manifest construction happen before a wallet is unlocked, and
+//! `manifest`/`planner`/`permit`/`journal` deliberately don't know how a
+//! batch is broadcast — that's `executor`'s job:
 //!
-//! Slice 2 delivers the CSV manifest (`manifest`), read-only preflight and
-//! deterministic packing (`planner`), the one-approval signing permit
-//! (`permit`), and the durable, fsync-before-broadcast journal (`journal`).
-//! Broadcast/confirm execution (`executor`, `direct`, `gasless`) is a later
-//! slice — nothing in this module performs network I/O other than the
-//! explicitly read-only preflight RPC lookups described in the plan.
+//! - `manifest`: the canonical CSV manifest, content-hashed into a
+//!   `batchId`.
+//! - `planner`: read-only preflight and deterministic packing of manifest
+//!   rows into chunks.
+//! - `permit`: the one-approval signing permit
+//!   ([`permit::BatchSigningPermit`]) — the only thing that ever touches the
+//!   loaded signer.
+//! - `journal`: the durable, fsync-before-broadcast event log and its resume
+//!   reducer.
+//! - `executor`: the bounded, backpressured pipeline
+//!   ([`executor::PushExecutor`]) that pulls chunks from `planner`, signs
+//!   them via `permit`, journals them, and broadcasts them through a
+//!   pluggable [`executor::ChunkBroadcaster`] (direct-to-RPC for self-funded
+//!   runs, pay-api's `/api/v1/transfer-batches` for gasless ones).
 
+pub mod executor;
 pub mod journal;
 pub mod manifest;
 pub mod permit;

--- a/rust/crates/core/src/client/push/mod.rs
+++ b/rust/crates/core/src/client/push/mod.rs
@@ -1,0 +1,6 @@
+//! Transport-independent primitives for a `pay push` batch payout.
+//!
+//! Parsing and manifest construction happen before a wallet is unlocked. This
+//! module deliberately does not know how a batch is signed or submitted.
+
+pub mod manifest;

--- a/rust/crates/core/src/client/push/permit.rs
+++ b/rust/crates/core/src/client/push/permit.rs
@@ -1,0 +1,1203 @@
+//! The one-approval batch signing permit.
+//!
+//! `pay push` shows one Touch ID / platform-auth prompt per process
+//! invocation ([`AuthIntent::AuthorizeBatch`]), then loads the signer exactly
+//! once into a [`BatchSigningPermit`]. Everything downstream (a later
+//! slice's bounded executor) hands the permit a *prepared* transaction per
+//! chunk and gets back a signature or a rejection — it never touches the raw
+//! signer. `sign_chunk` re-validates every field the plan requires before
+//! producing a signature, so a compromised or buggy caller cannot get the
+//! permit to sign anything outside the exact authorized plan.
+
+use std::collections::HashMap;
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use pay_kit::mpp::solana_keychain::{MemorySigner, SolanaSigner};
+use solana_hash::Hash;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_transaction::Transaction;
+
+use crate::accounts::AccountsStore;
+use crate::client::push::manifest::TransferManifest;
+use crate::client::push::planner::{
+    FeePayerMode, PlannedChunk, TransactionPlan, associated_token_program_id,
+    ata_create_idempotent_discriminator, compute_budget_program_id,
+    compute_unit_limit_discriminator, compute_unit_price_discriminator,
+    derive_associated_token_address, memo_program_id, system_program_id, token_2022_program_id,
+    token_program_id, transfer_checked_discriminator,
+};
+use crate::client::send::format_token_amount;
+use crate::keystore::AuthIntent;
+use crate::signer::{AuthOverride, load_signer_for_network_with_intent_and_override};
+use crate::{Error, Result};
+
+/// A chunk may be re-signed with a fresh blockhash a bounded number of times
+/// (e.g. after a proven blockhash expiry). This bounds retries without
+/// granting an unlimited number of chances to sign new content.
+pub const MAX_RESIGN_ATTEMPTS_PER_CHUNK: u32 = 5;
+
+/// Everything shown on the one authorization prompt, plus what
+/// [`AuthIntent::authorize_batch`] needs to pick a Linux Polkit action
+/// bucket.
+#[derive(Debug, Clone, Copy)]
+pub struct BatchAuthorizationSummary<'a> {
+    pub account: &'a str,
+    pub currency: &'a str,
+    pub currency_decimals: u8,
+    pub network: &'a str,
+    /// The exact recipient total from the plan (sum of every planned
+    /// transfer). Always `<= max_total_raw`.
+    pub recipient_total_raw: u64,
+    /// The worst-case ceiling the permit may sign for, including the
+    /// gasless reimbursement estimate when applicable. Equals
+    /// `recipient_total_raw` for a self-funded plan.
+    pub max_total_raw: u64,
+}
+
+/// Build the `AuthIntent::AuthorizeBatch` prompt for a plan. Stablecoins are
+/// USD-pegged 1:1, so the raw ceiling doubles as its own dollar estimate for
+/// the Linux Polkit payment-limit bucket.
+fn authorization_intent(
+    summary: &BatchAuthorizationSummary<'_>,
+    recipient_count: usize,
+    manifest_hash_prefix: &str,
+) -> AuthIntent {
+    let recipient_total_display =
+        format_token_amount(summary.recipient_total_raw, summary.currency_decimals);
+    let max_total_display = format_token_amount(summary.max_total_raw, summary.currency_decimals);
+    let max_total_usd = format!("${max_total_display}");
+    AuthIntent::authorize_batch(
+        summary.account,
+        recipient_count,
+        &recipient_total_display,
+        &max_total_display,
+        &max_total_usd,
+        summary.currency,
+        summary.network,
+        manifest_hash_prefix,
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SignedChunkRecord {
+    blockhash: Hash,
+    last_valid_block_height: u64,
+    attempts: u32,
+}
+
+/// Proof, supplied by the executor after querying RPC, that a chunk's
+/// previously signed blockhash has expired and it is safe to re-sign the
+/// same logical chunk with a fresh one. Permit-level pure validation
+/// (`resign_chunk`) still refuses the re-sign unless `confirmed_current_block_height`
+/// is strictly past `previous_last_valid_block_height` — this is what makes
+/// "unexpired re-sign" a rejection rather than a trust-the-caller no-op.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockhashExpiryProof {
+    pub previous_blockhash: Hash,
+    pub previous_last_valid_block_height: u64,
+    pub confirmed_current_block_height: u64,
+}
+
+/// The result of successfully signing one chunk.
+#[derive(Debug, Clone)]
+pub struct SignedChunk {
+    pub chunk_index: u32,
+    pub row_numbers: Vec<u64>,
+    /// The permit-held signer's signature. In self-funded mode this is also
+    /// the transaction's final on-chain id; in gasless mode pay-api's
+    /// fee-payer co-signature becomes the final id once broadcast.
+    pub signature: Signature,
+    pub signed_transaction_base64: String,
+    pub blockhash: Hash,
+    pub last_valid_block_height: u64,
+}
+
+/// The live, in-memory, one-approval batch signing authority.
+///
+/// Holds the loaded [`MemorySigner`] — nothing outside this module ever
+/// gets a reference to it. Dies with the process; there is no persistence
+/// and no serialization path for the signer itself.
+pub struct BatchSigningPermit {
+    manifest_hash: [u8; 32],
+    account_pubkey: Pubkey,
+    #[allow(dead_code)]
+    // recorded for parity with the plan's field list; validated by callers that route by network.
+    network_genesis_hash: [u8; 32],
+    mint: Pubkey,
+    token_program: Pubkey,
+    decimals: u8,
+    source_ata: Pubkey,
+    fee_payer_mode: FeePayerMode,
+    fee_payer: Pubkey,
+    chunks: Vec<PlannedChunk>,
+    max_token_raw: u64,
+    max_transactions: usize,
+    expires_at: DateTime<Utc>,
+
+    signer: MemorySigner,
+    runtime: tokio::runtime::Runtime,
+
+    signed_amount_raw: u64,
+    signed_tx_count: usize,
+    signed_chunks: HashMap<u32, SignedChunkRecord>,
+}
+
+impl std::fmt::Debug for BatchSigningPermit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BatchSigningPermit")
+            .field("account_pubkey", &self.account_pubkey)
+            .field("fee_payer_mode", &self.fee_payer_mode)
+            .field("chunks", &self.chunks.len())
+            .field("max_token_raw", &self.max_token_raw)
+            .field("expires_at", &self.expires_at)
+            .field("signed_tx_count", &self.signed_tx_count)
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+impl BatchSigningPermit {
+    /// Show the one `AuthorizeBatch` prompt, load the signer exactly once on
+    /// success, and construct the permit for `plan`. `ttl` bounds how long
+    /// the in-memory permit remains usable after authorization (it always
+    /// also dies with the process).
+    pub fn authorize(
+        network: &str,
+        store: &dyn AccountsStore,
+        account_override: Option<&str>,
+        network_genesis_hash: [u8; 32],
+        manifest: &TransferManifest,
+        plan: TransactionPlan,
+        summary: BatchAuthorizationSummary<'_>,
+        ttl: chrono::Duration,
+        auth_override: AuthOverride,
+    ) -> Result<Self> {
+        let manifest_hash_prefix = super::manifest_hash_prefix(&manifest.hash_hex()).to_string();
+        let recipient_count = manifest.rows.len();
+        let intent = authorization_intent(&summary, recipient_count, &manifest_hash_prefix);
+
+        let (signer, _ephemeral) = load_signer_for_network_with_intent_and_override(
+            network,
+            store,
+            account_override,
+            &intent,
+            auth_override,
+        )?;
+        let account_pubkey = signer.pubkey();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| Error::Config(format!("Failed to create signing runtime: {e}")))?;
+
+        let source_ata = derive_associated_token_address(
+            &account_pubkey,
+            &manifest.context.mint,
+            &manifest.context.token_program,
+        );
+
+        let max_transactions = plan.chunks.len();
+        Ok(Self {
+            manifest_hash: manifest.hash,
+            account_pubkey,
+            network_genesis_hash,
+            mint: manifest.context.mint,
+            token_program: manifest.context.token_program,
+            decimals: manifest.context.decimals,
+            source_ata,
+            fee_payer_mode: plan.fee_payer_mode,
+            fee_payer: plan.fee_payer,
+            chunks: plan.chunks,
+            max_token_raw: summary.max_total_raw,
+            max_transactions,
+            expires_at: Utc::now() + ttl,
+            signer,
+            runtime,
+            signed_amount_raw: 0,
+            signed_tx_count: 0,
+            signed_chunks: HashMap::new(),
+        })
+    }
+
+    pub fn account_pubkey(&self) -> Pubkey {
+        self.account_pubkey
+    }
+
+    pub fn fee_payer(&self) -> Pubkey {
+        self.fee_payer
+    }
+
+    pub fn fee_payer_mode(&self) -> FeePayerMode {
+        self.fee_payer_mode
+    }
+
+    pub fn manifest_hash(&self) -> [u8; 32] {
+        self.manifest_hash
+    }
+
+    pub fn chunk_count(&self) -> usize {
+        self.chunks.len()
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn signed_amount_raw(&self) -> u64 {
+        self.signed_amount_raw
+    }
+
+    pub fn signed_transaction_count(&self) -> usize {
+        self.signed_tx_count
+    }
+
+    fn plan_for(&self, chunk_index: u32) -> Result<&PlannedChunk> {
+        self.chunks
+            .get(chunk_index as usize)
+            .ok_or_else(|| Error::Config(format!("permit has no chunk index {chunk_index}")))
+    }
+
+    fn ensure_not_expired(&self) -> Result<()> {
+        if Utc::now() > self.expires_at {
+            return Err(Error::Config(
+                "batch signing permit has expired; re-run `pay push --resume` to authorize again"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Sign chunk `chunk_index` for the first time. Rejects a chunk that has
+    /// already been signed once — see [`Self::resign_chunk`] for the bounded,
+    /// proof-gated re-sign path.
+    pub fn sign_chunk(
+        &mut self,
+        chunk_index: u32,
+        prepared_transaction: &Transaction,
+        last_valid_block_height: u64,
+    ) -> Result<SignedChunk> {
+        self.ensure_not_expired()?;
+        if self.signed_chunks.contains_key(&chunk_index) {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index} was already signed; use resign_chunk with a blockhash expiry proof"
+            )));
+        }
+
+        let plan = self.plan_for(chunk_index)?.clone();
+        self.validate_prepared_transaction(&plan, prepared_transaction)?;
+
+        let chunk_total = plan.token_total_raw()?;
+        let projected_amount = self
+            .signed_amount_raw
+            .checked_add(chunk_total)
+            .ok_or_else(|| Error::Config("signed amount overflowed u64".to_string()))?;
+        if projected_amount > self.max_token_raw {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index} would sign {chunk_total} raw units, exceeding the authorized \
+                 ceiling of {} (already signed {})",
+                self.max_token_raw, self.signed_amount_raw
+            )));
+        }
+        if self.signed_tx_count + 1 > self.max_transactions {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index} would exceed the authorized transaction count ceiling of {}",
+                self.max_transactions
+            )));
+        }
+
+        // Reserve before producing a signature: the reservation stands even
+        // if a network error happens after this call returns.
+        self.signed_amount_raw = projected_amount;
+        self.signed_tx_count += 1;
+
+        let (signature, blockhash, encoded) = self.sign_transaction_bytes(prepared_transaction)?;
+        self.signed_chunks.insert(
+            chunk_index,
+            SignedChunkRecord {
+                blockhash,
+                last_valid_block_height,
+                attempts: 1,
+            },
+        );
+
+        Ok(SignedChunk {
+            chunk_index,
+            row_numbers: plan.row_numbers(),
+            signature,
+            signed_transaction_base64: encoded,
+            blockhash,
+            last_valid_block_height,
+        })
+    }
+
+    /// Re-sign the same logical chunk with a fresh blockhash after the
+    /// journal/executor has proven the previous blockhash expired.
+    ///
+    /// Consumes a bounded per-chunk attempt counter, not another unit of the
+    /// permit's token/transaction ceiling — this is the *same* recipient
+    /// allowance, just re-signed with a new blockhash.
+    pub fn resign_chunk(
+        &mut self,
+        chunk_index: u32,
+        prepared_transaction: &Transaction,
+        last_valid_block_height: u64,
+        expiry: &BlockhashExpiryProof,
+    ) -> Result<SignedChunk> {
+        self.ensure_not_expired()?;
+        let record = self
+            .signed_chunks
+            .get(&chunk_index)
+            .copied()
+            .ok_or_else(|| {
+                Error::Config(format!(
+                    "chunk {chunk_index} has no prior signature to re-sign; call sign_chunk first"
+                ))
+            })?;
+
+        if expiry.previous_blockhash != record.blockhash
+            || expiry.previous_last_valid_block_height != record.last_valid_block_height
+        {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index}: expiry proof does not match the permit's recorded prior signature"
+            )));
+        }
+        if expiry.confirmed_current_block_height <= expiry.previous_last_valid_block_height {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index}: prior blockhash has not proven expired yet \
+                 (confirmed height {} <= last valid height {})",
+                expiry.confirmed_current_block_height, expiry.previous_last_valid_block_height
+            )));
+        }
+        if record.attempts >= MAX_RESIGN_ATTEMPTS_PER_CHUNK {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index} exceeded the bounded re-sign attempt limit ({MAX_RESIGN_ATTEMPTS_PER_CHUNK})"
+            )));
+        }
+        if prepared_transaction.message.recent_blockhash == record.blockhash {
+            return Err(Error::Config(format!(
+                "chunk {chunk_index}: re-sign must use a fresh blockhash, not the expired one"
+            )));
+        }
+
+        let plan = self.plan_for(chunk_index)?.clone();
+        self.validate_prepared_transaction(&plan, prepared_transaction)?;
+
+        let (signature, blockhash, encoded) = self.sign_transaction_bytes(prepared_transaction)?;
+        let attempts = record.attempts + 1;
+        self.signed_chunks.insert(
+            chunk_index,
+            SignedChunkRecord {
+                blockhash,
+                last_valid_block_height,
+                attempts,
+            },
+        );
+
+        Ok(SignedChunk {
+            chunk_index,
+            row_numbers: plan.row_numbers(),
+            signature,
+            signed_transaction_base64: encoded,
+            blockhash,
+            last_valid_block_height,
+        })
+    }
+
+    fn sign_transaction_bytes(
+        &self,
+        prepared_transaction: &Transaction,
+    ) -> Result<(Signature, Hash, String)> {
+        let mut tx = prepared_transaction.clone();
+        let result = self
+            .runtime
+            .block_on(self.signer.sign_transaction(&mut tx))
+            .map_err(|e| Error::Config(format!("failed to sign prepared transaction: {e}")))?;
+        let (_, signature) = result.into_signed_transaction();
+        let blockhash = tx.message.recent_blockhash;
+        let bytes = bincode::serialize(&tx)
+            .map_err(|e| Error::Config(format!("failed to serialize signed transaction: {e}")))?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        Ok((signature, blockhash, encoded))
+    }
+
+    /// Re-validate every field the plan requires before a signature is ever
+    /// produced. See the module docs and the plan's "One-approval batch
+    /// permit" section for the exact checklist.
+    fn validate_prepared_transaction(&self, plan: &PlannedChunk, tx: &Transaction) -> Result<()> {
+        let message = &tx.message;
+        let chunk_index = plan.chunk_index;
+
+        let actual_fee_payer = *message
+            .account_keys
+            .first()
+            .ok_or_else(|| config_error(chunk_index, "prepared transaction has no accounts"))?;
+        if actual_fee_payer != self.fee_payer {
+            return Err(config_error(
+                chunk_index,
+                &format!(
+                    "fee payer {actual_fee_payer} does not match the authorized fee payer {}",
+                    self.fee_payer
+                ),
+            ));
+        }
+
+        let allowed_programs = [
+            compute_budget_program_id(),
+            associated_token_program_id(),
+            token_program_id(),
+            token_2022_program_id(),
+            memo_program_id(),
+        ];
+        for ix in &message.instructions {
+            let program_id = *message
+                .account_keys
+                .get(ix.program_id_index as usize)
+                .ok_or_else(|| {
+                    config_error(chunk_index, "instruction program id index out of range")
+                })?;
+            if !allowed_programs.contains(&program_id) {
+                return Err(config_error(
+                    chunk_index,
+                    &format!("instruction uses disallowed program {program_id}"),
+                ));
+            }
+        }
+
+        let mut cursor = 0usize;
+
+        let price_ix = instruction_at(message, cursor, chunk_index)?;
+        let price = decode_compute_unit_price(message, price_ix, chunk_index)?;
+        if price > plan.compute_unit_price_micro_lamports {
+            return Err(config_error(
+                chunk_index,
+                &format!(
+                    "compute-unit price {price} exceeds the approved ceiling of {}",
+                    plan.compute_unit_price_micro_lamports
+                ),
+            ));
+        }
+        cursor += 1;
+
+        let limit_ix = instruction_at(message, cursor, chunk_index)?;
+        let limit = decode_compute_unit_limit(message, limit_ix, chunk_index)?;
+        if limit > plan.compute_unit_limit {
+            return Err(config_error(
+                chunk_index,
+                &format!(
+                    "compute-unit limit {limit} exceeds the approved ceiling of {}",
+                    plan.compute_unit_limit
+                ),
+            ));
+        }
+        cursor += 1;
+
+        for entry in &plan.entries {
+            let expected_dest_ata =
+                derive_associated_token_address(&entry.recipient, &self.mint, &self.token_program);
+
+            if entry.ata_creation_required {
+                let ix = instruction_at(message, cursor, chunk_index)?;
+                validate_ata_create(
+                    message,
+                    ix,
+                    &self.fee_payer,
+                    &entry.recipient,
+                    &expected_dest_ata,
+                    &self.mint,
+                    &self.token_program,
+                    chunk_index,
+                )?;
+                cursor += 1;
+            }
+
+            let ix = instruction_at(message, cursor, chunk_index)?;
+            validate_transfer_checked(
+                message,
+                ix,
+                &self.source_ata,
+                &self.mint,
+                &expected_dest_ata,
+                &self.account_pubkey,
+                entry.amount_raw,
+                self.decimals,
+                chunk_index,
+            )?;
+            cursor += 1;
+        }
+
+        let memo_ix = instruction_at(message, cursor, chunk_index)?;
+        validate_memo(message, memo_ix, &plan.memo, chunk_index)?;
+        cursor += 1;
+
+        if cursor != message.instructions.len() {
+            return Err(config_error(
+                chunk_index,
+                &format!(
+                    "prepared transaction has {} unexpected trailing instruction(s)",
+                    message.instructions.len() - cursor
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+fn config_error(chunk_index: u32, detail: &str) -> Error {
+    Error::Config(format!("chunk {chunk_index}: {detail}"))
+}
+
+fn instruction_at(
+    message: &Message,
+    index: usize,
+    chunk_index: u32,
+) -> Result<&solana_message::compiled_instruction::CompiledInstruction> {
+    message.instructions.get(index).ok_or_else(|| {
+        config_error(
+            chunk_index,
+            "prepared transaction is missing an expected instruction",
+        )
+    })
+}
+
+fn account_at(message: &Message, index: u8, chunk_index: u32) -> Result<Pubkey> {
+    message
+        .account_keys
+        .get(index as usize)
+        .copied()
+        .ok_or_else(|| config_error(chunk_index, "instruction account index out of range"))
+}
+
+fn decode_compute_unit_price(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    chunk_index: u32,
+) -> Result<u64> {
+    let program_id = account_at(message, ix.program_id_index, chunk_index)?;
+    if program_id != compute_budget_program_id() {
+        return Err(config_error(
+            chunk_index,
+            "expected a compute-unit-price instruction",
+        ));
+    }
+    if ix.data.first().copied() != Some(compute_unit_price_discriminator()) || ix.data.len() != 9 {
+        return Err(config_error(
+            chunk_index,
+            "malformed compute-unit-price instruction",
+        ));
+    }
+    Ok(u64::from_le_bytes(ix.data[1..9].try_into().unwrap()))
+}
+
+fn decode_compute_unit_limit(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    chunk_index: u32,
+) -> Result<u32> {
+    let program_id = account_at(message, ix.program_id_index, chunk_index)?;
+    if program_id != compute_budget_program_id() {
+        return Err(config_error(
+            chunk_index,
+            "expected a compute-unit-limit instruction",
+        ));
+    }
+    if ix.data.first().copied() != Some(compute_unit_limit_discriminator()) || ix.data.len() != 5 {
+        return Err(config_error(
+            chunk_index,
+            "malformed compute-unit-limit instruction",
+        ));
+    }
+    Ok(u32::from_le_bytes(ix.data[1..5].try_into().unwrap()))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_ata_create(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    fee_payer: &Pubkey,
+    owner: &Pubkey,
+    expected_ata: &Pubkey,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+    chunk_index: u32,
+) -> Result<()> {
+    let program_id = account_at(message, ix.program_id_index, chunk_index)?;
+    if program_id != associated_token_program_id() {
+        return Err(config_error(
+            chunk_index,
+            "expected an ATA-create instruction",
+        ));
+    }
+    if ix.data != vec![ata_create_idempotent_discriminator()] {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create instruction is not the idempotent variant",
+        ));
+    }
+    if ix.accounts.len() != 6 {
+        return Err(config_error(
+            chunk_index,
+            "malformed ATA-create instruction",
+        ));
+    }
+    let payer = account_at(message, ix.accounts[0], chunk_index)?;
+    let ata = account_at(message, ix.accounts[1], chunk_index)?;
+    let owner_account = account_at(message, ix.accounts[2], chunk_index)?;
+    let mint_account = account_at(message, ix.accounts[3], chunk_index)?;
+    let system_program = account_at(message, ix.accounts[4], chunk_index)?;
+    let token_program_account = account_at(message, ix.accounts[5], chunk_index)?;
+
+    if payer != *fee_payer {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create is not paid by the authorized fee payer",
+        ));
+    }
+    if ata != *expected_ata {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create targets an unexpected address",
+        ));
+    }
+    if owner_account != *owner {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create targets an owner outside the planned recipient set",
+        ));
+    }
+    if mint_account != *mint {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create references the wrong mint",
+        ));
+    }
+    if system_program != system_program_id() {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create references the wrong system program",
+        ));
+    }
+    if token_program_account != *token_program {
+        return Err(config_error(
+            chunk_index,
+            "ATA-create references the wrong token program",
+        ));
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_transfer_checked(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    source_ata: &Pubkey,
+    mint: &Pubkey,
+    expected_destination: &Pubkey,
+    authority: &Pubkey,
+    amount_raw: u64,
+    decimals: u8,
+    chunk_index: u32,
+) -> Result<()> {
+    let program_id = account_at(message, ix.program_id_index, chunk_index)?;
+    let is_token = program_id == token_program_id();
+    let is_token_2022 = program_id == token_2022_program_id();
+    if !is_token && !is_token_2022 {
+        return Err(config_error(
+            chunk_index,
+            "expected a Token/Token-2022 transfer instruction",
+        ));
+    }
+    if ix.accounts.len() != 4 {
+        return Err(config_error(
+            chunk_index,
+            "malformed transfer_checked instruction",
+        ));
+    }
+    if ix.data.len() != 10 || ix.data[0] != transfer_checked_discriminator() {
+        return Err(config_error(
+            chunk_index,
+            "expected a transfer_checked instruction",
+        ));
+    }
+    let amount = u64::from_le_bytes(ix.data[1..9].try_into().unwrap());
+    let ix_decimals = ix.data[9];
+
+    let source = account_at(message, ix.accounts[0], chunk_index)?;
+    let mint_account = account_at(message, ix.accounts[1], chunk_index)?;
+    let destination = account_at(message, ix.accounts[2], chunk_index)?;
+    let authority_account = account_at(message, ix.accounts[3], chunk_index)?;
+
+    if source != *source_ata {
+        return Err(config_error(
+            chunk_index,
+            "transfer source ATA does not match the permit",
+        ));
+    }
+    if mint_account != *mint {
+        return Err(config_error(
+            chunk_index,
+            "transfer references the wrong mint",
+        ));
+    }
+    if destination != *expected_destination {
+        return Err(config_error(
+            chunk_index,
+            "transfer destination does not match the planned recipient",
+        ));
+    }
+    if authority_account != *authority {
+        return Err(config_error(
+            chunk_index,
+            "transfer authority does not match the permit's account",
+        ));
+    }
+    if amount != amount_raw {
+        return Err(config_error(
+            chunk_index,
+            &format!("transfer amount {amount} does not match the planned amount {amount_raw}"),
+        ));
+    }
+    if ix_decimals != decimals {
+        return Err(config_error(
+            chunk_index,
+            "transfer decimals do not match the mint",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_memo(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    expected_memo: &str,
+    chunk_index: u32,
+) -> Result<()> {
+    let program_id = account_at(message, ix.program_id_index, chunk_index)?;
+    if program_id != memo_program_id() {
+        return Err(config_error(chunk_index, "expected a memo instruction"));
+    }
+    match std::str::from_utf8(&ix.data) {
+        Ok(memo) if memo == expected_memo => Ok(()),
+        Ok(memo) => Err(config_error(
+            chunk_index,
+            &format!("memo `{memo}` does not match the planned memo `{expected_memo}`"),
+        )),
+        Err(_) => Err(config_error(chunk_index, "memo is not valid UTF-8")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accounts::{Account, AccountsFile, Keystore, MemoryAccountsStore};
+    use crate::client::push::manifest::{ManifestContext, parse_manifest_csv};
+    use crate::client::push::planner::{AtaSnapshot, DestinationAtaStatus, pack_chunks};
+    use solana_message::Message as LegacyMessage;
+
+    fn fresh_account_and_store() -> (MemoryAccountsStore, Pubkey) {
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let verifying_key = signing_key.verifying_key();
+        let mut full = Vec::with_capacity(64);
+        full.extend_from_slice(&signing_key.to_bytes());
+        full.extend_from_slice(&verifying_key.to_bytes());
+
+        let account = Account {
+            keystore: Keystore::Ephemeral,
+            active: false,
+            auth_required: Some(false),
+            pubkey: Some(bs58::encode(verifying_key.to_bytes()).into_string()),
+            vault: None,
+            account: None,
+            path: None,
+            secret_key_b58: Some(bs58::encode(&full).into_string()),
+            created_at: Some("2026-08-12T00:00:00Z".to_string()),
+            subscriptions: std::collections::BTreeMap::new(),
+        };
+
+        let mut file = AccountsFile::default();
+        file.upsert("localnet", "default", account);
+        let store = MemoryAccountsStore::with_file(file);
+        let pubkey = Pubkey::new_from_array(verifying_key.to_bytes());
+        (store, pubkey)
+    }
+
+    fn manifest_and_plan(
+        sender: &Pubkey,
+        rows: usize,
+        fee_payer_mode: FeePayerMode,
+        fee_payer: &Pubkey,
+    ) -> (TransferManifest, TransactionPlan) {
+        let mut csv = String::from("recipient,amount\n");
+        for i in 0..rows {
+            let recipient = Pubkey::new_from_array([(i + 10) as u8; 32]);
+            csv.push_str(&format!("{recipient},1\n"));
+        }
+        let context = ManifestContext {
+            network_genesis_hash: [3; 32],
+            mint: Pubkey::new_from_array([77; 32]),
+            token_program: token_program_id(),
+            decimals: 6,
+        };
+        let manifest = parse_manifest_csv(csv.as_bytes(), context).unwrap();
+        let ata = AtaSnapshot {
+            sender_ata: derive_associated_token_address(
+                sender,
+                &manifest.context.mint,
+                &manifest.context.token_program,
+            ),
+            sender_ata_exists: true,
+            destinations: manifest
+                .rows
+                .iter()
+                .map(|row| DestinationAtaStatus {
+                    recipient: row.recipient,
+                    ata: derive_associated_token_address(
+                        &row.recipient,
+                        &manifest.context.mint,
+                        &manifest.context.token_program,
+                    ),
+                    exists: false,
+                })
+                .collect(),
+        };
+        let plan = pack_chunks(&manifest, &ata, fee_payer_mode, sender, fee_payer, 1).unwrap();
+        (manifest, plan)
+    }
+
+    fn build_permit(
+        rows: usize,
+        fee_payer_mode: FeePayerMode,
+    ) -> (BatchSigningPermit, TransferManifest, Pubkey) {
+        let (store, sender) = fresh_account_and_store();
+        let fee_payer = if matches!(fee_payer_mode, FeePayerMode::Gasless) {
+            Pubkey::new_unique()
+        } else {
+            sender
+        };
+        let (manifest, plan) = manifest_and_plan(&sender, rows, fee_payer_mode, &fee_payer);
+        let max_total_raw = plan.total_token_raw().unwrap();
+        let summary = BatchAuthorizationSummary {
+            account: "default",
+            currency: "USDG",
+            currency_decimals: 6,
+            network: "localnet",
+            recipient_total_raw: max_total_raw,
+            max_total_raw,
+        };
+        let permit = BatchSigningPermit::authorize(
+            "localnet",
+            &store,
+            Some("default"),
+            manifest.context.network_genesis_hash,
+            &manifest,
+            plan,
+            summary,
+            chrono::Duration::hours(1),
+            None,
+        )
+        .unwrap();
+        (permit, manifest, sender)
+    }
+
+    fn build_unsigned_transaction(plan: &PlannedChunk, permit: &BatchSigningPermit) -> Transaction {
+        build_unsigned_transaction_with(plan, permit, permit.fee_payer, permit.account_pubkey)
+    }
+
+    fn build_unsigned_transaction_with(
+        plan: &PlannedChunk,
+        permit: &BatchSigningPermit,
+        fee_payer: Pubkey,
+        authority: Pubkey,
+    ) -> Transaction {
+        use crate::client::push::planner::{
+            compute_unit_limit_instruction, compute_unit_price_instruction,
+        };
+        use pay_kit::mpp::client::{TransferEntry, build_spl_transfer_batch_instructions};
+
+        let last = plan.entries.len() - 1;
+        let entries: Vec<TransferEntry> = plan
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| TransferEntry {
+                recipient: e.recipient,
+                amount: e.amount_raw,
+                ata_creation_required: e.ata_creation_required,
+                memo: if i == last {
+                    Some(plan.memo.clone())
+                } else {
+                    None
+                },
+            })
+            .collect();
+
+        let mut instructions = vec![
+            compute_unit_price_instruction(plan.compute_unit_price_micro_lamports),
+            compute_unit_limit_instruction(plan.compute_unit_limit),
+        ];
+        instructions.extend(
+            build_spl_transfer_batch_instructions(
+                &authority,
+                &permit.mint,
+                &permit.token_program,
+                permit.decimals,
+                &fee_payer,
+                &entries,
+            )
+            .unwrap(),
+        );
+
+        let message =
+            LegacyMessage::new_with_blockhash(&instructions, Some(&fee_payer), &Hash::new_unique());
+        Transaction::new_unsigned(message)
+    }
+
+    #[test]
+    fn sign_chunk_accepts_a_faithful_prepared_transaction() {
+        let (mut permit, _manifest, _sender) = build_permit(3, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction(&plan, &permit);
+
+        let signed = permit.sign_chunk(0, &tx, 1_000).unwrap();
+        assert_eq!(signed.chunk_index, 0);
+        assert_eq!(signed.row_numbers, plan.row_numbers());
+        assert_eq!(permit.signed_transaction_count(), 1);
+        assert_eq!(permit.signed_amount_raw(), plan.token_total_raw().unwrap());
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_recipient() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let mut plan = permit.chunks[0].clone();
+        plan.entries[0].recipient = Pubkey::new_unique();
+        let tx = build_unsigned_transaction(&plan, &permit);
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        // The row's ATA-create instruction (built for the wrong owner) is
+        // validated before its transfer_checked instruction, so this is
+        // rejected as an unexpected ATA-create target rather than a
+        // mismatched transfer destination — both are the same underlying
+        // "recipient does not match the plan" defect.
+        let message = err.to_string();
+        assert!(
+            message.contains("destination") || message.contains("unexpected address"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_amount() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let mut plan = permit.chunks[0].clone();
+        plan.entries[0].amount_raw += 1;
+        let tx = build_unsigned_transaction(&plan, &permit);
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("amount"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_mint() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let mut tx = build_unsigned_transaction(&plan, &permit);
+        // Corrupt the mint account referenced by the first transfer_checked
+        // instruction (index 3 in the compiled instruction list: price,
+        // limit, transfer#0's mint account key).
+        let bad_mint = Pubkey::new_unique();
+        let idx = tx
+            .message
+            .account_keys
+            .iter()
+            .position(|k| *k == permit.mint)
+            .unwrap();
+        tx.message.account_keys[idx] = bad_mint;
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("mint"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_source_ata() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let mut tx = build_unsigned_transaction(&plan, &permit);
+        let idx = tx
+            .message
+            .account_keys
+            .iter()
+            .position(|k| *k == permit.source_ata)
+            .unwrap();
+        tx.message.account_keys[idx] = Pubkey::new_unique();
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("source ATA"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_fee_payer() {
+        let (mut permit, _manifest, sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let other_fee_payer = Pubkey::new_unique();
+        let tx = build_unsigned_transaction_with(&plan, &permit, other_fee_payer, sender);
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("fee payer"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_wrong_memo() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let mut plan = permit.chunks[0].clone();
+        plan.memo = "pay-push:v1:deadbeef:0".to_string();
+        let tx = build_unsigned_transaction(&plan, &permit);
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("memo"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_disallowed_program() {
+        let (mut permit, _manifest, _sender) = build_permit(1, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let mut tx = build_unsigned_transaction(&plan, &permit);
+        // Swap the memo program for an arbitrary, disallowed program id.
+        let disallowed = Pubkey::new_unique();
+        let idx = tx
+            .message
+            .account_keys
+            .iter()
+            .position(|k| *k == memo_program_id())
+            .unwrap();
+        tx.message.account_keys[idx] = disallowed;
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("disallowed program"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_compute_budget_over_ceiling() {
+        let (permit, _manifest, _sender) = build_permit(1, FeePayerMode::SelfFunded);
+        let mut plan = permit.chunks[0].clone();
+        // Build the transaction with the plan's real (authorized) price,
+        // then lower the plan's own ceiling so that same price now exceeds
+        // what `validate_prepared_transaction` will accept.
+        let tx = build_unsigned_transaction(&plan, &permit);
+        plan.compute_unit_price_micro_lamports = 0;
+
+        let err = permit
+            .validate_prepared_transaction(&plan, &tx)
+            .unwrap_err();
+        assert!(err.to_string().contains("compute-unit price"), "{err}");
+    }
+
+    #[test]
+    fn sign_chunk_rejects_over_budget_amount() {
+        let (mut permit, _manifest, sender) = build_permit(2, FeePayerMode::SelfFunded);
+        permit.max_token_raw = 1; // lower than any real chunk total
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction_with(&plan, &permit, permit.fee_payer, sender);
+
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(
+            err.to_string().contains("exceeding the authorized ceiling"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn sign_chunk_twice_is_rejected_without_resign_proof() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction(&plan, &permit);
+        permit.sign_chunk(0, &tx, 1_000).unwrap();
+
+        let tx2 = build_unsigned_transaction(&plan, &permit);
+        let err = permit.sign_chunk(0, &tx2, 1_000).unwrap_err();
+        assert!(err.to_string().contains("already signed"), "{err}");
+    }
+
+    #[test]
+    fn resign_chunk_rejects_unexpired_blockhash() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction(&plan, &permit);
+        let signed = permit.sign_chunk(0, &tx, 1_000).unwrap();
+
+        let tx2 = build_unsigned_transaction(&plan, &permit); // fresh random blockhash
+        let proof = BlockhashExpiryProof {
+            previous_blockhash: signed.blockhash,
+            previous_last_valid_block_height: signed.last_valid_block_height,
+            confirmed_current_block_height: 500, // still before last_valid_block_height (1000)
+        };
+        let err = permit.resign_chunk(0, &tx2, 1_500, &proof).unwrap_err();
+        assert!(err.to_string().contains("has not proven expired"), "{err}");
+    }
+
+    #[test]
+    fn resign_chunk_succeeds_after_proven_expiry_without_double_counting() {
+        let (mut permit, _manifest, _sender) = build_permit(2, FeePayerMode::SelfFunded);
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction(&plan, &permit);
+        let signed = permit.sign_chunk(0, &tx, 1_000).unwrap();
+        let amount_after_first_sign = permit.signed_amount_raw();
+        let count_after_first_sign = permit.signed_transaction_count();
+
+        let tx2 = build_unsigned_transaction(&plan, &permit);
+        let proof = BlockhashExpiryProof {
+            previous_blockhash: signed.blockhash,
+            previous_last_valid_block_height: signed.last_valid_block_height,
+            confirmed_current_block_height: 2_000,
+        };
+        permit.resign_chunk(0, &tx2, 2_500, &proof).unwrap();
+
+        assert_eq!(permit.signed_amount_raw(), amount_after_first_sign);
+        assert_eq!(permit.signed_transaction_count(), count_after_first_sign);
+    }
+
+    #[test]
+    fn permit_expiry_rejects_further_signing() {
+        let (store, sender) = fresh_account_and_store();
+        let (manifest, plan) = manifest_and_plan(&sender, 1, FeePayerMode::SelfFunded, &sender);
+        let max_total_raw = plan.total_token_raw().unwrap();
+        let summary = BatchAuthorizationSummary {
+            account: "default",
+            currency: "USDG",
+            currency_decimals: 6,
+            network: "localnet",
+            recipient_total_raw: max_total_raw,
+            max_total_raw,
+        };
+        let mut permit = BatchSigningPermit::authorize(
+            "localnet",
+            &store,
+            Some("default"),
+            manifest.context.network_genesis_hash,
+            &manifest,
+            plan,
+            summary,
+            chrono::Duration::seconds(-1), // already expired
+            None,
+        )
+        .unwrap();
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction(&plan, &permit);
+        let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
+        assert!(err.to_string().contains("expired"), "{err}");
+    }
+
+    #[test]
+    fn gasless_permit_signs_as_authority_leaving_fee_payer_slot_unsigned() {
+        let (mut permit, _manifest, sender) = build_permit(2, FeePayerMode::Gasless);
+        let plan = permit.chunks[0].clone();
+        let tx = build_unsigned_transaction_with(&plan, &permit, permit.fee_payer, sender);
+        let signed = permit.sign_chunk(0, &tx, 1_000).unwrap();
+        assert_ne!(permit.fee_payer, sender);
+        assert_eq!(signed.chunk_index, 0);
+    }
+}

--- a/rust/crates/core/src/client/push/permit.rs
+++ b/rust/crates/core/src/client/push/permit.rs
@@ -2,12 +2,12 @@
 //!
 //! `pay push` shows one Touch ID / platform-auth prompt per process
 //! invocation ([`AuthIntent::AuthorizeBatch`]), then loads the signer exactly
-//! once into a [`BatchSigningPermit`]. Everything downstream (a later
-//! slice's bounded executor) hands the permit a *prepared* transaction per
-//! chunk and gets back a signature or a rejection — it never touches the raw
-//! signer. `sign_chunk` re-validates every field the plan requires before
-//! producing a signature, so a compromised or buggy caller cannot get the
-//! permit to sign anything outside the exact authorized plan.
+//! once into a [`BatchSigningPermit`]. Everything downstream
+//! ([`super::executor::PushExecutor`]) hands the permit a *prepared*
+//! transaction per chunk and gets back a signature or a rejection — it never
+//! touches the raw signer. `sign_chunk` re-validates every field the plan
+//! requires before producing a signature, so a compromised or buggy caller
+//! cannot get the permit to sign anything outside the exact authorized plan.
 
 use std::collections::HashMap;
 

--- a/rust/crates/core/src/client/push/permit.rs
+++ b/rust/crates/core/src/client/push/permit.rs
@@ -81,6 +81,57 @@ fn authorization_intent(
     )
 }
 
+/// Prove that every row `plan` intends to sign is exactly the row the
+/// authorization prompt showed the user — same recipient, same amount, no
+/// row added or dropped — before the permit accepts the plan at all.
+///
+/// `plan` and `manifest` are supplied separately by the caller, so nothing
+/// upstream of this call structurally guarantees they describe the same
+/// batch. Without this check a caller could show `manifest`'s recipients on
+/// the approval prompt and then hand the permit a `plan` built from a
+/// different recipient set; every downstream signature would be produced
+/// against the unreviewed plan.
+fn validate_plan_matches_manifest(
+    manifest: &TransferManifest,
+    plan: &TransactionPlan,
+) -> Result<()> {
+    let mut expected: HashMap<u64, (Pubkey, u64)> = manifest
+        .rows
+        .iter()
+        .map(|row| (row.row_number, (row.recipient, row.amount_raw)))
+        .collect();
+
+    for chunk in &plan.chunks {
+        for entry in &chunk.entries {
+            match expected.remove(&entry.row_number) {
+                Some((recipient, amount_raw))
+                    if recipient == entry.recipient && amount_raw == entry.amount_raw => {}
+                Some(_) => {
+                    return Err(Error::Config(format!(
+                        "plan row {} does not match the authorized manifest's recipient/amount",
+                        entry.row_number
+                    )));
+                }
+                None => {
+                    return Err(Error::Config(format!(
+                        "plan row {} is not present in the authorized manifest",
+                        entry.row_number
+                    )));
+                }
+            }
+        }
+    }
+
+    if !expected.is_empty() {
+        return Err(Error::Config(format!(
+            "plan is missing {} manifest row(s) that were shown for approval",
+            expected.len()
+        )));
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy)]
 struct SignedChunkRecord {
     blockhash: Hash,
@@ -175,6 +226,8 @@ impl BatchSigningPermit {
         ttl: chrono::Duration,
         auth_override: AuthOverride,
     ) -> Result<Self> {
+        validate_plan_matches_manifest(manifest, &plan)?;
+
         let manifest_hash_prefix = super::manifest_hash_prefix(&manifest.hash_hex()).to_string();
         let recipient_count = manifest.rows.len();
         let intent = authorization_intent(&summary, recipient_count, &manifest_hash_prefix);
@@ -1189,6 +1242,49 @@ mod tests {
         let tx = build_unsigned_transaction(&plan, &permit);
         let err = permit.sign_chunk(0, &tx, 1_000).unwrap_err();
         assert!(err.to_string().contains("expired"), "{err}");
+    }
+
+    #[test]
+    fn authorize_rejects_a_plan_whose_recipient_does_not_match_the_approved_manifest() {
+        // The exact authorization-binding gap Greptile flagged: the prompt
+        // is built from `manifest`, but a caller could hand `authorize` an
+        // unrelated `plan` — here, one signing a different recipient than
+        // the one the manifest (and therefore the approval prompt) showed.
+        let (store, sender) = fresh_account_and_store();
+        let (manifest, approved_plan) =
+            manifest_and_plan(&sender, 1, FeePayerMode::SelfFunded, &sender);
+        let mut mismatched_plan = approved_plan;
+        let approved_recipient = manifest.rows[0].recipient;
+        let swapped_recipient = Pubkey::new_unique();
+        assert_ne!(approved_recipient, swapped_recipient);
+        mismatched_plan.chunks[0].entries[0].recipient = swapped_recipient;
+
+        let max_total_raw = mismatched_plan.total_token_raw().unwrap();
+        let summary = BatchAuthorizationSummary {
+            account: "default",
+            currency: "USDG",
+            currency_decimals: 6,
+            network: "localnet",
+            recipient_total_raw: max_total_raw,
+            max_total_raw,
+        };
+        let err = BatchSigningPermit::authorize(
+            "localnet",
+            &store,
+            Some("default"),
+            manifest.context.network_genesis_hash,
+            &manifest,
+            mismatched_plan,
+            summary,
+            chrono::Duration::hours(1),
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("does not match the authorized manifest's recipient/amount"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/rust/crates/core/src/client/push/planner.rs
+++ b/rust/crates/core/src/client/push/planner.rs
@@ -1,0 +1,957 @@
+//! Read-only preflight, fee-mode selection, and deterministic transaction
+//! packing for `pay push`.
+//!
+//! Everything in this module runs before a wallet is ever unlocked: ATA
+//! lookups, blockhash/fee estimation, balance checks, and the exact
+//! instruction lists for every planned chunk. [`permit::BatchSigningPermit`]
+//! (built from a [`TransactionPlan`] after authorization) is the only thing
+//! downstream that is allowed to touch a signer.
+
+use solana_hash::Hash;
+use solana_instruction::Instruction;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
+use std::str::FromStr;
+
+use pay_kit::mpp::client::{
+    ComputeBudgetOptions, TransferEntry, build_spl_transfer_batch_instructions,
+};
+use pay_kit::mpp::protocol::solana::{
+    MAX_SPLITS, SOLANA_MAX_COMPUTE_UNIT_LIMIT, check_transaction_packet_size, programs,
+};
+
+use super::manifest::TransferManifest;
+use crate::{Error, Result};
+
+// ── Numeric bounds ──────────────────────────────────────────────────────────
+
+/// A gasless chunk's user payouts ride as MPP charge splits, and PayKit caps
+/// a charge at `MAX_SPLITS` splits (the fee-payer reimbursement is the
+/// primary transfer, so every user payout is a split). Re-exported from
+/// PayKit rather than duplicated: it is already `pub const` there
+/// (`pay_kit::mpp::protocol::solana::MAX_SPLITS`), so hardcoding a second
+/// copy would be exactly the drift risk the plan warns against.
+pub const MAX_GASLESS_TRANSFERS_PER_CHUNK: usize = MAX_SPLITS;
+
+/// Floor on the SOL reserve preflight sets aside on top of the exact
+/// estimated fee and missing-ATA rent (plan: `max(10_000 lamports, 5% of the
+/// estimated transaction fees)`).
+pub const MIN_FEE_RESERVE_LAMPORTS: u64 = 10_000;
+
+/// Conservative secondary safety margin on top of `check_transaction_packet_size`.
+/// A legacy message can technically reference more account keys than this
+/// before hitting the packet-size ceiling in unusual cases (many
+/// already-existing ATAs, e.g.), but pay-push chunks are homogeneous
+/// (compute budget + ATA-create + transfer_checked + memo), so in practice
+/// packet size binds first. This exists as defense in depth, not as the
+/// primary bound.
+pub const MAX_STATIC_ACCOUNT_KEYS: usize = 64;
+
+/// `spl_token::state::Account::LEN`. Duplicated as a plain constant rather
+/// than adding an `spl-token` dependency for one number — this is a stable
+/// on-chain account layout, not implementation detail.
+pub const TOKEN_ACCOUNT_LEN: usize = 165;
+
+/// Token-2022 base account length. The Associated Token Account program
+/// attaches an `ImmutableOwner` extension (2-byte type + 2-byte length + 0
+/// bytes of body) plus a 1-byte account-type discriminator to every ATA it
+/// creates, on top of the same 165-byte base layout Token uses.
+///
+/// This does not account for mint-specific extensions that also enlarge the
+/// *token account* (e.g. `TransferFeeAmount` for a `TransferFeeConfig`
+/// mint). V1 does not parse per-mint extensions; the fee/rent reserve buffer
+/// (see [`compute_reserve_lamports`]) is expected to absorb the difference
+/// for the currently supported stablecoin set. Decision #8 already excludes
+/// confidential mints from V1.
+pub const TOKEN_2022_BASE_ATA_LEN: usize = TOKEN_ACCOUNT_LEN + 1 + 4;
+
+/// Conservative compute-unit ceiling enforced while *packing* (before the
+/// real simulate-and-refine pass the plan describes happens against a live
+/// RPC). Chosen well under [`SOLANA_MAX_COMPUTE_UNIT_LIMIT`] so the
+/// after-simulation refinement always has headroom to raise the limit
+/// without ever needing to shrink a chunk post hoc.
+pub const PACKING_COMPUTE_UNIT_CEILING: u32 = 1_200_000;
+
+// Conservative fixed per-instruction compute-unit estimates used only to
+// decide whether a candidate chunk is *plausibly* cheap enough while
+// packing. These are deliberately generous placeholders: the plan's real
+// bound comes from simulating the finalized chunk and re-deriving its exact
+// `SetComputeUnitLimit` (see [`refine_compute_unit_limit`]), which every
+// signed transaction must go through before authorization.
+const COMPUTE_BUDGET_OVERHEAD_UNITS: u64 = 500;
+const MEMO_OVERHEAD_UNITS: u64 = 500;
+const TRANSFER_CHECKED_UNITS: u64 = 10_000;
+const ATA_CREATE_UNITS: u64 = 25_000;
+
+/// `spl_associated_token_account::instruction::AssociatedTokenAccountInstruction::CreateIdempotent`
+/// discriminator, and the SetComputeUnit{Price,Limit} discriminators from
+/// the Compute Budget program. Matches PayKit's own private constants of
+/// the same name (`mpp::client::charge`) byte-for-byte; duplicated here
+/// because the permit must decode instructions built by this planner
+/// without depending on PayKit's private builder internals.
+const ATA_CREATE_IDEMPOTENT_DISCRIMINATOR: u8 = 1;
+const COMPUTE_UNIT_LIMIT_DISCRIMINATOR: u8 = 2;
+const COMPUTE_UNIT_PRICE_DISCRIMINATOR: u8 = 3;
+/// `spl_token::instruction::TokenInstruction::TransferChecked` discriminator.
+const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
+
+// ── Fee mode ─────────────────────────────────────────────────────────────
+
+/// Who ends up paying transaction fees and missing-ATA rent for a batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeePayerMode {
+    /// The sender's own SOL balance pays fees and rent.
+    SelfFunded,
+    /// pay-api's fee payer pays fees and rent, reimbursed in stablecoin.
+    Gasless,
+}
+
+/// The user's requested fee mode (`pay push --self-funded` / `--gasless` /
+/// default `auto`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FeeModeRequest {
+    #[default]
+    Auto,
+    SelfFunded,
+    Gasless,
+}
+
+/// The exact SOL cost self-funded mode would incur, as measured by
+/// preflight (`getFeeForMessage` plus rent for missing ATAs plus the
+/// explicit reserve).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SelfFundedCost {
+    pub estimated_fee_lamports: u64,
+    pub missing_ata_rent_lamports: u64,
+    pub reserve_lamports: u64,
+}
+
+impl SelfFundedCost {
+    /// `fee + rent + reserve`, checked against `u64` overflow (preflight
+    /// numbers are real cluster quantities and will never be anywhere near
+    /// this large, but a corrupt RPC response should error, not wrap).
+    pub fn total_lamports(&self) -> Result<u64> {
+        self.estimated_fee_lamports
+            .checked_add(self.missing_ata_rent_lamports)
+            .and_then(|sum| sum.checked_add(self.reserve_lamports))
+            .ok_or_else(|| Error::Config("self-funded cost overflowed u64 lamports".to_string()))
+    }
+}
+
+/// `max(MIN_FEE_RESERVE_LAMPORTS, 5% of estimated_fee_lamports)`.
+pub fn compute_reserve_lamports(estimated_fee_lamports: u64) -> u64 {
+    let five_percent = ((estimated_fee_lamports as u128 * 5) / 100) as u64;
+    five_percent.max(MIN_FEE_RESERVE_LAMPORTS)
+}
+
+/// Choose (or reject) a fee-payer mode from the measured preflight cost.
+///
+/// - `SelfFunded` request: fails fast when SOL is short — a forced
+///   self-funded run never falls back to gasless.
+/// - `Gasless` request: fails fast when pay-api is unavailable — a forced
+///   gasless run never treats spare SOL as permission to spend it.
+/// - `Auto`: self-funded when SOL exactly covers `total_lamports()`,
+///   otherwise gasless (if available), otherwise an actionable shortfall
+///   error naming both the SOL gap and the pay-api unavailability.
+pub fn decide_fee_mode(
+    requested: FeeModeRequest,
+    sol_lamports: u64,
+    cost: &SelfFundedCost,
+    gasless_available: bool,
+) -> Result<FeePayerMode> {
+    let total = cost.total_lamports()?;
+    let self_funded_covered = sol_lamports >= total;
+
+    match requested {
+        FeeModeRequest::SelfFunded => {
+            if self_funded_covered {
+                Ok(FeePayerMode::SelfFunded)
+            } else {
+                Err(Error::Config(format!(
+                    "self-funded mode requires {total} lamports (fee {} + rent {} + reserve {}) \
+                     but the sender only has {sol_lamports} lamports of SOL",
+                    cost.estimated_fee_lamports,
+                    cost.missing_ata_rent_lamports,
+                    cost.reserve_lamports
+                )))
+            }
+        }
+        FeeModeRequest::Gasless => {
+            if gasless_available {
+                Ok(FeePayerMode::Gasless)
+            } else {
+                Err(Error::Config(
+                    "gasless mode requires pay-api, which is unavailable".to_string(),
+                ))
+            }
+        }
+        FeeModeRequest::Auto => {
+            if self_funded_covered {
+                Ok(FeePayerMode::SelfFunded)
+            } else if gasless_available {
+                Ok(FeePayerMode::Gasless)
+            } else {
+                Err(Error::Config(format!(
+                    "auto fee mode could not proceed: self-funded needs {total} lamports but the \
+                     sender only has {sol_lamports}, and pay-api (gasless fallback) is unavailable"
+                )))
+            }
+        }
+    }
+}
+
+// ── Rent ─────────────────────────────────────────────────────────────────
+
+/// `spl_token`/`spl_token_2022` account length for a mint's ATAs. See
+/// [`TOKEN_2022_BASE_ATA_LEN`] for the Token-2022 approximation caveat.
+pub fn token_account_len(token_program: &Pubkey) -> usize {
+    if *token_program == token_2022_program_id() {
+        TOKEN_2022_BASE_ATA_LEN
+    } else {
+        TOKEN_ACCOUNT_LEN
+    }
+}
+
+/// Solana's rent-exemption formula (`solana_rent::Rent::default().minimum_balance`),
+/// duplicated as a plain function rather than pulling in a `solana-rent`
+/// dependency for one calculation. `ACCOUNT_STORAGE_OVERHEAD` (128),
+/// `DEFAULT_LAMPORTS_PER_BYTE_YEAR` (3480), and `DEFAULT_EXEMPTION_THRESHOLD`
+/// (2.0) are stable cluster-wide protocol defaults, not implementation
+/// detail that could silently drift underneath this crate.
+pub fn rent_exempt_minimum_lamports(data_len: usize) -> u64 {
+    const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;
+    const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 100 * 365 / (1024 * 1024);
+    const DEFAULT_EXEMPTION_THRESHOLD: f64 = 2.0;
+
+    (((ACCOUNT_STORAGE_OVERHEAD + data_len as u64) * DEFAULT_LAMPORTS_PER_BYTE_YEAR) as f64
+        * DEFAULT_EXEMPTION_THRESHOLD) as u64
+}
+
+// ── ATA snapshot ─────────────────────────────────────────────────────────
+
+/// Whether one destination's ATA already exists, as observed by preflight's
+/// bounded `getMultipleAccounts` calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DestinationAtaStatus {
+    pub recipient: Pubkey,
+    pub ata: Pubkey,
+    pub exists: bool,
+}
+
+/// The exact set of ATA facts the plan's preflight step needs, aligned
+/// 1:1 by index with [`TransferManifest::rows`].
+#[derive(Debug, Clone)]
+pub struct AtaSnapshot {
+    pub sender_ata: Pubkey,
+    pub sender_ata_exists: bool,
+    pub destinations: Vec<DestinationAtaStatus>,
+}
+
+impl AtaSnapshot {
+    pub fn missing_count(&self) -> usize {
+        self.destinations.iter().filter(|d| !d.exists).count()
+    }
+}
+
+// ── Packing ──────────────────────────────────────────────────────────────
+
+/// One planned SPL transfer inside a chunk. Carries `row_number` (rather
+/// than a bare index) so a permit-rejection or journal entry can always cite
+/// the exact CSV line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedTransferEntry {
+    pub row_number: u64,
+    pub recipient: Pubkey,
+    pub amount_raw: u64,
+    pub ata_creation_required: bool,
+}
+
+/// One exact, sized, packet-checked transaction shape. Everything a
+/// `BatchSigningPermit` needs to validate a re-presented transaction against
+/// what was authorized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedChunk {
+    pub chunk_index: u32,
+    pub entries: Vec<PlannedTransferEntry>,
+    pub compute_unit_price_micro_lamports: u64,
+    pub compute_unit_limit: u32,
+    pub memo: String,
+    /// Serialized length of the unsigned transaction at planning time
+    /// (placeholder blockhash). Recorded for observability; the packet-size
+    /// bound has already been enforced by the time this struct exists.
+    pub serialized_len: usize,
+}
+
+impl PlannedChunk {
+    pub fn row_numbers(&self) -> Vec<u64> {
+        self.entries.iter().map(|e| e.row_number).collect()
+    }
+
+    /// Checked sum of this chunk's transfer amounts.
+    pub fn token_total_raw(&self) -> Result<u64> {
+        self.entries
+            .iter()
+            .try_fold(0u64, |acc, e| acc.checked_add(e.amount_raw))
+            .ok_or_else(|| Error::Config("chunk token total overflowed u64".to_string()))
+    }
+}
+
+/// The complete, ordered, deterministic transaction plan for a manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionPlan {
+    pub fee_payer_mode: FeePayerMode,
+    pub fee_payer: Pubkey,
+    pub chunks: Vec<PlannedChunk>,
+}
+
+impl TransactionPlan {
+    pub fn total_transactions(&self) -> usize {
+        self.chunks.len()
+    }
+
+    pub fn total_token_raw(&self) -> Result<u64> {
+        self.chunks.iter().try_fold(0u64, |acc, chunk| {
+            let total = chunk.token_total_raw()?;
+            acc.checked_add(total)
+                .ok_or_else(|| Error::Config("plan token total overflowed u64".to_string()))
+        })
+    }
+}
+
+/// Pack every manifest row into the fewest ordered, packet-size-respecting
+/// chunks, per the plan's "Transaction-packing algorithm" section.
+///
+/// `sender` is the token authority (and, in self-funded mode, also the fee
+/// payer). `fee_payer` is the account paying transaction fees and
+/// missing-ATA rent for every chunk: the sender itself in self-funded mode,
+/// or pay-api's advertised fee payer in gasless mode.
+pub fn pack_chunks(
+    manifest: &TransferManifest,
+    ata: &AtaSnapshot,
+    fee_payer_mode: FeePayerMode,
+    sender: &Pubkey,
+    fee_payer: &Pubkey,
+    compute_unit_price_micro_lamports: u64,
+) -> Result<TransactionPlan> {
+    if manifest.rows.len() != ata.destinations.len() {
+        return Err(Error::Config(
+            "ATA snapshot row count does not match the manifest".to_string(),
+        ));
+    }
+    for (row, dest) in manifest.rows.iter().zip(ata.destinations.iter()) {
+        if row.recipient != dest.recipient {
+            return Err(Error::Config(format!(
+                "ATA snapshot row {} recipient mismatch",
+                row.row_number
+            )));
+        }
+    }
+
+    let prefix = super::manifest_hash_prefix(&manifest.hash_hex()).to_string();
+    let mut chunks: Vec<PlannedChunk> = Vec::new();
+    let mut pending_rows: Vec<usize> = Vec::new();
+
+    for row_index in 0..manifest.rows.len() {
+        pending_rows.push(row_index);
+        let chunk_index = chunks.len() as u32;
+
+        let gasless_cap_exceeded = matches!(fee_payer_mode, FeePayerMode::Gasless)
+            && pending_rows.len() > MAX_GASLESS_TRANSFERS_PER_CHUNK;
+
+        let build_result = if gasless_cap_exceeded {
+            None
+        } else {
+            Some(build_planned_chunk(
+                manifest,
+                ata,
+                &pending_rows,
+                chunk_index,
+                fee_payer_mode,
+                sender,
+                fee_payer,
+                compute_unit_price_micro_lamports,
+                &prefix,
+            ))
+        };
+
+        let fits = matches!(build_result, Some(Ok(_)));
+        if fits {
+            // Row fits in the current (still-open) chunk; keep accumulating.
+            continue;
+        }
+
+        if pending_rows.len() == 1 {
+            let reason = match build_result {
+                Some(Err(e)) => e.to_string(),
+                _ => format!(
+                    "gasless chunks are capped at {MAX_GASLESS_TRANSFERS_PER_CHUNK} payouts"
+                ),
+            };
+            return Err(Error::Config(format!(
+                "CSV row {} cannot fit in a transaction on its own: {reason}",
+                manifest.rows[row_index].row_number
+            )));
+        }
+
+        // Finalize everything except the row that just broke the bound, then
+        // retry that row alone in a fresh chunk.
+        pending_rows.pop();
+        let finalized = build_planned_chunk(
+            manifest,
+            ata,
+            &pending_rows,
+            chunk_index,
+            fee_payer_mode,
+            sender,
+            fee_payer,
+            compute_unit_price_micro_lamports,
+            &prefix,
+        )?;
+        chunks.push(finalized);
+
+        pending_rows = vec![row_index];
+        let next_chunk_index = chunks.len() as u32;
+        if let Err(e) = build_planned_chunk(
+            manifest,
+            ata,
+            &pending_rows,
+            next_chunk_index,
+            fee_payer_mode,
+            sender,
+            fee_payer,
+            compute_unit_price_micro_lamports,
+            &prefix,
+        ) {
+            return Err(Error::Config(format!(
+                "CSV row {} cannot fit in a transaction on its own: {e}",
+                manifest.rows[row_index].row_number
+            )));
+        }
+    }
+
+    if !pending_rows.is_empty() {
+        let chunk_index = chunks.len() as u32;
+        chunks.push(build_planned_chunk(
+            manifest,
+            ata,
+            &pending_rows,
+            chunk_index,
+            fee_payer_mode,
+            sender,
+            fee_payer,
+            compute_unit_price_micro_lamports,
+            &prefix,
+        )?);
+    }
+
+    Ok(TransactionPlan {
+        fee_payer_mode,
+        fee_payer: *fee_payer,
+        chunks,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_planned_chunk(
+    manifest: &TransferManifest,
+    ata: &AtaSnapshot,
+    row_indices: &[usize],
+    chunk_index: u32,
+    fee_payer_mode: FeePayerMode,
+    sender: &Pubkey,
+    fee_payer: &Pubkey,
+    compute_unit_price_micro_lamports: u64,
+    manifest_prefix: &str,
+) -> Result<PlannedChunk> {
+    if matches!(fee_payer_mode, FeePayerMode::Gasless)
+        && row_indices.len() > MAX_GASLESS_TRANSFERS_PER_CHUNK
+    {
+        return Err(Error::Config(format!(
+            "gasless chunks are capped at {MAX_GASLESS_TRANSFERS_PER_CHUNK} payouts (MPP split limit)"
+        )));
+    }
+
+    let memo = format!("pay-push:v1:{manifest_prefix}:{chunk_index}");
+    let last = row_indices.len() - 1;
+    let ata_create_count = row_indices
+        .iter()
+        .filter(|&&idx| !ata.destinations[idx].exists)
+        .count();
+
+    let kit_entries: Vec<TransferEntry> = row_indices
+        .iter()
+        .enumerate()
+        .map(|(position, &row_index)| {
+            let row = &manifest.rows[row_index];
+            let dest = &ata.destinations[row_index];
+            TransferEntry {
+                recipient: row.recipient,
+                amount: row.amount_raw,
+                ata_creation_required: !dest.exists,
+                memo: if position == last {
+                    Some(memo.clone())
+                } else {
+                    None
+                },
+            }
+        })
+        .collect();
+
+    let compute_unit_limit = estimate_compute_units(kit_entries.len(), ata_create_count);
+    let compute_budget = ComputeBudgetOptions {
+        compute_unit_price_micro_lamports,
+        compute_unit_limit,
+    };
+    compute_budget.validate().map_err(kit_error)?;
+
+    let mut instructions = vec![
+        compute_unit_price_instruction(compute_budget.compute_unit_price_micro_lamports),
+        compute_unit_limit_instruction(compute_budget.compute_unit_limit),
+    ];
+    let batch = build_spl_transfer_batch_instructions(
+        sender,
+        &manifest.context.mint,
+        &manifest.context.token_program,
+        manifest.context.decimals,
+        fee_payer,
+        &kit_entries,
+    )
+    .map_err(kit_error)?;
+    instructions.extend(batch);
+
+    let message = Message::new_with_blockhash(&instructions, Some(fee_payer), &Hash::default());
+    if message.account_keys.len() > MAX_STATIC_ACCOUNT_KEYS {
+        return Err(Error::Config(format!(
+            "chunk needs {} account keys, exceeding the conservative {MAX_STATIC_ACCOUNT_KEYS}-key limit",
+            message.account_keys.len()
+        )));
+    }
+
+    let transaction = Transaction::new_unsigned(message);
+    let serialized_len = check_transaction_packet_size(&transaction).map_err(kit_error)?;
+
+    let entries = row_indices
+        .iter()
+        .map(|&row_index| {
+            let row = &manifest.rows[row_index];
+            PlannedTransferEntry {
+                row_number: row.row_number,
+                recipient: row.recipient,
+                amount_raw: row.amount_raw,
+                ata_creation_required: !ata.destinations[row_index].exists,
+            }
+        })
+        .collect();
+
+    Ok(PlannedChunk {
+        chunk_index,
+        entries,
+        compute_unit_price_micro_lamports: compute_budget.compute_unit_price_micro_lamports,
+        compute_unit_limit: compute_budget.compute_unit_limit,
+        memo,
+        serialized_len,
+    })
+}
+
+fn estimate_compute_units(transfer_count: usize, ata_create_count: usize) -> u32 {
+    let total = COMPUTE_BUDGET_OVERHEAD_UNITS
+        + MEMO_OVERHEAD_UNITS
+        + (transfer_count as u64) * TRANSFER_CHECKED_UNITS
+        + (ata_create_count as u64) * ATA_CREATE_UNITS;
+    total.min(PACKING_COMPUTE_UNIT_CEILING as u64) as u32
+}
+
+/// Apply the plan's post-finalize compute-unit refinement formula:
+/// `ceil(units_consumed * 1.15) + 10_000`, capped at Solana's real
+/// per-transaction ceiling. Pure and unit-testable; the network round trip
+/// that produces `units_consumed` (a signature-verification-disabled
+/// `simulateTransaction` call against the finalized chunk) is executor RPC
+/// glue and is wired up alongside broadcast in a later slice.
+pub fn refine_compute_unit_limit(units_consumed: u64) -> u32 {
+    let scaled = units_consumed.saturating_mul(115).div_ceil(100);
+    let with_margin = scaled.saturating_add(10_000);
+    with_margin.min(SOLANA_MAX_COMPUTE_UNIT_LIMIT as u64) as u32
+}
+
+// ── Instruction helpers (mirror PayKit's private compute-budget builders) ──
+
+pub(crate) fn compute_unit_price_instruction(micro_lamports: u64) -> Instruction {
+    let mut data = vec![COMPUTE_UNIT_PRICE_DISCRIMINATOR];
+    data.extend_from_slice(&micro_lamports.to_le_bytes());
+    Instruction {
+        program_id: compute_budget_program_id(),
+        accounts: vec![],
+        data,
+    }
+}
+
+pub(crate) fn compute_unit_limit_instruction(units: u32) -> Instruction {
+    let mut data = vec![COMPUTE_UNIT_LIMIT_DISCRIMINATOR];
+    data.extend_from_slice(&units.to_le_bytes());
+    Instruction {
+        program_id: compute_budget_program_id(),
+        accounts: vec![],
+        data,
+    }
+}
+
+/// Standard Associated Token Account address derivation
+/// (`[owner, token_program, mint]` seeds under the ATA program). Duplicated
+/// from PayKit's private helper of the same shape because the permit needs
+/// to re-derive the expected destination ATA for validation without
+/// depending on PayKit's private builder internals.
+pub(crate) fn derive_associated_token_address(
+    owner: &Pubkey,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+) -> Pubkey {
+    let seeds = &[owner.as_ref(), token_program.as_ref(), mint.as_ref()];
+    Pubkey::find_program_address(seeds, &associated_token_program_id()).0
+}
+
+pub(crate) fn compute_budget_program_id() -> Pubkey {
+    program_pubkey(programs::COMPUTE_BUDGET_PROGRAM)
+}
+
+pub(crate) fn memo_program_id() -> Pubkey {
+    program_pubkey(programs::MEMO_PROGRAM)
+}
+
+pub(crate) fn associated_token_program_id() -> Pubkey {
+    program_pubkey(programs::ASSOCIATED_TOKEN_PROGRAM)
+}
+
+pub(crate) fn token_program_id() -> Pubkey {
+    program_pubkey(programs::TOKEN_PROGRAM)
+}
+
+pub(crate) fn token_2022_program_id() -> Pubkey {
+    program_pubkey(programs::TOKEN_2022_PROGRAM)
+}
+
+pub(crate) fn system_program_id() -> Pubkey {
+    program_pubkey(programs::SYSTEM_PROGRAM)
+}
+
+fn program_pubkey(value: &str) -> Pubkey {
+    Pubkey::from_str(value).expect("PayKit program id constants are always valid base58")
+}
+
+pub(crate) fn kit_error(error: pay_kit::mpp::Error) -> Error {
+    Error::Mpp(error.to_string())
+}
+
+pub(crate) const fn ata_create_idempotent_discriminator() -> u8 {
+    ATA_CREATE_IDEMPOTENT_DISCRIMINATOR
+}
+
+pub(crate) const fn transfer_checked_discriminator() -> u8 {
+    TRANSFER_CHECKED_DISCRIMINATOR
+}
+
+pub(crate) const fn compute_unit_price_discriminator() -> u8 {
+    COMPUTE_UNIT_PRICE_DISCRIMINATOR
+}
+
+pub(crate) const fn compute_unit_limit_discriminator() -> u8 {
+    COMPUTE_UNIT_LIMIT_DISCRIMINATOR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest_with_rows(rows: usize, decimals: u8) -> TransferManifest {
+        let mut csv = String::from("recipient,amount\n");
+        for i in 0..rows {
+            let recipient = Pubkey::new_from_array([(i + 1) as u8; 32]);
+            csv.push_str(&format!("{recipient},1\n"));
+        }
+        let context = super::super::manifest::ManifestContext {
+            network_genesis_hash: [1; 32],
+            mint: Pubkey::new_from_array([9; 32]),
+            token_program: token_program_id(),
+            decimals,
+        };
+        super::super::manifest::parse_manifest_csv(csv.as_bytes(), context).unwrap()
+    }
+
+    fn snapshot_all_missing(manifest: &TransferManifest) -> AtaSnapshot {
+        AtaSnapshot {
+            sender_ata: Pubkey::new_unique(),
+            sender_ata_exists: true,
+            destinations: manifest
+                .rows
+                .iter()
+                .map(|row| DestinationAtaStatus {
+                    recipient: row.recipient,
+                    ata: derive_associated_token_address(
+                        &row.recipient,
+                        &manifest.context.mint,
+                        &manifest.context.token_program,
+                    ),
+                    exists: false,
+                })
+                .collect(),
+        }
+    }
+
+    fn snapshot_all_existing(manifest: &TransferManifest) -> AtaSnapshot {
+        let mut snapshot = snapshot_all_missing(manifest);
+        for dest in &mut snapshot.destinations {
+            dest.exists = true;
+        }
+        snapshot
+    }
+
+    // ── decide_fee_mode ──
+
+    #[test]
+    fn auto_prefers_self_funded_when_sol_covers_cost() {
+        let cost = SelfFundedCost {
+            estimated_fee_lamports: 5_000,
+            missing_ata_rent_lamports: 2_039_280,
+            reserve_lamports: 10_000,
+        };
+        let mode = decide_fee_mode(FeeModeRequest::Auto, 10_000_000, &cost, true).unwrap();
+        assert_eq!(mode, FeePayerMode::SelfFunded);
+    }
+
+    #[test]
+    fn auto_falls_back_to_gasless_when_sol_short() {
+        let cost = SelfFundedCost {
+            estimated_fee_lamports: 5_000,
+            missing_ata_rent_lamports: 2_039_280,
+            reserve_lamports: 10_000,
+        };
+        let mode = decide_fee_mode(FeeModeRequest::Auto, 1_000, &cost, true).unwrap();
+        assert_eq!(mode, FeePayerMode::Gasless);
+    }
+
+    #[test]
+    fn auto_fails_when_sol_short_and_gasless_unavailable() {
+        let cost = SelfFundedCost {
+            estimated_fee_lamports: 5_000,
+            missing_ata_rent_lamports: 0,
+            reserve_lamports: 10_000,
+        };
+        let err = decide_fee_mode(FeeModeRequest::Auto, 1_000, &cost, false).unwrap_err();
+        assert!(err.to_string().contains("pay-api"));
+    }
+
+    #[test]
+    fn forced_self_funded_fails_fast_on_shortfall_even_if_gasless_available() {
+        let cost = SelfFundedCost {
+            estimated_fee_lamports: 5_000,
+            missing_ata_rent_lamports: 0,
+            reserve_lamports: 10_000,
+        };
+        let err = decide_fee_mode(FeeModeRequest::SelfFunded, 1_000, &cost, true).unwrap_err();
+        assert!(err.to_string().contains("self-funded mode requires"));
+    }
+
+    #[test]
+    fn forced_gasless_never_spends_available_sol() {
+        let cost = SelfFundedCost {
+            estimated_fee_lamports: 5_000,
+            missing_ata_rent_lamports: 0,
+            reserve_lamports: 10_000,
+        };
+        // Plenty of SOL, but forced gasless with pay-api down must still fail
+        // rather than silently spending SOL.
+        let err =
+            decide_fee_mode(FeeModeRequest::Gasless, 10_000_000_000, &cost, false).unwrap_err();
+        assert!(err.to_string().contains("gasless mode requires pay-api"));
+
+        let mode = decide_fee_mode(FeeModeRequest::Gasless, 10_000_000_000, &cost, true).unwrap();
+        assert_eq!(mode, FeePayerMode::Gasless);
+    }
+
+    #[test]
+    fn reserve_uses_five_percent_floor_of_ten_thousand() {
+        assert_eq!(compute_reserve_lamports(0), MIN_FEE_RESERVE_LAMPORTS);
+        assert_eq!(compute_reserve_lamports(100_000), MIN_FEE_RESERVE_LAMPORTS);
+        assert_eq!(compute_reserve_lamports(1_000_000), 50_000);
+    }
+
+    #[test]
+    fn rent_exempt_minimum_matches_known_token_account_rent() {
+        // Well-known real-world SPL token account rent-exempt minimum.
+        assert_eq!(rent_exempt_minimum_lamports(TOKEN_ACCOUNT_LEN), 2_039_280);
+    }
+
+    // ── pack_chunks ──
+
+    #[test]
+    fn every_row_appears_exactly_once_in_original_order() {
+        let manifest = manifest_with_rows(50, 6);
+        let ata = snapshot_all_missing(&manifest);
+        let sender = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+
+        let mut seen_row_numbers = Vec::new();
+        for chunk in &plan.chunks {
+            seen_row_numbers.extend(chunk.row_numbers());
+        }
+        let expected: Vec<u64> = manifest.rows.iter().map(|r| r.row_number).collect();
+        assert_eq!(seen_row_numbers, expected);
+    }
+
+    #[test]
+    fn packed_transactions_never_exceed_packet_size() {
+        let manifest = manifest_with_rows(200, 6);
+        let ata = snapshot_all_missing(&manifest);
+        let sender = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+        assert!(
+            plan.chunks.len() > 1,
+            "200 missing-ATA rows must span multiple chunks"
+        );
+        for chunk in &plan.chunks {
+            assert!(chunk.serialized_len <= pay_kit::mpp::protocol::solana::PACKET_DATA_SIZE);
+        }
+    }
+
+    #[test]
+    fn gasless_chunks_cap_at_eight_transfers() {
+        let manifest = manifest_with_rows(20, 6);
+        let ata = snapshot_all_existing(&manifest);
+        let sender = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::Gasless,
+            &sender,
+            &fee_payer,
+            1,
+        )
+        .unwrap();
+        for chunk in &plan.chunks {
+            assert!(chunk.entries.len() <= MAX_GASLESS_TRANSFERS_PER_CHUNK);
+        }
+        let total: usize = plan.chunks.iter().map(|c| c.entries.len()).sum();
+        assert_eq!(total, 20);
+        assert_eq!(plan.chunks.len(), 3); // 8 + 8 + 4
+    }
+
+    #[test]
+    fn self_funded_existing_atas_pack_more_transfers_per_chunk_than_missing_atas() {
+        let manifest_missing = manifest_with_rows(100, 6);
+        let missing = snapshot_all_missing(&manifest_missing);
+        let sender = Pubkey::new_unique();
+        let plan_missing = pack_chunks(
+            &manifest_missing,
+            &missing,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+
+        let manifest_existing = manifest_with_rows(100, 6);
+        let existing = snapshot_all_existing(&manifest_existing);
+        let plan_existing = pack_chunks(
+            &manifest_existing,
+            &existing,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+
+        assert!(plan_existing.chunks.len() < plan_missing.chunks.len());
+    }
+
+    #[test]
+    fn token_2022_packs_successfully() {
+        let mut manifest = manifest_with_rows(10, 6);
+        manifest.context.token_program = token_2022_program_id();
+        // Rebuild rows against a Token-2022 context (parse_manifest_csv baked
+        // in the token program used at manifest_with_rows time already
+        // matched TOKEN_PROGRAM; overwrite it directly here since packing
+        // only reads `manifest.context`, not the hash).
+        let ata = snapshot_all_missing(&manifest);
+        let sender = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+        assert!(!plan.chunks.is_empty());
+    }
+
+    #[test]
+    fn memo_is_last_instruction_and_carries_chunk_identity() {
+        let manifest = manifest_with_rows(3, 6);
+        let ata = snapshot_all_missing(&manifest);
+        let sender = Pubkey::new_unique();
+        let plan = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap();
+        let hash_hex = manifest.hash_hex();
+        let prefix = super::super::manifest_hash_prefix(&hash_hex);
+        for chunk in &plan.chunks {
+            assert_eq!(
+                chunk.memo,
+                format!("pay-push:v1:{prefix}:{}", chunk.chunk_index)
+            );
+        }
+    }
+
+    #[test]
+    fn refine_compute_unit_limit_applies_margin_and_caps() {
+        assert_eq!(refine_compute_unit_limit(100_000), 125_000);
+        assert_eq!(
+            refine_compute_unit_limit(SOLANA_MAX_COMPUTE_UNIT_LIMIT as u64 * 10),
+            SOLANA_MAX_COMPUTE_UNIT_LIMIT
+        );
+    }
+
+    #[test]
+    fn ata_snapshot_length_mismatch_is_rejected() {
+        let manifest = manifest_with_rows(5, 6);
+        let mut ata = snapshot_all_missing(&manifest);
+        ata.destinations.pop();
+        let sender = Pubkey::new_unique();
+        let err = pack_chunks(
+            &manifest,
+            &ata,
+            FeePayerMode::SelfFunded,
+            &sender,
+            &sender,
+            1,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("does not match"));
+    }
+}

--- a/rust/crates/core/src/client/push/planner.rs
+++ b/rust/crates/core/src/client/push/planner.rs
@@ -554,6 +554,65 @@ fn build_planned_chunk(
     })
 }
 
+/// Build the real (unsigned) transaction for `chunk`, ready for
+/// [`super::permit::BatchSigningPermit::sign_chunk`]. This is the
+/// production counterpart of `build_planned_chunk`'s internal
+/// instruction-building (which only proves the chunk *fits*, at packing
+/// time, against a placeholder blockhash): the executor calls this once it
+/// has a live blockhash, right before signing, so staleness is bounded to
+/// one round trip rather than however long a chunk sat in a plan.
+///
+/// `blockhash` must be a recently-fetched value from the network the chunk
+/// targets; this function performs no RPC itself, matching every other
+/// pure/read-only-preflight function in this module.
+pub fn build_chunk_transaction(
+    chunk: &PlannedChunk,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+    decimals: u8,
+    sender: &Pubkey,
+    fee_payer: &Pubkey,
+    blockhash: Hash,
+) -> Result<Transaction> {
+    let last = chunk.entries.len().checked_sub(1).ok_or_else(|| {
+        Error::Config("cannot build a transaction for a chunk with no entries".to_string())
+    })?;
+    let kit_entries: Vec<TransferEntry> = chunk
+        .entries
+        .iter()
+        .enumerate()
+        .map(|(position, entry)| TransferEntry {
+            recipient: entry.recipient,
+            amount: entry.amount_raw,
+            ata_creation_required: entry.ata_creation_required,
+            memo: if position == last {
+                Some(chunk.memo.clone())
+            } else {
+                None
+            },
+        })
+        .collect();
+
+    let mut instructions = vec![
+        compute_unit_price_instruction(chunk.compute_unit_price_micro_lamports),
+        compute_unit_limit_instruction(chunk.compute_unit_limit),
+    ];
+    instructions.extend(
+        build_spl_transfer_batch_instructions(
+            sender,
+            mint,
+            token_program,
+            decimals,
+            fee_payer,
+            &kit_entries,
+        )
+        .map_err(kit_error)?,
+    );
+
+    let message = Message::new_with_blockhash(&instructions, Some(fee_payer), &blockhash);
+    Ok(Transaction::new_unsigned(message))
+}
+
 fn estimate_compute_units(transfer_count: usize, ata_create_count: usize) -> u32 {
     let total = COMPUTE_BUDGET_OVERHEAD_UNITS
         + MEMO_OVERHEAD_UNITS

--- a/rust/crates/keystore/src/auth.rs
+++ b/rust/crates/keystore/src/auth.rs
@@ -23,6 +23,15 @@ pub enum AuthIntent {
     OpenSession(String),
     UseGatewayFeePayer(String),
     UseAccount(String),
+    /// One-approval authorization for a `pay push` CSV batch. Shown once
+    /// after read-only preflight, naming the exact recipient count, token
+    /// total, and worst-case ceiling (including gasless reimbursement) the
+    /// resulting signing permit may sign — never a generic "N payments"
+    /// allowance. See `pay_core::client::push::permit`.
+    AuthorizeBatch {
+        message: String,
+        limit: Option<PaymentLimit>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -221,6 +230,39 @@ impl AuthIntent {
         Self::UseGatewayFeePayer("use your pay account as the gateway fee payer".to_string())
     }
 
+    /// Build the one-approval `pay push` batch authorization prompt.
+    ///
+    /// `recipient_total_display` and `max_total_display` are pre-formatted
+    /// decimal amounts (e.g. `"1234.56 USDG"`); `max_total_usd` is the same
+    /// maximum expressed as a `"$..."` string used only to pick the Linux
+    /// Polkit action bucket (stablecoins are USD-pegged 1:1, so the raw
+    /// batch ceiling doubles as its own USD estimate).
+    #[allow(clippy::too_many_arguments)]
+    pub fn authorize_batch(
+        account: &str,
+        recipient_count: usize,
+        recipient_total_display: &str,
+        max_total_display: &str,
+        max_total_usd: &str,
+        currency: &str,
+        network: &str,
+        manifest_hash_prefix: &str,
+    ) -> Self {
+        let message = batch_authorization_message(
+            account,
+            recipient_count,
+            recipient_total_display,
+            max_total_display,
+            currency,
+            network,
+            manifest_hash_prefix,
+        );
+        Self::AuthorizeBatch {
+            message,
+            limit: PaymentLimit::from_amount(max_total_usd),
+        }
+    }
+
     pub fn use_account(message: impl Into<String>) -> Self {
         Self::UseAccount(message.into())
     }
@@ -255,6 +297,7 @@ impl AuthIntent {
     pub fn message(&self) -> &str {
         match self {
             Self::AuthorizePayment { message, .. }
+            | Self::AuthorizeBatch { message, .. }
             | Self::CreateAccount(message)
             | Self::ImportAccount(message)
             | Self::ExportAccount(message)
@@ -267,7 +310,7 @@ impl AuthIntent {
 
     pub fn payment_limit(&self) -> Option<PaymentLimit> {
         match self {
-            Self::AuthorizePayment { limit, .. } => *limit,
+            Self::AuthorizePayment { limit, .. } | Self::AuthorizeBatch { limit, .. } => *limit,
             _ => None,
         }
     }
@@ -359,6 +402,33 @@ fn payment_authorization_message(
     }
 
     message
+}
+
+#[allow(clippy::too_many_arguments)]
+fn batch_authorization_message(
+    account: &str,
+    recipient_count: usize,
+    recipient_total_display: &str,
+    max_total_display: &str,
+    currency: &str,
+    network: &str,
+    manifest_hash_prefix: &str,
+) -> String {
+    let account = truncate_detail(&prompt_detail(account), 64);
+    let currency = truncate_detail(&prompt_detail(currency), 24);
+    let network = truncate_detail(&prompt_detail(network), 24);
+    let manifest_hash_prefix = truncate_detail(&prompt_detail(manifest_hash_prefix), 24);
+
+    format!(
+        "authorize a batch payout from {account}.\n\n\
+         recipients: {recipient_count}\n\n\
+         recipient total: {recipient_total} {currency}\n\n\
+         maximum total: {max_total} {currency}\n\n\
+         network: {network}\n\n\
+         manifest: {manifest_hash_prefix}",
+        recipient_total = truncate_detail(&prompt_detail(recipient_total_display), 32),
+        max_total = truncate_detail(&prompt_detail(max_total_display), 32),
+    )
 }
 
 fn payment_message_with_account(message: &str, account: &str) -> String {
@@ -578,6 +648,21 @@ mod tests {
                 .count(),
             64
         );
+    }
+
+    #[test]
+    fn authorize_batch_names_every_required_field() {
+        let intent = AuthIntent::authorize_batch(
+            "default", 1_000, "1234.56", "1250.00", "$1250.00", "USDG", "mainnet", "a42f82c1",
+        );
+        let message = intent.prompt_message();
+        assert!(message.starts_with("authorize a batch payout from default."));
+        assert!(message.contains("recipients: 1000"));
+        assert!(message.contains("recipient total: 1234.56 USDG"));
+        assert!(message.contains("maximum total: 1250.00 USDG"));
+        assert!(message.contains("network: mainnet"));
+        assert!(message.contains("manifest: a42f82c1"));
+        assert_eq!(intent.payment_limit(), Some(PaymentLimit::AboveUsd50));
     }
 
     #[test]

--- a/rust/crates/keystore/src/linux/mod.rs
+++ b/rust/crates/keystore/src/linux/mod.rs
@@ -116,6 +116,12 @@ fn polkit_action_for_intent(intent: &AuthIntent) -> &'static str {
         AuthIntent::AuthorizePayment { limit, .. } => limit
             .map(polkit_payment_limit_action)
             .unwrap_or(POLKIT_ACTION_PAYMENT),
+        // A batch is "a series of payments" like a session budget; reuse the
+        // same action plus the existing per-limit-bucket mapping rather than
+        // installing a whole new policy action for Slice 2.
+        AuthIntent::AuthorizeBatch { limit, .. } => limit
+            .map(polkit_payment_limit_action)
+            .unwrap_or(POLKIT_ACTION_SESSION),
         AuthIntent::CreateAccount(_) => POLKIT_ACTION_CREATE,
         AuthIntent::ImportAccount(_) => POLKIT_ACTION_IMPORT,
         AuthIntent::ExportAccount(_) => POLKIT_ACTION_EXPORT,
@@ -626,6 +632,29 @@ mod tests {
         assert_eq!(
             polkit_action_for_intent(&AuthIntent::use_gateway_fee_payer()),
             POLKIT_ACTION_GATEWAY_FEE_PAYER
+        );
+    }
+
+    #[test]
+    fn batch_intents_use_session_action_bucketed_by_limit() {
+        assert_eq!(
+            polkit_action_for_intent(&AuthIntent::authorize_batch(
+                "default", 10, "1.00", "1.00", "$0.05", "USDG", "mainnet", "a42f82c1",
+            )),
+            "sh.pay.authorize-payment-up-to-usd-005"
+        );
+        assert_eq!(
+            polkit_action_for_intent(&AuthIntent::authorize_batch(
+                "default",
+                10,
+                "1.00",
+                "1.00",
+                "not-a-dollar-amount",
+                "USDG",
+                "mainnet",
+                "a42f82c1",
+            )),
+            POLKIT_ACTION_SESSION
         );
     }
 

--- a/rust/crates/keystore/src/linux/mod.rs
+++ b/rust/crates/keystore/src/linux/mod.rs
@@ -118,7 +118,7 @@ fn polkit_action_for_intent(intent: &AuthIntent) -> &'static str {
             .unwrap_or(POLKIT_ACTION_PAYMENT),
         // A batch is "a series of payments" like a session budget; reuse the
         // same action plus the existing per-limit-bucket mapping rather than
-        // installing a whole new policy action for Slice 2.
+        // installing a whole new policy action for `pay push`.
         AuthIntent::AuthorizeBatch { limit, .. } => limit
             .map(polkit_payment_limit_action)
             .unwrap_or(POLKIT_ACTION_SESSION),

--- a/rust/crates/pay-api-core/Cargo.toml
+++ b/rust/crates/pay-api-core/Cargo.toml
@@ -8,13 +8,21 @@ license.workspace = true
 pay-api-types = { path = "../pay-api-types" }
 
 base64 = "0.22"
+bincode = { workspace = true }
+blake3 = { workspace = true }
 borsh = { version = "1", features = ["derive"] }
 bs58 = "0.5"
+chrono = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 pay-kit = { workspace = true }
+solana-hash = { workspace = true }
+solana-instruction = { workspace = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+solana-transaction = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
@@ -23,3 +31,5 @@ tracing = { workspace = true }
 borsh = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }
 solana-address = { version = "2", features = ["borsh", "curve25519"] }
+solana-keypair = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/rust/crates/pay-api-core/src/lib.rs
+++ b/rust/crates/pay-api-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod rpc;
 pub mod stablecoin;
 pub mod subscription_state;
 pub mod token_metadata;
+pub mod transfer_batch;
 
 pub use error::{Error, Result};
 pub use pay_api_types::{

--- a/rust/crates/pay-api-core/src/rpc.rs
+++ b/rust/crates/pay-api-core/src/rpc.rs
@@ -423,6 +423,39 @@ impl RpcClient {
             .ok_or(Error::RpcMalformed)
     }
 
+    /// `getLatestBlockhash`, returning both the blockhash and the block
+    /// height after which it stops being valid.
+    ///
+    /// Used by `/api/v1/transfer-batches`' quote step: the caller needs
+    /// `lastValidBlockHeight` (not just the blockhash) so it knows exactly
+    /// when its signed chunk expires and a fresh quote is required. Kept
+    /// separate from [`Self::get_latest_blockhash`] rather than changing
+    /// that method's return type, since `/v1/send` and `/v1/redeem` already
+    /// depend on its `String`-only shape.
+    pub async fn get_latest_blockhash_with_last_valid_height(
+        &self,
+        rpc_url: &str,
+    ) -> Result<(String, u64)> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getLatestBlockhash",
+            "params": [{ "commitment": "confirmed" }],
+        });
+        let result = self.post_rpc_value(rpc_url, body).await?;
+        let value = result.get("value").ok_or(Error::RpcMalformed)?;
+        let blockhash = value
+            .get("blockhash")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or(Error::RpcMalformed)?;
+        let last_valid_block_height = value
+            .get("lastValidBlockHeight")
+            .and_then(Value::as_u64)
+            .ok_or(Error::RpcMalformed)?;
+        Ok((blockhash, last_valid_block_height))
+    }
+
     /// `sendTransaction` — submit a fully-signed, base64-encoded transaction.
     /// Returns the transaction signature on success.
     ///

--- a/rust/crates/pay-api-core/src/transfer_batch.rs
+++ b/rust/crates/pay-api-core/src/transfer_batch.rs
@@ -1,0 +1,1277 @@
+//! Business logic behind `POST /api/v1/transfer-batches` — gasless CSV
+//! batch payouts. The handler in `pay-api` only parses the HTTP request,
+//! calls into this module, and maps the result to a response; every rule
+//! below is what actually decides whether a chunk gets broadcast.
+//!
+//! ## Why this doesn't depend on `pay-core::client::push`
+//!
+//! `pay-core`'s `client::push` module (`manifest`/`planner`/`permit`/
+//! `journal`) is the CLI's shared core, but `pay-api-core` cannot pull it
+//! in: `permit::BatchSigningPermit` is built around a *local, one-time
+//! Touch ID / Polkit authorization prompt* over a keystore-backed signer
+//! (`pay-core::keystore`, `pay-core::signer`) — concepts that only make
+//! sense for a desktop CLI holding the end user's own key. A stateless HTTP
+//! handler has no keystore and no user to prompt; it signs with whatever
+//! `pay-api/src/signer.rs` resolves at boot (a GCP-KMS key in production,
+//! an in-memory key for local dev — see [`TransferBatchSponsor`]). So the
+//! slice of *instruction-shape validation* this endpoint needs (compute
+//! budget + idempotent-ATA-create + `transfer_checked` + memo, matching
+//! `pay_core::client::push::planner`'s chunk shape byte-for-byte) is
+//! re-derived here directly against PayKit, the same way the CLI's planner
+//! and permit do — not imported from them. [`validate_prepared_transaction`]
+//! is deliberately structured like `permit::BatchSigningPermit`'s
+//! same-named validator for exactly this reason: the two are independent
+//! implementations of one shared on-chain contract, so they *should* look
+//! alike and are expected to be kept in sync by hand.
+//!
+//! ## Two-step, header-gated flow (mirrors `send.rs`)
+//!
+//! 1. **Quote** — POST with no `Authorization` header. [`validate_request`]
+//!    checks the chunk's shape, then [`quote`] resolves live on-chain state
+//!    (which destination ATAs are missing, a fresh blockhash) and returns
+//!    HTTP 402 with a `TransferBatchChallengeBody`: the sponsor's fee-payer
+//!    pubkey, the exact blockhash to build against, and its expiry.
+//! 2. **Submit** — POST the *same* body again with
+//!    `Authorization: Bearer <base64 bincode Transaction>`. The caller
+//!    signed that exact chunk transaction locally as `sender` (`pay push`'s
+//!    CLI does this with `permit::BatchSigningPermit::sign_chunk`, which
+//!    leaves the fee-payer slot unsigned for a gasless chunk — see
+//!    `journal::ChunkResumeAction::RepresentGaslessCredential`, whose doc
+//!    comment already describes re-presenting this exact credential to
+//!    pay-api on resume). [`submit`] decodes it, re-validates every
+//!    instruction against the request's own fields (never trusting
+//!    anything in the transaction that can be independently derived),
+//!    verifies `sender`'s signature, appends the sponsor's fee-payer
+//!    signature, broadcasts, waits for confirmation, and returns
+//!    [`TransferBatchResponse`].
+//!
+//! A chunk is one atomic transaction — Solana has no notion of a
+//! transaction landing "3 of 4 instructions succeeded" — so partial-chunk
+//! failure is not a real state the chain can produce.
+//! [`pay_api_types::transfer_batch::TransferBatchResponse`] deliberately
+//! carries one signature and one status for the whole chunk rather than a
+//! per-transfer outcome list; a failed chunk is reported as one HTTP error
+//! (via [`TransferBatchError`]), not a 200 with partial results.
+//!
+//! ## Known simplifications (flagged, not silently worked around)
+//!
+//! - **Fee-reimbursement pricing is a static, operator-configured
+//!   SOL/USD rate** ([`TransferBatchSettings::usd_per_sol`]), not a live
+//!   oracle lookup like `/v1/send`'s Helius DAS / CoinGecko fallback. The
+//!   quoted `feeReimbursementRaw` is informational only: unlike
+//!   `/v1/send`'s `fee_within`, nothing in the on-chain chunk transaction
+//!   actually collects it (see the next point) — a real settlement/billing
+//!   path for it is follow-up work.
+//! - **The chunk transaction never contains a reimbursement transfer.**
+//!   `pay_core::client::push::permit::BatchSigningPermit::sign_chunk` (already
+//!   shipped and tested) signs a gasless chunk as *exactly* compute-budget +
+//!   `{ata-create?, transfer_checked}` per row + memo — no extra transfer to
+//!   the fee payer. Since that CLI behavior is load-bearing and already
+//!   tested, [`validate_prepared_transaction`] matches it exactly rather
+//!   than inventing an on-chain reimbursement leg the real client never
+//!   produces.
+//! - **No stored challenge state.** This module is stateless: a quote's
+//!   "expiry" is enforced implicitly by the blockhash's own
+//!   `lastValidBlockHeight` (an expired chunk simply fails to land on-chain
+//!   and `submit` surfaces that as an RPC error), not by a
+//!   server-side session the endpoint would need a database for.
+//! - **ATA rent is a configured flat lamport figure**
+//!   ([`TransferBatchSettings::ata_rent_lamports`]), not a live
+//!   `getMinimumBalanceForRentExemption` lookup, and does not distinguish
+//!   Token vs Token-2022 account length. Both are the same kind of
+//!   deliberate v1 simplification `pay_core::client::push::planner` already
+//!   documents for its own rent/fee estimates.
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::Engine;
+use chrono::Duration as ChronoDuration;
+use pay_api_types::transfer_batch::{
+    BATCH_ID_HEX_LEN, MAX_TRANSFER_BATCH_TRANSFERS, MIN_TRANSFER_BATCH_TRANSFERS,
+    TransferBatchChallengeBody, TransferBatchErrorBody, TransferBatchErrorDetail,
+    TransferBatchRequest, TransferBatchResponse, TransferBatchStatus, TransferNetwork,
+};
+use pay_kit::mpp::protocol::solana::programs;
+use pay_kit::mpp::solana_keychain::SolanaSigner;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_transaction::Transaction;
+
+use crate::ata::associated_token_address;
+use crate::rpc::RpcClient;
+use crate::stablecoin::Stablecoin;
+
+/// Leading hex characters of `batchId` used in the on-chain memo. Mirrors
+/// `pay_core::client::push::MANIFEST_HASH_PREFIX_LEN` — duplicated as a
+/// plain constant (not imported) for the same reason every other small
+/// constant in this module is duplicated rather than pulled in from
+/// `pay-core`: see the module docs.
+const MANIFEST_HASH_PREFIX_LEN: usize = 8;
+
+/// Mirrors PayKit's private compute-budget/ATA-create/transfer-checked
+/// instruction discriminators. Byte-for-byte identical to the constants of
+/// the same name in `pay_core::client::push::planner`, which documents the
+/// same duplication rationale: this validator must decode instructions
+/// built by PayKit without depending on PayKit's private builder internals.
+const ATA_CREATE_IDEMPOTENT_DISCRIMINATOR: u8 = 1;
+const COMPUTE_UNIT_LIMIT_DISCRIMINATOR: u8 = 2;
+const COMPUTE_UNIT_PRICE_DISCRIMINATOR: u8 = 3;
+const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
+
+/// The Solana account index a fee payer's signature always occupies:
+/// `account_keys[0]` is always the fee payer, by protocol convention.
+const FEE_PAYER_SIGNATURE_INDEX: usize = 0;
+
+// ── Errors ───────────────────────────────────────────────────────────────
+
+/// Every way a `/api/v1/transfer-batches` request or credential can be
+/// rejected. Each variant carries enough detail for
+/// [`TransferBatchError::to_body`] to produce an actionable
+/// [`TransferBatchErrorBody`] (which field, why, whether retrying makes
+/// sense) rather than a generic "bad request".
+#[derive(Debug, thiserror::Error)]
+pub enum TransferBatchError {
+    #[error(
+        "batchId must be exactly {BATCH_ID_HEX_LEN} lowercase hex characters (a BLAKE3 digest)"
+    )]
+    InvalidBatchId,
+    #[error("sender is not a valid base58 Solana address")]
+    InvalidSender,
+    #[error("unsupported currency `{0}`")]
+    UnsupportedCurrency(String),
+    #[error(
+        "transfers must contain between {MIN_TRANSFER_BATCH_TRANSFERS} and {MAX_TRANSFER_BATCH_TRANSFERS} entries, got {actual}"
+    )]
+    TransferCountOutOfBounds { actual: usize },
+    #[error("transfers[{index}].recipient is not a valid base58 Solana address")]
+    InvalidRecipient { index: usize },
+    #[error(
+        "transfers[{index}].amount `{amount}` is not a valid positive decimal amount at {decimals} decimals"
+    )]
+    InvalidAmount {
+        index: usize,
+        amount: String,
+        decimals: u8,
+    },
+    #[error("transfers[{index}].rowId {row_id} duplicates transfers[{first_index}].rowId")]
+    DuplicateRowId {
+        index: usize,
+        first_index: usize,
+        row_id: u64,
+    },
+    #[error("push is not configured for network `{0}`")]
+    NetworkNotConfigured(String),
+    #[error("Authorization header is not a valid base64-encoded prepared transaction: {0}")]
+    MalformedCredential(String),
+    #[error("prepared transaction does not match the authorized chunk: {0}")]
+    TransactionMismatch(String),
+    #[error("sender's signature over the prepared transaction is missing or invalid")]
+    InvalidSenderSignature,
+    #[error("the fee-payer signature slot must be unsigned in the submitted transaction")]
+    FeePayerSlotAlreadySigned,
+    #[error("push sponsor is not configured: {0}")]
+    SponsorNotConfigured(String),
+    #[error("failed to co-sign the prepared transaction: {0}")]
+    SigningFailed(String),
+    #[error(transparent)]
+    Rpc(#[from] crate::error::Error),
+}
+
+impl TransferBatchError {
+    pub fn http_status(&self) -> u16 {
+        match self {
+            Self::Rpc(err) => err.http_status(),
+            Self::SponsorNotConfigured(_) => 503,
+            Self::SigningFailed(_) => 502,
+            _ => 400,
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidBatchId => "invalid_batch_id",
+            Self::InvalidSender => "invalid_sender",
+            Self::UnsupportedCurrency(_) => "unsupported_currency",
+            Self::TransferCountOutOfBounds { .. } => "invalid_transfer_count",
+            Self::InvalidRecipient { .. } => "invalid_recipient",
+            Self::InvalidAmount { .. } => "invalid_amount",
+            Self::DuplicateRowId { .. } => "duplicate_row_id",
+            Self::NetworkNotConfigured(_) => "network_not_configured",
+            Self::MalformedCredential(_) => "malformed_credential",
+            Self::TransactionMismatch(_) => "transaction_mismatch",
+            Self::InvalidSenderSignature => "invalid_sender_signature",
+            Self::FeePayerSlotAlreadySigned => "fee_payer_slot_already_signed",
+            Self::SponsorNotConfigured(_) => "sponsor_not_configured",
+            Self::SigningFailed(_) => "signing_failed",
+            Self::Rpc(_) => "rpc_error",
+        }
+    }
+
+    pub fn field(&self) -> Option<String> {
+        match self {
+            Self::InvalidBatchId => Some("batchId".to_string()),
+            Self::InvalidSender => Some("sender".to_string()),
+            Self::UnsupportedCurrency(_) => Some("currency".to_string()),
+            Self::TransferCountOutOfBounds { .. } => Some("transfers".to_string()),
+            Self::InvalidRecipient { index } => Some(format!("transfers[{index}].recipient")),
+            Self::InvalidAmount { index, .. } => Some(format!("transfers[{index}].amount")),
+            Self::DuplicateRowId { index, .. } => Some(format!("transfers[{index}].rowId")),
+            Self::NetworkNotConfigured(_) => Some("network".to_string()),
+            _ => None,
+        }
+    }
+
+    /// Whether an identical retry (of the whole request, credential
+    /// included) might succeed with no changes.
+    pub fn retryable(&self) -> bool {
+        match self {
+            Self::SponsorNotConfigured(_) | Self::SigningFailed(_) => true,
+            Self::Rpc(err) => matches!(
+                err,
+                crate::error::Error::RpcTimeout { .. }
+                    | crate::error::Error::RpcRateLimited
+                    | crate::error::Error::RpcTransport(_)
+            ),
+            _ => false,
+        }
+    }
+
+    pub fn to_body(&self) -> TransferBatchErrorBody {
+        TransferBatchErrorBody {
+            error: TransferBatchErrorDetail {
+                code: self.code().to_string(),
+                message: self.to_string(),
+                field: self.field(),
+                retryable: self.retryable(),
+            },
+        }
+    }
+}
+
+// ── Validation ───────────────────────────────────────────────────────────
+
+/// One transfer after parsing: recipient and amount are structurally valid
+/// and amount is already in the stablecoin's raw base units.
+#[derive(Debug, Clone)]
+pub struct ValidatedTransfer {
+    pub row_id: u64,
+    pub recipient: Pubkey,
+    pub amount_raw: u64,
+}
+
+/// A `TransferBatchRequest` after every pure (no-I/O) check has passed.
+#[derive(Debug, Clone)]
+pub struct ValidatedChunk {
+    /// Lowercased 64-hex-character batch id, as received.
+    pub batch_id: String,
+    pub chunk_index: u32,
+    pub sender: Pubkey,
+    pub network: TransferNetwork,
+    pub coin: Stablecoin,
+    pub transfers: Vec<ValidatedTransfer>,
+    /// `pay-push:v1:<8-hex-char batchId prefix>:<chunkIndex>` — must match
+    /// `pay_core::client::push::planner`'s memo format exactly, since the
+    /// CLI stamps this same string into the transaction it signs.
+    pub memo: String,
+}
+
+impl ValidatedChunk {
+    /// Sum of every transfer's raw amount. `None` on overflow (impossible
+    /// in practice at 8 transfers of `u64::MAX` each not summing past
+    /// `u64::MAX`... except it *is* possible with adversarial input, so this
+    /// is checked, not assumed).
+    pub fn recipient_amount_raw(&self) -> Option<u64> {
+        self.transfers
+            .iter()
+            .try_fold(0u64, |acc, t| acc.checked_add(t.amount_raw))
+    }
+}
+
+/// Validate a `TransferBatchRequest`'s shape: no RPC, no config beyond the
+/// stablecoin registry every other endpoint already resolves at boot.
+pub fn validate_request(
+    request: &TransferBatchRequest,
+    stablecoins: &[Stablecoin],
+) -> Result<ValidatedChunk, TransferBatchError> {
+    if request.batch_id.len() != BATCH_ID_HEX_LEN
+        || request.batch_id.bytes().any(|b| b.is_ascii_uppercase())
+        || blake3::Hash::from_hex(&request.batch_id).is_err()
+    {
+        return Err(TransferBatchError::InvalidBatchId);
+    }
+
+    let sender =
+        Pubkey::from_str(request.sender.trim()).map_err(|_| TransferBatchError::InvalidSender)?;
+
+    let currency = request.currency.trim();
+    let coin = stablecoins
+        .iter()
+        .find(|c| c.symbol.eq_ignore_ascii_case(currency) || c.mint.to_string() == currency)
+        .cloned()
+        .ok_or_else(|| TransferBatchError::UnsupportedCurrency(request.currency.clone()))?;
+
+    if request.transfers.len() < MIN_TRANSFER_BATCH_TRANSFERS
+        || request.transfers.len() > MAX_TRANSFER_BATCH_TRANSFERS
+    {
+        return Err(TransferBatchError::TransferCountOutOfBounds {
+            actual: request.transfers.len(),
+        });
+    }
+
+    let mut transfers = Vec::with_capacity(request.transfers.len());
+    let mut seen_row_ids: Vec<u64> = Vec::with_capacity(request.transfers.len());
+    for (index, entry) in request.transfers.iter().enumerate() {
+        if let Some(first_index) = seen_row_ids.iter().position(|&r| r == entry.row_id) {
+            return Err(TransferBatchError::DuplicateRowId {
+                index,
+                first_index,
+                row_id: entry.row_id,
+            });
+        }
+        seen_row_ids.push(entry.row_id);
+
+        let recipient = Pubkey::from_str(entry.recipient.trim())
+            .map_err(|_| TransferBatchError::InvalidRecipient { index })?;
+        let amount_raw =
+            parse_positive_base_units(&entry.amount, coin.decimals).ok_or_else(|| {
+                TransferBatchError::InvalidAmount {
+                    index,
+                    amount: entry.amount.clone(),
+                    decimals: coin.decimals,
+                }
+            })?;
+        transfers.push(ValidatedTransfer {
+            row_id: entry.row_id,
+            recipient,
+            amount_raw,
+        });
+    }
+
+    let batch_id = request.batch_id.to_ascii_lowercase();
+    let prefix = &batch_id[..MANIFEST_HASH_PREFIX_LEN];
+    let memo = format!("pay-push:v1:{prefix}:{}", request.chunk_index);
+
+    Ok(ValidatedChunk {
+        batch_id,
+        chunk_index: request.chunk_index,
+        sender,
+        network: request.network,
+        coin,
+        transfers,
+        memo,
+    })
+}
+
+fn parse_positive_base_units(amount: &str, decimals: u8) -> Option<u64> {
+    let raw = pay_kit::mpp::parse_units(amount.trim(), decimals).ok()?;
+    let parsed = raw.parse::<u64>().ok()?;
+    if parsed == 0 { None } else { Some(parsed) }
+}
+
+// ── Runtime ──────────────────────────────────────────────────────────────
+
+/// The pay-api-controlled signer that co-signs every gasless chunk as fee
+/// payer. Resolved once at boot by `pay-api/src/signer.rs` (GCP KMS in
+/// production, an in-memory key for local dev) — this module never touches
+/// key material directly, only the [`SolanaSigner`] trait object.
+pub struct TransferBatchSponsor {
+    pub fee_payer_pubkey: Pubkey,
+    pub signer: Arc<dyn SolanaSigner>,
+}
+
+/// Operator-configured pricing and transaction-shape ceilings. See the
+/// module docs' "Known simplifications" for why these are static config
+/// rather than live lookups.
+#[derive(Debug, Clone)]
+pub struct TransferBatchSettings {
+    pub compute_unit_price_micro_lamports: u64,
+    pub compute_unit_limit: u32,
+    pub estimated_fee_lamports: u64,
+    pub ata_rent_lamports: u64,
+    pub usd_per_sol: f64,
+    pub challenge_ttl: ChronoDuration,
+    pub confirm_timeout: Duration,
+}
+
+/// Everything [`quote`] and [`submit`] need for one request, borrowed from
+/// `pay-api`'s `AppState` for the duration of the call.
+pub struct TransferBatchRuntime<'a> {
+    pub rpc: &'a RpcClient,
+    pub rpc_url: &'a str,
+    pub sponsor: &'a TransferBatchSponsor,
+    pub settings: &'a TransferBatchSettings,
+}
+
+impl<'a> TransferBatchRuntime<'a> {
+    /// Resolve the RPC endpoint for `chunk.network` and bundle it with the
+    /// sponsor/settings pay-api already resolved at boot.
+    pub fn resolve(
+        chunk: &ValidatedChunk,
+        rpc: &'a RpcClient,
+        networks: &'a std::collections::HashMap<TransferNetwork, String>,
+        sponsor: &'a TransferBatchSponsor,
+        settings: &'a TransferBatchSettings,
+    ) -> Result<Self, TransferBatchError> {
+        let rpc_url = networks
+            .get(&chunk.network)
+            .map(String::as_str)
+            .ok_or_else(|| {
+                TransferBatchError::NetworkNotConfigured(chunk.network.as_str().to_string())
+            })?;
+        Ok(Self {
+            rpc,
+            rpc_url,
+            sponsor,
+            settings,
+        })
+    }
+}
+
+// ── Quote (402) ──────────────────────────────────────────────────────────
+
+/// Resolve live on-chain state for `chunk` and price it. This is the only
+/// I/O `quote` performs: two RPC calls (`getMultipleAccounts` for
+/// destination ATAs, `getLatestBlockhash`).
+pub async fn quote(
+    runtime: &TransferBatchRuntime<'_>,
+    chunk: &ValidatedChunk,
+) -> Result<TransferBatchChallengeBody, TransferBatchError> {
+    let dest_atas: Vec<String> = chunk
+        .transfers
+        .iter()
+        .map(|t| {
+            associated_token_address(&t.recipient, &chunk.coin.mint, &chunk.coin.token_program)
+                .to_string()
+        })
+        .collect();
+    let accounts = runtime
+        .rpc
+        .get_multiple_accounts(runtime.rpc_url, &dest_atas)
+        .await
+        .map_err(TransferBatchError::Rpc)?;
+    let missing_ata_count = accounts.iter().filter(|a| a.is_none()).count();
+
+    let (recent_blockhash, challenge_last_valid_block_height) = runtime
+        .rpc
+        .get_latest_blockhash_with_last_valid_height(runtime.rpc_url)
+        .await
+        .map_err(TransferBatchError::Rpc)?;
+
+    let recipient_amount_raw = chunk.recipient_amount_raw().ok_or_else(|| {
+        TransferBatchError::TransactionMismatch("recipient amount total overflowed u64".to_string())
+    })?;
+
+    let estimated_fee_lamports = runtime.settings.estimated_fee_lamports.saturating_add(
+        (missing_ata_count as u64).saturating_mul(runtime.settings.ata_rent_lamports),
+    );
+
+    let fee_reimbursement_raw = fee_reimbursement_base_units(
+        estimated_fee_lamports,
+        runtime.settings.usd_per_sol,
+        chunk.coin.decimals,
+    )?;
+
+    let total_amount_raw = recipient_amount_raw
+        .checked_add(fee_reimbursement_raw)
+        .ok_or_else(|| {
+            TransferBatchError::TransactionMismatch("total amount overflowed u64".to_string())
+        })?;
+
+    Ok(TransferBatchChallengeBody {
+        batch_id: chunk.batch_id.clone(),
+        chunk_index: chunk.chunk_index,
+        transfer_count: chunk.transfers.len(),
+        recipient_amount_raw: recipient_amount_raw.to_string(),
+        fee_reimbursement_raw: fee_reimbursement_raw.to_string(),
+        total_amount_raw: total_amount_raw.to_string(),
+        estimated_fee_lamports,
+        missing_ata_count,
+        fee_payer: runtime.sponsor.fee_payer_pubkey.to_string(),
+        recent_blockhash,
+        challenge_expires_at: (chrono::Utc::now() + runtime.settings.challenge_ttl).to_rfc3339(),
+        challenge_last_valid_block_height,
+    })
+}
+
+fn fee_reimbursement_base_units(
+    estimated_fee_lamports: u64,
+    usd_per_sol: f64,
+    decimals: u8,
+) -> Result<u64, TransferBatchError> {
+    if !usd_per_sol.is_finite() || usd_per_sol <= 0.0 {
+        return Err(TransferBatchError::SponsorNotConfigured(
+            "push.usdPerSol must be a positive finite number".to_string(),
+        ));
+    }
+    let scale = 10f64.powi(decimals as i32);
+    let raw = ((estimated_fee_lamports as f64 / 1_000_000_000f64) * usd_per_sol * scale).ceil();
+    if !raw.is_finite() || raw < 0.0 || raw > u64::MAX as f64 {
+        return Err(TransferBatchError::SponsorNotConfigured(
+            "computed fee reimbursement is out of range".to_string(),
+        ));
+    }
+    Ok(raw as u64)
+}
+
+// ── Submit (200) ─────────────────────────────────────────────────────────
+
+/// Decode, validate, co-sign, and broadcast a caller-signed chunk
+/// transaction. `prepared_transaction_base64` is the exact bearer
+/// credential produced by `permit::BatchSigningPermit::sign_chunk` for a
+/// gasless chunk (base64 `bincode` of a `Transaction` with `sender`'s
+/// signature present and the fee-payer slot still default/unsigned).
+pub async fn submit(
+    runtime: &TransferBatchRuntime<'_>,
+    chunk: &ValidatedChunk,
+    prepared_transaction_base64: &str,
+) -> Result<TransferBatchResponse, TransferBatchError> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(prepared_transaction_base64.trim())
+        .map_err(|e| TransferBatchError::MalformedCredential(e.to_string()))?;
+    let mut tx: Transaction = bincode::deserialize(&bytes)
+        .map_err(|e| TransferBatchError::MalformedCredential(e.to_string()))?;
+
+    validate_prepared_transaction(chunk, runtime, &tx)?;
+    verify_sender_signature(&tx, &chunk.sender)?;
+
+    if tx
+        .signatures
+        .get(FEE_PAYER_SIGNATURE_INDEX)
+        .copied()
+        .unwrap_or_default()
+        != Signature::default()
+    {
+        return Err(TransferBatchError::FeePayerSlotAlreadySigned);
+    }
+
+    runtime
+        .sponsor
+        .signer
+        .sign_transaction(&mut tx)
+        .await
+        .map_err(|e| TransferBatchError::SigningFailed(e.to_string()))?;
+
+    let signed_bytes =
+        bincode::serialize(&tx).map_err(|e| TransferBatchError::SigningFailed(e.to_string()))?;
+    let signed_b64 = base64::engine::general_purpose::STANDARD.encode(signed_bytes);
+
+    let signature = runtime
+        .rpc
+        .send_raw_transaction(runtime.rpc_url, &signed_b64)
+        .await
+        .map_err(TransferBatchError::Rpc)?;
+    runtime
+        .rpc
+        .confirm_signature(
+            runtime.rpc_url,
+            &signature,
+            runtime.settings.confirm_timeout,
+        )
+        .await
+        .map_err(TransferBatchError::Rpc)?;
+
+    Ok(TransferBatchResponse {
+        batch_id: chunk.batch_id.clone(),
+        chunk_index: chunk.chunk_index,
+        row_ids: chunk.transfers.iter().map(|t| t.row_id).collect(),
+        signature,
+        status: TransferBatchStatus::Confirmed,
+    })
+}
+
+fn verify_sender_signature(tx: &Transaction, sender: &Pubkey) -> Result<(), TransferBatchError> {
+    let index = tx
+        .message
+        .account_keys
+        .iter()
+        .position(|k| k == sender)
+        .ok_or(TransferBatchError::InvalidSenderSignature)?;
+    let signature = tx
+        .signatures
+        .get(index)
+        .ok_or(TransferBatchError::InvalidSenderSignature)?;
+    if *signature == Signature::default() {
+        return Err(TransferBatchError::InvalidSenderSignature);
+    }
+    if !signature.verify(sender.as_ref(), &tx.message_data()) {
+        return Err(TransferBatchError::InvalidSenderSignature);
+    }
+    Ok(())
+}
+
+/// Re-validate every field the chunk requires before a fee-payer signature
+/// is ever produced. Structured like (and kept in sync by hand with)
+/// `pay_core::client::push::permit::BatchSigningPermit::validate_prepared_transaction` —
+/// see the module docs for why the two can't share code.
+fn validate_prepared_transaction(
+    chunk: &ValidatedChunk,
+    runtime: &TransferBatchRuntime<'_>,
+    tx: &Transaction,
+) -> Result<(), TransferBatchError> {
+    let message = &tx.message;
+
+    let actual_fee_payer = *message
+        .account_keys
+        .first()
+        .ok_or_else(|| mismatch("prepared transaction has no accounts"))?;
+    if actual_fee_payer != runtime.sponsor.fee_payer_pubkey {
+        return Err(mismatch(&format!(
+            "fee payer {actual_fee_payer} does not match the configured sponsor {}",
+            runtime.sponsor.fee_payer_pubkey
+        )));
+    }
+
+    let allowed_programs = [
+        program_id(programs::COMPUTE_BUDGET_PROGRAM),
+        program_id(programs::ASSOCIATED_TOKEN_PROGRAM),
+        program_id(programs::TOKEN_PROGRAM),
+        program_id(programs::TOKEN_2022_PROGRAM),
+        program_id(programs::MEMO_PROGRAM),
+    ];
+    for ix in &message.instructions {
+        let pid = account_at(message, ix.program_id_index)?;
+        if !allowed_programs.contains(&pid) {
+            return Err(mismatch(&format!(
+                "instruction uses disallowed program {pid}"
+            )));
+        }
+    }
+
+    let mut cursor = 0usize;
+
+    let price_ix = instruction_at(message, cursor)?;
+    let price = decode_compute_unit_price(message, price_ix)?;
+    if price > runtime.settings.compute_unit_price_micro_lamports {
+        return Err(mismatch(&format!(
+            "compute-unit price {price} exceeds the sponsor's ceiling of {}",
+            runtime.settings.compute_unit_price_micro_lamports
+        )));
+    }
+    cursor += 1;
+
+    let limit_ix = instruction_at(message, cursor)?;
+    let limit = decode_compute_unit_limit(message, limit_ix)?;
+    if limit > runtime.settings.compute_unit_limit {
+        return Err(mismatch(&format!(
+            "compute-unit limit {limit} exceeds the sponsor's ceiling of {}",
+            runtime.settings.compute_unit_limit
+        )));
+    }
+    cursor += 1;
+
+    let source_ata =
+        associated_token_address(&chunk.sender, &chunk.coin.mint, &chunk.coin.token_program);
+
+    for entry in &chunk.transfers {
+        let expected_dest_ata = associated_token_address(
+            &entry.recipient,
+            &chunk.coin.mint,
+            &chunk.coin.token_program,
+        );
+
+        // An idempotent ATA-create instruction is optional: whether the
+        // destination already exists is a live on-chain fact the caller
+        // observed independently at sign time, and idempotent creation is
+        // harmless either way. If present, it must be well-formed and
+        // target exactly this recipient — never trust its presence alone.
+        if let Some(ix) = message.instructions.get(cursor) {
+            let pid = account_at(message, ix.program_id_index)?;
+            if pid == program_id(programs::ASSOCIATED_TOKEN_PROGRAM) {
+                validate_ata_create(
+                    message,
+                    ix,
+                    &runtime.sponsor.fee_payer_pubkey,
+                    &entry.recipient,
+                    &expected_dest_ata,
+                    &chunk.coin.mint,
+                    &chunk.coin.token_program,
+                )?;
+                cursor += 1;
+            }
+        }
+
+        let transfer_ix = instruction_at(message, cursor)?;
+        validate_transfer_checked(
+            message,
+            transfer_ix,
+            &source_ata,
+            &chunk.coin.mint,
+            &expected_dest_ata,
+            &chunk.sender,
+            entry.amount_raw,
+            chunk.coin.decimals,
+        )?;
+        cursor += 1;
+    }
+
+    let memo_ix = instruction_at(message, cursor)?;
+    validate_memo(message, memo_ix, &chunk.memo)?;
+    cursor += 1;
+
+    if cursor != message.instructions.len() {
+        return Err(mismatch(&format!(
+            "prepared transaction has {} unexpected trailing instruction(s)",
+            message.instructions.len() - cursor
+        )));
+    }
+
+    Ok(())
+}
+
+fn mismatch(detail: &str) -> TransferBatchError {
+    TransferBatchError::TransactionMismatch(detail.to_string())
+}
+
+fn program_id(value: &str) -> Pubkey {
+    Pubkey::from_str(value).expect("PayKit program id constants are always valid base58")
+}
+
+fn instruction_at(
+    message: &Message,
+    index: usize,
+) -> Result<&solana_message::compiled_instruction::CompiledInstruction, TransferBatchError> {
+    message
+        .instructions
+        .get(index)
+        .ok_or_else(|| mismatch("prepared transaction is missing an expected instruction"))
+}
+
+fn account_at(message: &Message, index: u8) -> Result<Pubkey, TransferBatchError> {
+    message
+        .account_keys
+        .get(index as usize)
+        .copied()
+        .ok_or_else(|| mismatch("instruction account index out of range"))
+}
+
+fn decode_compute_unit_price(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+) -> Result<u64, TransferBatchError> {
+    let program = account_at(message, ix.program_id_index)?;
+    if program != program_id(programs::COMPUTE_BUDGET_PROGRAM) {
+        return Err(mismatch("expected a compute-unit-price instruction"));
+    }
+    if ix.data.first().copied() != Some(COMPUTE_UNIT_PRICE_DISCRIMINATOR) || ix.data.len() != 9 {
+        return Err(mismatch("malformed compute-unit-price instruction"));
+    }
+    Ok(u64::from_le_bytes(ix.data[1..9].try_into().unwrap()))
+}
+
+fn decode_compute_unit_limit(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+) -> Result<u32, TransferBatchError> {
+    let program = account_at(message, ix.program_id_index)?;
+    if program != program_id(programs::COMPUTE_BUDGET_PROGRAM) {
+        return Err(mismatch("expected a compute-unit-limit instruction"));
+    }
+    if ix.data.first().copied() != Some(COMPUTE_UNIT_LIMIT_DISCRIMINATOR) || ix.data.len() != 5 {
+        return Err(mismatch("malformed compute-unit-limit instruction"));
+    }
+    Ok(u32::from_le_bytes(ix.data[1..5].try_into().unwrap()))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_ata_create(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    fee_payer: &Pubkey,
+    owner: &Pubkey,
+    expected_ata: &Pubkey,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+) -> Result<(), TransferBatchError> {
+    if ix.data != [ATA_CREATE_IDEMPOTENT_DISCRIMINATOR] {
+        return Err(mismatch(
+            "ATA-create instruction is not the idempotent variant",
+        ));
+    }
+    if ix.accounts.len() != 6 {
+        return Err(mismatch("malformed ATA-create instruction"));
+    }
+    let payer = account_at(message, ix.accounts[0])?;
+    let ata = account_at(message, ix.accounts[1])?;
+    let owner_account = account_at(message, ix.accounts[2])?;
+    let mint_account = account_at(message, ix.accounts[3])?;
+    let system_program = account_at(message, ix.accounts[4])?;
+    let token_program_account = account_at(message, ix.accounts[5])?;
+
+    if payer != *fee_payer {
+        return Err(mismatch(
+            "ATA-create is not paid by the sponsor's fee payer",
+        ));
+    }
+    if ata != *expected_ata {
+        return Err(mismatch("ATA-create targets an unexpected address"));
+    }
+    if owner_account != *owner {
+        return Err(mismatch(
+            "ATA-create targets an owner outside the authorized chunk",
+        ));
+    }
+    if mint_account != *mint {
+        return Err(mismatch("ATA-create references the wrong mint"));
+    }
+    if system_program != program_id(programs::SYSTEM_PROGRAM) {
+        return Err(mismatch("ATA-create references the wrong system program"));
+    }
+    if token_program_account != *token_program {
+        return Err(mismatch("ATA-create references the wrong token program"));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_transfer_checked(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    source_ata: &Pubkey,
+    mint: &Pubkey,
+    expected_destination: &Pubkey,
+    authority: &Pubkey,
+    amount_raw: u64,
+    decimals: u8,
+) -> Result<(), TransferBatchError> {
+    let program = account_at(message, ix.program_id_index)?;
+    let is_token = program == program_id(programs::TOKEN_PROGRAM);
+    let is_token_2022 = program == program_id(programs::TOKEN_2022_PROGRAM);
+    if !is_token && !is_token_2022 {
+        return Err(mismatch("expected a Token/Token-2022 transfer instruction"));
+    }
+    if ix.accounts.len() != 4 {
+        return Err(mismatch("malformed transfer_checked instruction"));
+    }
+    if ix.data.len() != 10 || ix.data[0] != TRANSFER_CHECKED_DISCRIMINATOR {
+        return Err(mismatch("expected a transfer_checked instruction"));
+    }
+    let amount = u64::from_le_bytes(ix.data[1..9].try_into().unwrap());
+    let ix_decimals = ix.data[9];
+
+    let source = account_at(message, ix.accounts[0])?;
+    let mint_account = account_at(message, ix.accounts[1])?;
+    let destination = account_at(message, ix.accounts[2])?;
+    let authority_account = account_at(message, ix.accounts[3])?;
+
+    if source != *source_ata {
+        return Err(mismatch(
+            "transfer source ATA does not match the authorized sender",
+        ));
+    }
+    if mint_account != *mint {
+        return Err(mismatch("transfer references the wrong mint"));
+    }
+    if destination != *expected_destination {
+        return Err(mismatch(
+            "transfer destination does not match the authorized chunk",
+        ));
+    }
+    if authority_account != *authority {
+        return Err(mismatch(
+            "transfer authority does not match the authorized sender",
+        ));
+    }
+    if amount != amount_raw {
+        return Err(mismatch(&format!(
+            "transfer amount {amount} does not match the authorized amount {amount_raw}"
+        )));
+    }
+    if ix_decimals != decimals {
+        return Err(mismatch("transfer decimals do not match the mint"));
+    }
+    Ok(())
+}
+
+fn validate_memo(
+    message: &Message,
+    ix: &solana_message::compiled_instruction::CompiledInstruction,
+    expected_memo: &str,
+) -> Result<(), TransferBatchError> {
+    let program = account_at(message, ix.program_id_index)?;
+    if program != program_id(programs::MEMO_PROGRAM) {
+        return Err(mismatch("expected a memo instruction"));
+    }
+    match std::str::from_utf8(&ix.data) {
+        Ok(memo) if memo == expected_memo => Ok(()),
+        Ok(memo) => Err(mismatch(&format!(
+            "memo `{memo}` does not match the authorized memo `{expected_memo}`"
+        ))),
+        Err(_) => Err(mismatch("memo is not valid UTF-8")),
+    }
+}
+
+// Only used to build well-formed test fixtures below; kept internal.
+#[cfg(test)]
+fn compute_unit_price_instruction(micro_lamports: u64) -> solana_instruction::Instruction {
+    let mut data = vec![COMPUTE_UNIT_PRICE_DISCRIMINATOR];
+    data.extend_from_slice(&micro_lamports.to_le_bytes());
+    solana_instruction::Instruction {
+        program_id: program_id(programs::COMPUTE_BUDGET_PROGRAM),
+        accounts: vec![],
+        data,
+    }
+}
+
+#[cfg(test)]
+fn compute_unit_limit_instruction(units: u32) -> solana_instruction::Instruction {
+    let mut data = vec![COMPUTE_UNIT_LIMIT_DISCRIMINATOR];
+    data.extend_from_slice(&units.to_le_bytes());
+    solana_instruction::Instruction {
+        program_id: program_id(programs::COMPUTE_BUDGET_PROGRAM),
+        accounts: vec![],
+        data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stablecoin::TokenProgram;
+    use pay_api_types::transfer_batch::TransferBatchEntry;
+    use pay_kit::mpp::client::{TransferEntry, build_spl_transfer_batch_instructions};
+    use solana_hash::Hash;
+
+    fn coin() -> Stablecoin {
+        Stablecoin {
+            symbol: "USDG".to_string(),
+            mint: Pubkey::new_unique(),
+            token_program: TokenProgram::SplToken.program_id(),
+            decimals: 6,
+        }
+    }
+
+    fn valid_request(sender: &Pubkey, transfers: usize) -> TransferBatchRequest {
+        TransferBatchRequest {
+            batch_id: "a".repeat(BATCH_ID_HEX_LEN),
+            chunk_index: 0,
+            sender: sender.to_string(),
+            currency: "USDG".to_string(),
+            network: TransferNetwork::Localnet,
+            transfers: (0..transfers)
+                .map(|i| TransferBatchEntry {
+                    row_id: i as u64,
+                    recipient: Pubkey::new_unique().to_string(),
+                    amount: "1.5".to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn validate_request_accepts_a_well_formed_chunk() {
+        let sender = Pubkey::new_unique();
+        let request = valid_request(&sender, 3);
+        let chunk = validate_request(&request, &[coin()]).unwrap();
+        assert_eq!(chunk.transfers.len(), 3);
+        assert_eq!(chunk.sender, sender);
+        assert_eq!(chunk.memo, "pay-push:v1:aaaaaaaa:0");
+        assert_eq!(chunk.recipient_amount_raw().unwrap(), 1_500_000 * 3);
+    }
+
+    #[test]
+    fn validate_request_rejects_bad_batch_id_shape() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 1);
+        request.batch_id = "not-hex".to_string();
+        let err = validate_request(&request, &[coin()]).unwrap_err();
+        assert!(matches!(err, TransferBatchError::InvalidBatchId));
+        assert_eq!(err.field(), Some("batchId".to_string()));
+    }
+
+    #[test]
+    fn validate_request_rejects_uppercase_batch_id() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 1);
+        request.batch_id = "A".repeat(BATCH_ID_HEX_LEN);
+        assert!(matches!(
+            validate_request(&request, &[coin()]).unwrap_err(),
+            TransferBatchError::InvalidBatchId
+        ));
+    }
+
+    #[test]
+    fn validate_request_rejects_too_many_transfers() {
+        let sender = Pubkey::new_unique();
+        let request = valid_request(&sender, MAX_TRANSFER_BATCH_TRANSFERS + 1);
+        let err = validate_request(&request, &[coin()]).unwrap_err();
+        assert!(matches!(
+            err,
+            TransferBatchError::TransferCountOutOfBounds { actual } if actual == MAX_TRANSFER_BATCH_TRANSFERS + 1
+        ));
+    }
+
+    #[test]
+    fn validate_request_rejects_empty_transfers() {
+        let sender = Pubkey::new_unique();
+        let request = valid_request(&sender, 0);
+        assert!(matches!(
+            validate_request(&request, &[coin()]).unwrap_err(),
+            TransferBatchError::TransferCountOutOfBounds { actual: 0 }
+        ));
+    }
+
+    #[test]
+    fn validate_request_rejects_unsupported_currency() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 1);
+        request.currency = "NOPE".to_string();
+        let err = validate_request(&request, &[coin()]).unwrap_err();
+        assert!(matches!(err, TransferBatchError::UnsupportedCurrency(c) if c == "NOPE"));
+    }
+
+    #[test]
+    fn validate_request_rejects_invalid_recipient() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 1);
+        request.transfers[0].recipient = "not-a-pubkey".to_string();
+        let err = validate_request(&request, &[coin()]).unwrap_err();
+        assert!(matches!(
+            err,
+            TransferBatchError::InvalidRecipient { index: 0 }
+        ));
+        assert_eq!(err.field(), Some("transfers[0].recipient".to_string()));
+    }
+
+    #[test]
+    fn validate_request_rejects_zero_amount() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 1);
+        request.transfers[0].amount = "0".to_string();
+        assert!(matches!(
+            validate_request(&request, &[coin()]).unwrap_err(),
+            TransferBatchError::InvalidAmount { index: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn validate_request_rejects_duplicate_row_ids() {
+        let sender = Pubkey::new_unique();
+        let mut request = valid_request(&sender, 2);
+        request.transfers[1].row_id = request.transfers[0].row_id;
+        let err = validate_request(&request, &[coin()]).unwrap_err();
+        assert!(matches!(
+            err,
+            TransferBatchError::DuplicateRowId {
+                index: 1,
+                first_index: 0,
+                ..
+            }
+        ));
+    }
+
+    /// A throwaway in-memory keypair wrapped as a `pay_kit` signer, the same
+    /// way both the sponsor and (in real gasless pushes) the CLI's
+    /// `permit::BatchSigningPermit` wrap theirs. The pubkey is sliced
+    /// directly out of the 64-byte Solana keypair layout
+    /// (`secret[0..32] || public[32..64]`) rather than going through the
+    /// `solana_signer::Signer` trait, so tests don't need a direct
+    /// dependency on the `solana-signer` crate just for one accessor.
+    fn fresh_signer() -> (pay_kit::mpp::solana_keychain::Signer, Pubkey) {
+        let keypair = solana_keypair::Keypair::new();
+        let bytes = keypair.to_bytes();
+        let pubkey = Pubkey::new_from_array(bytes[32..64].try_into().unwrap());
+        let json = serde_json::to_string(&bytes.to_vec()).unwrap();
+        let signer = pay_kit::mpp::solana_keychain::Signer::from_memory(&json).unwrap();
+        assert_eq!(signer.pubkey(), pubkey);
+        (signer, pubkey)
+    }
+
+    fn sponsor() -> (TransferBatchSponsor, Pubkey) {
+        let (signer, pubkey) = fresh_signer();
+        (
+            TransferBatchSponsor {
+                fee_payer_pubkey: pubkey,
+                signer: Arc::new(signer),
+            },
+            pubkey,
+        )
+    }
+
+    fn settings() -> TransferBatchSettings {
+        TransferBatchSettings {
+            compute_unit_price_micro_lamports: 10_000,
+            compute_unit_limit: 400_000,
+            estimated_fee_lamports: 10_000,
+            ata_rent_lamports: 2_039_280,
+            usd_per_sol: 150.0,
+            challenge_ttl: ChronoDuration::minutes(2),
+            confirm_timeout: Duration::from_secs(30),
+        }
+    }
+
+    fn unsigned_chunk_transaction(
+        chunk: &ValidatedChunk,
+        fee_payer: &Pubkey,
+        settings: &TransferBatchSettings,
+    ) -> Transaction {
+        let last = chunk.transfers.len() - 1;
+        let entries: Vec<TransferEntry> = chunk
+            .transfers
+            .iter()
+            .enumerate()
+            .map(|(i, t)| TransferEntry {
+                recipient: t.recipient,
+                amount: t.amount_raw,
+                ata_creation_required: false,
+                memo: if i == last {
+                    Some(chunk.memo.clone())
+                } else {
+                    None
+                },
+            })
+            .collect();
+
+        let mut instructions = vec![
+            compute_unit_price_instruction(settings.compute_unit_price_micro_lamports),
+            compute_unit_limit_instruction(settings.compute_unit_limit),
+        ];
+        instructions.extend(
+            build_spl_transfer_batch_instructions(
+                &chunk.sender,
+                &chunk.coin.mint,
+                &chunk.coin.token_program,
+                chunk.coin.decimals,
+                fee_payer,
+                &entries,
+            )
+            .unwrap(),
+        );
+
+        let message =
+            Message::new_with_blockhash(&instructions, Some(fee_payer), &Hash::new_unique());
+        Transaction::new_unsigned(message)
+    }
+
+    /// Build the exact chunk transaction `sender_signer` would produce via
+    /// `permit::BatchSigningPermit::sign_chunk` for a gasless chunk: signed
+    /// as the sending authority, fee-payer slot left default/unsigned.
+    async fn build_signed_chunk_transaction(
+        chunk: &ValidatedChunk,
+        fee_payer: &Pubkey,
+        sender_signer: &pay_kit::mpp::solana_keychain::Signer,
+        settings: &TransferBatchSettings,
+    ) -> Transaction {
+        let mut tx = unsigned_chunk_transaction(chunk, fee_payer, settings);
+        sender_signer.sign_transaction(&mut tx).await.unwrap();
+        tx
+    }
+
+    #[tokio::test]
+    async fn submit_rejects_a_transaction_with_no_sender_signature() {
+        let (_sender_signer, sender) = fresh_signer();
+        let request = valid_request(&sender, 1);
+        let coin = coin();
+        let chunk = validate_request(&request, &[coin]).unwrap();
+
+        let (sponsor, fee_payer) = sponsor();
+        let settings = settings();
+        let tx = unsigned_chunk_transaction(&chunk, &fee_payer, &settings);
+        let bytes = bincode::serialize(&tx).unwrap();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+
+        let rpc = RpcClient::new(Duration::from_secs(1)).unwrap();
+        let networks = std::collections::HashMap::from([(
+            TransferNetwork::Localnet,
+            "http://localhost:1".to_string(),
+        )]);
+        let runtime =
+            TransferBatchRuntime::resolve(&chunk, &rpc, &networks, &sponsor, &settings).unwrap();
+
+        let err = submit(&runtime, &chunk, &b64).await.unwrap_err();
+        assert!(matches!(err, TransferBatchError::InvalidSenderSignature));
+    }
+
+    #[tokio::test]
+    async fn validate_prepared_transaction_accepts_a_faithful_transaction() {
+        let (sender_signer, sender) = fresh_signer();
+        let request = valid_request(&sender, 2);
+        let coin = coin();
+        let chunk = validate_request(&request, &[coin]).unwrap();
+        let (sponsor, fee_payer) = sponsor();
+        let settings = settings();
+
+        let tx =
+            build_signed_chunk_transaction(&chunk, &fee_payer, &sender_signer, &settings).await;
+        let networks = std::collections::HashMap::from([(
+            TransferNetwork::Localnet,
+            "http://localhost:1".to_string(),
+        )]);
+        let rpc = RpcClient::new(Duration::from_secs(1)).unwrap();
+        let runtime =
+            TransferBatchRuntime::resolve(&chunk, &rpc, &networks, &sponsor, &settings).unwrap();
+
+        assert!(validate_prepared_transaction(&chunk, &runtime, &tx).is_ok());
+        assert!(verify_sender_signature(&tx, &chunk.sender).is_ok());
+    }
+
+    #[tokio::test]
+    async fn validate_prepared_transaction_rejects_wrong_fee_payer() {
+        let (sender_signer, sender) = fresh_signer();
+        let request = valid_request(&sender, 1);
+        let coin = coin();
+        let chunk = validate_request(&request, &[coin]).unwrap();
+        let (sponsor, _fee_payer) = sponsor();
+        let settings = settings();
+
+        let other_fee_payer = Pubkey::new_unique();
+        let tx =
+            build_signed_chunk_transaction(&chunk, &other_fee_payer, &sender_signer, &settings)
+                .await;
+        let networks = std::collections::HashMap::from([(
+            TransferNetwork::Localnet,
+            "http://localhost:1".to_string(),
+        )]);
+        let rpc = RpcClient::new(Duration::from_secs(1)).unwrap();
+        let runtime =
+            TransferBatchRuntime::resolve(&chunk, &rpc, &networks, &sponsor, &settings).unwrap();
+
+        let err = validate_prepared_transaction(&chunk, &runtime, &tx).unwrap_err();
+        assert!(err.to_string().contains("fee payer"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn validate_prepared_transaction_rejects_tampered_amount() {
+        let (sender_signer, sender) = fresh_signer();
+        let request = valid_request(&sender, 1);
+        let coin = coin();
+        let chunk = validate_request(&request, std::slice::from_ref(&coin)).unwrap();
+        let (sponsor, fee_payer) = sponsor();
+        let settings = settings();
+
+        // Build against a *different* (higher) amount than what was
+        // validated, simulating a caller trying to smuggle a bigger
+        // transfer past the quoted chunk.
+        let mut tampered = chunk.clone();
+        tampered.transfers[0].amount_raw += 1;
+        let tx =
+            build_signed_chunk_transaction(&tampered, &fee_payer, &sender_signer, &settings).await;
+
+        let networks = std::collections::HashMap::from([(
+            TransferNetwork::Localnet,
+            "http://localhost:1".to_string(),
+        )]);
+        let rpc = RpcClient::new(Duration::from_secs(1)).unwrap();
+        let runtime =
+            TransferBatchRuntime::resolve(&chunk, &rpc, &networks, &sponsor, &settings).unwrap();
+
+        let err = validate_prepared_transaction(&chunk, &runtime, &tx).unwrap_err();
+        assert!(err.to_string().contains("amount"), "{err}");
+    }
+
+    #[test]
+    fn fee_reimbursement_base_units_rejects_non_positive_price() {
+        assert!(fee_reimbursement_base_units(10_000, 0.0, 6).is_err());
+        assert!(fee_reimbursement_base_units(10_000, f64::NAN, 6).is_err());
+    }
+
+    #[test]
+    fn fee_reimbursement_base_units_scales_by_decimals() {
+        // 10_000 lamports = 0.00001 SOL, at $150/SOL = $0.0015, at 6
+        // decimals that's 1_500 raw units (rounded up).
+        let raw = fee_reimbursement_base_units(10_000, 150.0, 6).unwrap();
+        assert_eq!(raw, 1_500);
+    }
+}

--- a/rust/crates/pay-api-types/Cargo.toml
+++ b/rust/crates/pay-api-types/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+schemars = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/rust/crates/pay-api-types/src/lib.rs
+++ b/rust/crates/pay-api-types/src/lib.rs
@@ -6,6 +6,8 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+pub mod transfer_batch;
+
 /// Networks the service can route to.
 ///
 /// Aliases (`mainnet-beta`, `surfpool`, `localnet`) parse to the same variant

--- a/rust/crates/pay-api-types/src/transfer_batch.rs
+++ b/rust/crates/pay-api-types/src/transfer_batch.rs
@@ -1,0 +1,295 @@
+//! Wire contract for the gasless batch-transfer API
+//! (`POST /api/v1/transfer-batches`).
+//!
+//! These are the only definitions of this contract — `pay-api-core` and
+//! `pay-api` import from here rather than redefining a parallel copy. Every
+//! request/response type is `#[serde(deny_unknown_fields)]` and derives
+//! [`schemars::JsonSchema`] so `/api/v1/schemas/*` can serve a generated
+//! schema instead of a hand-maintained one drifting from the real types.
+
+use std::str::FromStr;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// A batch may carry 1..=8 transfers per chunk. Mirrors PayKit's
+/// `mpp::protocol::solana::MAX_SPLITS`: a gasless chunk rides as one MPP
+/// charge whose primary transfer is the fee-payer reimbursement, so every
+/// user payout is a split, and PayKit caps a charge at 8 splits. Duplicated
+/// as a plain constant (rather than a `pay-kit` dependency) because this
+/// crate is the dependency-light wire-contract layer that both the CLI core
+/// and the API server import; `pay-api-core` asserts this stays in sync with
+/// `pay_kit::mpp::protocol::solana::MAX_SPLITS` in its own test suite.
+pub const MIN_TRANSFER_BATCH_TRANSFERS: usize = 1;
+pub const MAX_TRANSFER_BATCH_TRANSFERS: usize = 8;
+
+/// A `batchId` is a BLAKE3 digest of the client's canonical CSV manifest:
+/// 32 bytes, lowercase hex, so exactly 64 characters.
+pub const BATCH_ID_HEX_LEN: usize = 64;
+
+/// Canonical wire network identifier for the gasless batch-transfer API.
+///
+/// Deliberately distinct from the legacy `Network` (`mainnet` | `sandbox`)
+/// used by `/v1/send`: those two enums serve different contracts on
+/// purpose. `Network::Sandbox` conflates "no real cluster" with "localnet",
+/// which would force a USDG *Devnet* batch to lie and claim to be the local
+/// sandbox. `TransferNetwork` has no aliases and no legacy baggage — it is
+/// exactly the three canonical MPP wire slugs (`mainnet`, `devnet`,
+/// `localnet`), matching `pay_kit::mpp::protocol::solana::validate_network`
+/// one-for-one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferNetwork {
+    Mainnet,
+    Devnet,
+    Localnet,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unknown transfer network: {0}")]
+pub struct UnknownTransferNetwork(pub String);
+
+impl TransferNetwork {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Devnet => "devnet",
+            Self::Localnet => "localnet",
+        }
+    }
+}
+
+impl FromStr for TransferNetwork {
+    type Err = UnknownTransferNetwork;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mainnet" => Ok(Self::Mainnet),
+            "devnet" => Ok(Self::Devnet),
+            "localnet" => Ok(Self::Localnet),
+            other => Err(UnknownTransferNetwork(other.to_string())),
+        }
+    }
+}
+
+/// One payout inside a `TransferBatchRequest`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TransferBatchEntry {
+    /// The CSV row identity this transfer settles. Echoed back verbatim in
+    /// the confirmed response so the caller can reconcile against its own
+    /// manifest without re-deriving row order.
+    pub row_id: u64,
+    /// Base58 recipient wallet address.
+    pub recipient: String,
+    /// Decimal amount string, parsed at the resolved mint's decimals
+    /// (e.g. `"1.25"`). Never a raw base-unit integer — the caller doesn't
+    /// need to know the mint's decimals to build this request.
+    pub amount: String,
+}
+
+/// `POST /api/v1/transfer-batches` request body.
+///
+/// One request always represents exactly one previously-packed chunk of a
+/// larger CSV batch: `batchId` identifies the manifest, `chunkIndex`
+/// identifies this chunk within it, and `transfers` is 1..=8 payouts.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TransferBatchRequest {
+    /// 32-byte manifest hash, lowercase hex (64 characters).
+    pub batch_id: String,
+    /// This chunk's position within the batch. Stamped into the on-chain
+    /// memo alongside `batchId` so the settled transaction is
+    /// self-describing.
+    pub chunk_index: u32,
+    /// Base58 sender wallet address — the token authority for every
+    /// transfer in this chunk, and the application-level idempotency key's
+    /// first component (`(sender, batchId, chunkIndex)`).
+    pub sender: String,
+    /// Stablecoin symbol or mint address (e.g. `"USDG"`).
+    pub currency: String,
+    pub network: TransferNetwork,
+    pub transfers: Vec<TransferBatchEntry>,
+}
+
+/// Unauthenticated (402) response: enough structured pricing information for
+/// the caller to decide whether to authorize and sign, without leaking
+/// anything the client couldn't derive itself from a public quote.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferBatchChallengeBody {
+    pub batch_id: String,
+    pub chunk_index: u32,
+    pub transfer_count: usize,
+    /// Sum of the requested payouts, raw base units, as a string (preserves
+    /// u64 precision in JSON).
+    pub recipient_amount_raw: String,
+    /// The primary transfer: one transaction-fee-and-rent reimbursement to
+    /// pay-api's fee payer, converted to the batch's stablecoin and rounded
+    /// up. Raw base units, as a string.
+    pub fee_reimbursement_raw: String,
+    /// `recipientAmountRaw + feeReimbursementRaw`, raw base units, as a
+    /// string.
+    pub total_amount_raw: String,
+    pub estimated_fee_lamports: u64,
+    /// Number of the `transfers` whose destination associated-token-account
+    /// does not exist yet (and is therefore idempotently created, at the
+    /// sender's-batch-reimbursed expense, alongside the transfer).
+    pub missing_ata_count: usize,
+    /// Base58 pay-api fee-payer key — the primary recipient of this charge.
+    pub fee_payer: String,
+    /// Base58-encoded recent blockhash the caller must build its chunk
+    /// transaction against. Required (not just `challenge_last_valid_block_height`)
+    /// because the caller has to compile and sign the exact message this
+    /// blockhash was stamped into — a block height alone isn't enough to
+    /// reconstruct it.
+    pub recent_blockhash: String,
+    /// RFC 3339 UTC timestamp after which this specific challenge can no
+    /// longer be redeemed.
+    pub challenge_expires_at: String,
+    /// Last Solana block height at which the blockhash embedded in this
+    /// challenge remains valid.
+    pub challenge_last_valid_block_height: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferBatchStatus {
+    Confirmed,
+}
+
+/// Authorized (200) response.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferBatchResponse {
+    pub batch_id: String,
+    pub chunk_index: u32,
+    /// The settled row IDs, in the same order as the request's `transfers`.
+    pub row_ids: Vec<u64>,
+    pub signature: String,
+    pub status: TransferBatchStatus,
+}
+
+/// One shared, actionable error shape for every `/api/v1/transfer-batches`
+/// failure.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TransferBatchErrorBody {
+    pub error: TransferBatchErrorDetail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TransferBatchErrorDetail {
+    /// A stable, machine-matchable identifier, e.g. `"duplicate_recipient"`.
+    pub code: String,
+    /// Human-readable detail, safe to display.
+    pub message: String,
+    /// JSON-path-ish pointer to the offending field, e.g.
+    /// `"transfers[3].recipient"`, when the error is field-scoped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Whether an identical retry might succeed without any change to the
+    /// request (e.g. a rate limit or a transient upstream failure).
+    pub retryable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transfer_network_round_trips_canonical_slugs() {
+        for (slug, network) in [
+            ("mainnet", TransferNetwork::Mainnet),
+            ("devnet", TransferNetwork::Devnet),
+            ("localnet", TransferNetwork::Localnet),
+        ] {
+            assert_eq!(slug.parse::<TransferNetwork>().unwrap(), network);
+            assert_eq!(network.as_str(), slug);
+            assert_eq!(
+                serde_json::to_string(&network).unwrap(),
+                format!("\"{slug}\"")
+            );
+        }
+    }
+
+    #[test]
+    fn transfer_network_rejects_legacy_aliases() {
+        // Unlike the legacy `Network` enum, there is no "sandbox" or
+        // "surfpool" alias here — exactly the three canonical MPP slugs.
+        for bad in ["mainnet-beta", "sandbox", "surfpool", "testnet", ""] {
+            assert!(bad.parse::<TransferNetwork>().is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn request_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "batchId": "a".repeat(64),
+            "chunkIndex": 0,
+            "sender": "sender",
+            "currency": "USDG",
+            "network": "mainnet",
+            "transfers": [],
+            "unexpectedField": true,
+        });
+        assert!(serde_json::from_value::<TransferBatchRequest>(value).is_err());
+    }
+
+    #[test]
+    fn request_round_trips_camel_case_wire_shape() {
+        let request = TransferBatchRequest {
+            batch_id: "a".repeat(64),
+            chunk_index: 3,
+            sender: "Sender111111111111111111111111111111111111".to_string(),
+            currency: "USDG".to_string(),
+            network: TransferNetwork::Mainnet,
+            transfers: vec![TransferBatchEntry {
+                row_id: 2,
+                recipient: "Recipient1111111111111111111111111111111111".to_string(),
+                amount: "1.25".to_string(),
+            }],
+        };
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["batchId"], serde_json::json!("a".repeat(64)));
+        assert_eq!(value["chunkIndex"], serde_json::json!(3));
+        assert_eq!(value["transfers"][0]["rowId"], serde_json::json!(2));
+        let round_tripped: TransferBatchRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped.chunk_index, request.chunk_index);
+    }
+
+    #[test]
+    fn error_body_serializes_shared_shape() {
+        let body = TransferBatchErrorBody {
+            error: TransferBatchErrorDetail {
+                code: "duplicate_recipient".to_string(),
+                message: "transfers[3].recipient duplicates transfers[0].recipient".to_string(),
+                field: Some("transfers[3].recipient".to_string()),
+                retryable: false,
+            },
+        };
+        let value = serde_json::to_value(&body).unwrap();
+        assert_eq!(
+            value["error"]["code"],
+            serde_json::json!("duplicate_recipient")
+        );
+        assert_eq!(value["error"]["retryable"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn json_schemas_generate_for_request_and_response() {
+        let request_schema = schemars::schema_for!(TransferBatchRequest);
+        let response_schema = schemars::schema_for!(TransferBatchResponse);
+        assert!(
+            serde_json::to_value(&request_schema)
+                .unwrap()
+                .get("properties")
+                .is_some()
+        );
+        assert!(
+            serde_json::to_value(&response_schema)
+                .unwrap()
+                .get("properties")
+                .is_some()
+        );
+    }
+}

--- a/rust/crates/pay-api/Cargo.toml
+++ b/rust/crates/pay-api/Cargo.toml
@@ -13,6 +13,7 @@ pay-api-core = { path = "../pay-api-core" }
 pay-api-types = { path = "../pay-api-types" }
 
 axum = { workspace = true }
+chrono = { workspace = true }
 figment = { workspace = true, features = ["yaml"] }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }

--- a/rust/crates/pay-api/src/config.rs
+++ b/rust/crates/pay-api/src/config.rs
@@ -4,6 +4,7 @@ use figment::Figment;
 use figment::providers::{Env, Format, Yaml};
 use pay_api_core::StablecoinSpec;
 use pay_api_types::Network;
+use pay_api_types::transfer_batch::TransferNetwork;
 use serde::Deserialize;
 use url::Url;
 
@@ -44,6 +45,14 @@ pub struct Config {
     /// and signs payouts.
     #[serde(default)]
     pub redemption: RedemptionConfig,
+
+    /// `POST /api/v1/transfer-batches` gasless CSV batch-payout
+    /// configuration — `pay push`'s server side. Its own fee-payer block
+    /// rather than reusing `send.fee_payer`, since a dedicated sponsor
+    /// wallet for bulk payouts should be operable (and rate-limited)
+    /// independently of `/v1/send`'s hot wallet.
+    #[serde(default)]
+    pub push: PushConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -119,6 +128,108 @@ impl Default for SendConfig {
             fee_refund_split: FeeRefundSplitConfig::default(),
         }
     }
+}
+
+/// `POST /api/v1/transfer-batches` config. See `pay-api-core`'s
+/// `transfer_batch` module docs for what each pricing/ceiling field feeds
+/// into and which of them are deliberate v1 simplifications (a static
+/// `usdPerSol` rather than a live oracle, a flat `ataRentLamports` rather
+/// than a live rent lookup).
+#[derive(Debug, Deserialize, Clone)]
+pub struct PushConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Per-network RPC URL. Keyed by the canonical MPP wire slug
+    /// (`mainnet` / `devnet` / `localnet`) rather than the legacy two-value
+    /// `Network` enum `send`/`redemption` use — see
+    /// `pay_api_types::transfer_batch::TransferNetwork`'s doc comment for
+    /// why those two enums are deliberately not unified.
+    #[serde(default)]
+    pub networks: HashMap<TransferNetwork, NetworkConfig>,
+
+    /// The wallet that signs as fee payer for every gasless chunk.
+    #[serde(default)]
+    pub fee_payer: FeePayerConfig,
+
+    #[serde(default = "default_push_compute_unit_price_micro_lamports")]
+    pub compute_unit_price_micro_lamports: u64,
+
+    #[serde(default = "default_push_compute_unit_limit")]
+    pub compute_unit_limit: u32,
+
+    /// Base SOL cost (2 signatures) a chunk transaction is expected to
+    /// cost, before any missing-ATA rent.
+    #[serde(default = "default_push_estimated_fee_lamports")]
+    pub estimated_fee_lamports: u64,
+
+    /// Flat per-missing-ATA rent-exemption estimate, in lamports. A live
+    /// `getMinimumBalanceForRentExemption` figure as of this writing for a
+    /// 165-byte SPL Token account.
+    #[serde(default = "default_push_ata_rent_lamports")]
+    pub ata_rent_lamports: u64,
+
+    /// Static, operator-refreshed SOL/USD price used to convert the
+    /// estimated fee into the batch's stablecoin for display in the 402
+    /// quote. Not a live oracle lookup — see the module docs.
+    #[serde(default = "default_push_usd_per_sol")]
+    pub usd_per_sol: f64,
+
+    /// How long a 402 quote's blockhash is expected to remain valid before
+    /// the caller should request a fresh one.
+    #[serde(default = "default_push_challenge_ttl_seconds")]
+    pub challenge_ttl_seconds: i64,
+
+    /// Wall-clock budget to wait for a submitted chunk's `confirmed`
+    /// commitment before `submit` gives up and returns a retryable error.
+    #[serde(default = "default_push_confirm_timeout_seconds")]
+    pub confirm_timeout_seconds: u64,
+}
+
+impl Default for PushConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            networks: HashMap::new(),
+            fee_payer: FeePayerConfig::default(),
+            compute_unit_price_micro_lamports: default_push_compute_unit_price_micro_lamports(),
+            compute_unit_limit: default_push_compute_unit_limit(),
+            estimated_fee_lamports: default_push_estimated_fee_lamports(),
+            ata_rent_lamports: default_push_ata_rent_lamports(),
+            usd_per_sol: default_push_usd_per_sol(),
+            challenge_ttl_seconds: default_push_challenge_ttl_seconds(),
+            confirm_timeout_seconds: default_push_confirm_timeout_seconds(),
+        }
+    }
+}
+
+fn default_push_compute_unit_price_micro_lamports() -> u64 {
+    10_000
+}
+
+fn default_push_compute_unit_limit() -> u32 {
+    400_000
+}
+
+fn default_push_estimated_fee_lamports() -> u64 {
+    // 5_000 lamports per ed25519 signature x 2 (sender + sponsor fee payer).
+    10_000
+}
+
+fn default_push_ata_rent_lamports() -> u64 {
+    2_039_280
+}
+
+fn default_push_usd_per_sol() -> f64 {
+    150.0
+}
+
+fn default_push_challenge_ttl_seconds() -> i64 {
+    120
+}
+
+fn default_push_confirm_timeout_seconds() -> u64 {
+    30
 }
 
 /// `/v1/subscriptions/*` config. The cancel handler returns a charge-intent
@@ -873,6 +984,58 @@ impl Config {
             if self.subscriptions.confirm_timeout_seconds == 0 {
                 return Err(ConfigError::Invalid(
                     "subscriptions.confirm_timeout_seconds must be greater than zero".into(),
+                ));
+            }
+        }
+        if self.push.enabled {
+            if self.push.networks.is_empty() {
+                return Err(ConfigError::Invalid(
+                    "push.networks must contain at least one entry when push.enabled is true"
+                        .into(),
+                ));
+            }
+            for (net, nc) in &self.push.networks {
+                if nc.rpc_url.trim().is_empty() {
+                    return Err(ConfigError::Invalid(format!(
+                        "push.networks.{}.rpc_url is empty",
+                        net.as_str()
+                    )));
+                }
+            }
+            if self
+                .push
+                .fee_payer
+                .key_name
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(ConfigError::Invalid(
+                    "push.fee_payer.key_name is required when push.enabled is true".into(),
+                ));
+            }
+            if self
+                .push
+                .fee_payer
+                .pubkey
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(ConfigError::Invalid(
+                    "push.fee_payer.pubkey is required when push.enabled is true".into(),
+                ));
+            }
+            if self.push.usd_per_sol <= 0.0 || !self.push.usd_per_sol.is_finite() {
+                return Err(ConfigError::Invalid(
+                    "push.usd_per_sol must be a positive finite number".into(),
+                ));
+            }
+            if self.push.confirm_timeout_seconds == 0 {
+                return Err(ConfigError::Invalid(
+                    "push.confirm_timeout_seconds must be greater than zero".into(),
                 ));
             }
         }

--- a/rust/crates/pay-api/src/endpoints/mod.rs
+++ b/rust/crates/pay-api/src/endpoints/mod.rs
@@ -5,3 +5,4 @@ pub mod redeem;
 pub mod send;
 pub mod stablecoin_balances;
 pub mod subscriptions;
+pub mod transfer_batches;

--- a/rust/crates/pay-api/src/endpoints/transfer_batches.rs
+++ b/rust/crates/pay-api/src/endpoints/transfer_batches.rs
@@ -1,0 +1,132 @@
+//! `POST /api/v1/transfer-batches`
+//!
+//! Gasless CSV batch payouts — `pay push`'s server side. This handler is
+//! intentionally thin: it parses the HTTP request, resolves which network
+//! runtime to use, and dispatches to `pay_api_core::transfer_batch`'s
+//! `quote`/`submit` for every actual decision (validation, pricing,
+//! instruction-shape checks, signing, broadcasting). See that module's docs
+//! for the full two-step flow and the design decisions behind it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use pay_api_core::Error;
+use pay_api_core::transfer_batch::{
+    TransferBatchError, TransferBatchRuntime, TransferBatchSettings, TransferBatchSponsor, quote,
+    submit, validate_request,
+};
+use pay_api_types::transfer_batch::{TransferBatchRequest, TransferNetwork};
+use tracing::warn;
+
+use crate::config::PushConfig;
+use crate::state::AppState;
+
+const NOT_CONFIGURED_MESSAGE: &str =
+    "set PAY_API_PUSH__ENABLED=true and configure push.fee_payer / push.networks";
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<TransferBatchRequest>,
+) -> Result<Response, ApiError> {
+    let push = state.push.as_ref().ok_or_else(|| {
+        ApiError(TransferBatchError::SponsorNotConfigured(
+            NOT_CONFIGURED_MESSAGE.to_string(),
+        ))
+    })?;
+
+    let chunk = validate_request(&request, &state.stablecoins).map_err(ApiError)?;
+    let runtime = TransferBatchRuntime::resolve(
+        &chunk,
+        &state.rpc,
+        &push.networks,
+        &push.sponsor,
+        &push.settings,
+    )
+    .map_err(ApiError)?;
+
+    match headers.get(AUTHORIZATION) {
+        None => {
+            let body = quote(&runtime, &chunk).await.map_err(ApiError)?;
+            Ok((StatusCode::PAYMENT_REQUIRED, Json(body)).into_response())
+        }
+        Some(header) => {
+            let header_str = header.to_str().map_err(|_| {
+                ApiError(TransferBatchError::MalformedCredential(
+                    "Authorization header is not valid UTF-8".to_string(),
+                ))
+            })?;
+            let credential = header_str
+                .strip_prefix("Bearer ")
+                .unwrap_or(header_str)
+                .trim();
+            let body = submit(&runtime, &chunk, credential)
+                .await
+                .map_err(ApiError)?;
+            Ok((StatusCode::OK, Json(body)).into_response())
+        }
+    }
+}
+
+pub struct ApiError(TransferBatchError);
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status =
+            StatusCode::from_u16(self.0.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        if status.is_server_error() {
+            warn!(error = %self.0, "transfer-batches request failed");
+        }
+        (status, Json(self.0.to_body())).into_response()
+    }
+}
+
+// ── State carried at boot ───────────────────────────────────────────────
+
+/// Cached push settings the api boots with. The sponsor's fee-payer
+/// signer is resolved once here (not per-request) since a batch push
+/// naturally reuses it across many chunks.
+pub struct PushState {
+    pub networks: HashMap<TransferNetwork, String>,
+    pub sponsor: TransferBatchSponsor,
+    pub settings: TransferBatchSettings,
+}
+
+impl PushState {
+    pub async fn from_config(cfg: &PushConfig) -> Result<Self, Error> {
+        let signer = crate::signer::build_fee_payer_signer(
+            &cfg.fee_payer,
+            "push.fee_payer.key_name is missing",
+            "push.fee_payer.pubkey is missing",
+        )
+        .await?;
+        let fee_payer_pubkey = signer.pubkey();
+        let networks = cfg
+            .networks
+            .iter()
+            .map(|(network, nc)| (*network, nc.rpc_url.clone()))
+            .collect();
+
+        Ok(Self {
+            networks,
+            sponsor: TransferBatchSponsor {
+                fee_payer_pubkey,
+                signer,
+            },
+            settings: TransferBatchSettings {
+                compute_unit_price_micro_lamports: cfg.compute_unit_price_micro_lamports,
+                compute_unit_limit: cfg.compute_unit_limit,
+                estimated_fee_lamports: cfg.estimated_fee_lamports,
+                ata_rent_lamports: cfg.ata_rent_lamports,
+                usd_per_sol: cfg.usd_per_sol,
+                challenge_ttl: chrono::Duration::seconds(cfg.challenge_ttl_seconds),
+                confirm_timeout: std::time::Duration::from_secs(cfg.confirm_timeout_seconds),
+            },
+        })
+    }
+}

--- a/rust/crates/pay-api/src/main.rs
+++ b/rust/crates/pay-api/src/main.rs
@@ -57,6 +57,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/v1/subscriptions/cancel",
             post(endpoints::subscriptions::cancel_handler),
         )
+        .route(
+            "/api/v1/transfer-batches",
+            post(endpoints::transfer_batches::handler),
+        )
         .with_state(state)
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http());

--- a/rust/crates/pay-api/src/state.rs
+++ b/rust/crates/pay-api/src/state.rs
@@ -11,6 +11,7 @@ use crate::config::{
     Config, FeePayerConfig, MoonpayConfig, NetworkConfig, SendConfig, SubscriptionsConfig,
 };
 use crate::endpoints::redeem::RedemptionState;
+use crate::endpoints::transfer_batches::PushState;
 
 /// Application state — read-only after construction, so a plain `Arc<AppState>`
 /// is enough; no `RwLock` is needed.
@@ -37,6 +38,9 @@ pub struct AppState {
     /// can't be configured (send disabled, no fee-payer signer, no network, or
     /// no Token-2022 coin).
     pub confidential: HashMap<Network, ConfidentialHandle>,
+    /// Resolved `POST /api/v1/transfer-batches` state. `None` when
+    /// `push.enabled` is false; the handler returns 503 in that case.
+    pub push: Option<PushState>,
 }
 
 impl AppState {
@@ -61,6 +65,12 @@ impl AppState {
 
         let confidential = build_confidential_workers(config, &stablecoins).await;
 
+        let push = if config.push.enabled {
+            Some(PushState::from_config(&config.push).await?)
+        } else {
+            None
+        };
+
         Ok(Self {
             rpc: RpcClient::new(Duration::from_millis(config.rpc_timeout_ms))?,
             networks: config.networks.clone(),
@@ -72,6 +82,7 @@ impl AppState {
             subscriptions_fee_payer,
             redemption,
             confidential,
+            push,
         })
     }
 


### PR DESCRIPTION
## Summary
- Canonical CSV manifest, planner (fee-mode decision, ATA/rent/fee preflight, deterministic packing into 1..=8-transfer chunks), and signing permit that re-validates a chunk before every signature.
- Durable JSONL journal — the fsync-before-broadcast write is structurally required before a broadcast can happen at all (`ChunkBroadcastPermit` is the only value the broadcast step accepts, and the only way to get one is a completed journal write).
- `POST /api/v1/transfer-batches`: a gasless batch-transfer endpoint. Business logic lives in `pay-api-core` (validation, quote/submit flow, structural re-derivation of the prepared transaction from the request's own fields); the `pay-api` handler is a thin parse/call/map-response layer.
- `PushExecutor` (`core::client::push::executor`): the CLI-facing pipeline — instruction batching → transaction encoding/signing → broadcast → journal, bounded by a max-in-flight window (default 32) with one batched signature-status poll per tick instead of one call per signature.
- Bumps the `pay-kit` pin to `a6a00352` for the prepared-transaction builder and batch-instruction helpers this depends on.

## Test plan
- `cargo fmt --check`
- `cargo test --workspace -- --test-threads=1` (full workspace green)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)