### PR TITLE
docs: rename payment channel -> tab in prose

### DIFF
--- a/rust/crates/cli/src/commands/goose.rs
+++ b/rust/crates/cli/src/commands/goose.rs
@@ -107,7 +107,7 @@ pub(crate) fn goose_provider_env(
         ),
         // Goose otherwise makes a second, hidden model request after each of
         // the first few turns to generate a session title. With a paid
-        // provider that request opens and settles its own payment channel.
+        // provider that request opens and settles its own tab.
         (
             GOOSE_DISABLE_SESSION_NAMING_ENV.to_string(),
             "true".to_string(),

--- a/rust/crates/cli/src/commands/mod.rs
+++ b/rust/crates/cli/src/commands/mod.rs
@@ -628,7 +628,7 @@ fn handle_outcome(
             } else {
                 crate::components::print_notice(
                     crate::components::NoticeLevel::Info,
-                    "MPP payment channel required",
+                    "MPP tab required",
                     &format!("Spending limit: {cap_display}"),
                 );
             }

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -1501,7 +1501,7 @@ impl StartCommand {
                         reserve_session_delivery(delivery_state.clone(), body.0)
                     }),
                 )
-                // Payment-channel settle-receipt poll. Payment-channel sessions
+                // Tab settle-receipt poll. Tab sessions
                 // settle out-of-band at idle-close, so (unlike x402) there's no
                 // per-request settlement header — clients poll this for the
                 // on-chain signature to build the receipt URL.
@@ -2640,10 +2640,10 @@ struct SessionDeliveryRequest {
     expires_at: Option<i64>,
 }
 
-/// Payment-channel settle-receipt poll
+/// Tab settle-receipt poll
 /// (`GET /__402/payment-channels/receipt/:channelId`): `{ settledSignature,
 /// finalized }` for a channel. Clients poll this until `settledSignature` is
-/// non-null to render the on-chain receipt URL (payment-channel sessions settle
+/// non-null to render the on-chain receipt URL (tab sessions settle
 /// out-of-band at idle-close, so there's no per-request header).
 fn session_receipt(state: AppState, channel_id: String) -> axum::response::Response {
     let signature = state

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -78,7 +78,7 @@ pub enum RunOutcome {
         resource_url: String,
     },
     /// The server returned 402 with an x402 `upto` (usage-metered) challenge —
-    /// authorize a ceiling via a payment channel; the operator settles the
+    /// authorize a ceiling via a tab; the operator settles the
     /// actual amount after serving.
     X402UptoChallenge {
         challenge: Box<x402::UptoChallenge>,
@@ -694,7 +694,7 @@ pub(crate) fn classify_402_with_preference(
         if is_solana_method {
             debug!(
                 resource = resource_url,
-                "Detected MPP payment-channel challenge (Solana)"
+                "Detected MPP tab challenge (Solana)"
             );
             return RunOutcome::SessionChallenge {
                 challenge: Box::new(challenge.clone()),

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -1,6 +1,6 @@
 //! Session intent client — open channels, sign vouchers, close.
 //!
-//! A session keeps a pre-funded on-chain payment channel open across many API
+//! A session keeps a pre-funded on-chain tab open across many API
 //! calls. Each call consumes a small voucher increment instead of a full
 //! on-chain transaction, making high-frequency AI workloads cheap.
 //!
@@ -70,7 +70,7 @@ impl SessionHandle {
 
     /// Create a handle wrapping an already-opened channel.
     ///
-    /// `channel_id` is the on-chain payment-channel public key — obtained after
+    /// `channel_id` is the on-chain tab public key — obtained after
     /// broadcasting and confirming the open transaction.
     /// `signer` is the session key whose public key was passed as
     /// `authorized_signer` in the open transaction.
@@ -190,7 +190,7 @@ impl SessionHandle {
         })
     }
 
-    /// Build an `Authorization` header for a payment-channel `open` action.
+    /// Build an `Authorization` header for a tab `open` action.
     ///
     /// `open_slot` must come from the challenge's `recentSlot` and
     /// `transaction` must be the base64 open transaction built against the
@@ -253,7 +253,7 @@ impl SessionHandle {
 
 // ── Session open ─────────────────────────────────────────────────────────────
 
-/// Open a payment-channel session from a 402 challenge.
+/// Open a tab session from a 402 challenge.
 ///
 /// Builds the open transaction against the challenge's `recentBlockhash` and
 /// `recentSlot`, prompts for spend authorization, and returns the handle plus
@@ -410,7 +410,7 @@ pub fn open_payment_channel_session_header(
         channel = %open.channel_id,
         deposit,
         voucher_signer = ?voucher_signer,
-        "payment-channel session authorization header ready"
+        "tab session authorization header ready"
     );
 
     Ok((handle, auth_header))

--- a/rust/crates/core/src/client/x402.rs
+++ b/rust/crates/core/src/client/x402.rs
@@ -271,7 +271,7 @@ pub fn parse_upto_accepts(
     pay_kit::x402::client::upto::parse_upto_accepts(headers, body)
 }
 
-/// Build a signed x402 `upto` payment: a payment-channel `open` authorization
+/// Build a signed x402 `upto` payment: a tab `open` authorization
 /// whose deposit is the authorized ceiling. The client signs only the open;
 /// the fee payer co-signs and broadcasts it, and the receiver authorizer signs
 /// settlement for the actual metered amount. Mirrors [`build_payment`] — same

--- a/rust/crates/core/src/server/session.rs
+++ b/rust/crates/core/src/server/session.rs
@@ -7,7 +7,7 @@
 //! # Pull-mode session flow
 //!
 //! ```text
-//! Client sends `open` with deterministic payment-channel fields
+//! Client sends `open` with deterministic tab fields
 //!   │
 //!   ▼
 //! Server validates the fields against the challenge and opens the channel
@@ -196,14 +196,14 @@ impl SessionOperatorRuntime {
         }
 
         let authorized_signer = params.authorized_signer.ok_or_else(|| {
-            Error::Mpp("payment-channel watermark missing authorized signer".to_string())
+            Error::Mpp("tab watermark missing authorized signer".to_string())
         })?;
         let voucher_signature = params.voucher_signature.as_deref().ok_or_else(|| {
-            Error::Mpp("payment-channel watermark missing voucher signature".to_string())
+            Error::Mpp("tab watermark missing voucher signature".to_string())
         })?;
         let signature = decode_voucher_signature(voucher_signature)?;
         let expires_at = params.voucher_expires_at.ok_or_else(|| {
-            Error::Mpp("payment-channel watermark missing voucher expiry".to_string())
+            Error::Mpp("tab watermark missing voucher expiry".to_string())
         })?;
         let instructions = pay_kit::mpp::program::payment_channels::build_settle_instructions(
             &params.channel_id,
@@ -231,12 +231,12 @@ impl SessionOperatorRuntime {
         let signature = handle
             .settle(params.channel_id.to_string(), instructions)
             .await
-            .map_err(|e| Error::Mpp(format!("payment-channel watermark settlement: {e}")))?;
+            .map_err(|e| Error::Mpp(format!("tab watermark settlement: {e}")))?;
         tracing::info!(
             channel_id,
             cumulative = params.settled,
             %signature,
-            "payment-channel watermark broadcast"
+            "tab watermark broadcast"
         );
         Ok(())
     }
@@ -353,18 +353,18 @@ impl SessionOperatorRuntime {
             return Ok(None);
         };
         let channel = solana_pubkey::Pubkey::from_str(channel_id)
-            .map_err(|e| Error::Mpp(format!("invalid payment channel: {e}")))?;
+            .map_err(|e| Error::Mpp(format!("invalid tab: {e}")))?;
         use pay_kit::mpp::program::payment_channels::generated::generated::accounts::Channel;
         use pay_kit::mpp::solana_rpc_client::nonblocking::rpc_client::RpcClient;
         use solana_commitment_config::CommitmentConfig;
         RpcClient::new(rpc_url)
             .get_account_with_commitment(&channel, CommitmentConfig::confirmed())
             .await
-            .map_err(|error| Error::Mpp(format!("failed to fetch payment channel: {error}")))?
+            .map_err(|error| Error::Mpp(format!("failed to fetch tab: {error}")))?
             .value
             .map(|account| {
                 Channel::from_bytes(&account.data)
-                    .map_err(|e| Error::Mpp(format!("failed to decode payment channel: {e}")))
+                    .map_err(|e| Error::Mpp(format!("failed to decode tab: {e}")))
             })
             .transpose()
     }
@@ -388,16 +388,16 @@ impl SessionOperatorRuntime {
             .map(|s| s.pubkey())
             .unwrap_or_else(|| signer.pubkey());
         let rpc_url = self.rpc_url.clone().ok_or_else(|| {
-            Error::Mpp("payment-channel settlement requires an RPC URL".to_string())
+            Error::Mpp("tab settlement requires an RPC URL".to_string())
         })?;
         let payer = params
             .payer
-            .ok_or_else(|| Error::Mpp("payment-channel settlement missing payer".to_string()))?;
+            .ok_or_else(|| Error::Mpp("tab settlement missing payer".to_string()))?;
         let mint = params
             .mint
-            .ok_or_else(|| Error::Mpp("payment-channel settlement missing mint".to_string()))?;
+            .ok_or_else(|| Error::Mpp("tab settlement missing mint".to_string()))?;
         let authorized_signer = params.authorized_signer.ok_or_else(|| {
-            Error::Mpp("payment-channel settlement missing authorized signer".to_string())
+            Error::Mpp("tab settlement missing authorized signer".to_string())
         })?;
         let token_program = spl_token_program();
 
@@ -418,7 +418,7 @@ impl SessionOperatorRuntime {
             (true, None) if params.settled == 0 => None,
             (true, None) => {
                 return Err(Error::Mpp(
-                    "payment-channel settlement missing highest voucher signature".to_string(),
+                    "tab settlement missing highest voucher signature".to_string(),
                 ));
             }
         };
@@ -481,8 +481,8 @@ impl SessionOperatorRuntime {
         let signature = handle
             .settle(channel_id, instructions)
             .await
-            .map_err(|e| Error::Mpp(format!("payment-channel settlement: {e}")))?;
-        wait_for_transaction_confirmed(&rpc_url, &signature, "payment-channel settlement").await?;
+            .map_err(|e| Error::Mpp(format!("tab settlement: {e}")))?;
+        wait_for_transaction_confirmed(&rpc_url, &signature, "tab settlement").await?;
         Ok(Some(signature))
     }
 }
@@ -710,7 +710,7 @@ impl SessionLifecycleRunloop {
                     tracing::warn!(
                         channel_id,
                         error,
-                        "failed to persist payment-channel lifecycle touch"
+                        "failed to persist tab lifecycle touch"
                     );
                 }
                 let _ = response.send(result);
@@ -794,7 +794,7 @@ impl SessionLifecycleRunloop {
             Err(error) => {
                 tracing::warn!(
                     %error,
-                    "failed to enumerate payment channels for lifecycle ownership reconciliation"
+                    "failed to enumerate tabs for lifecycle ownership reconciliation"
                 );
                 return;
             }
@@ -844,7 +844,7 @@ impl SessionLifecycleRunloop {
                 tracing::debug!(
                     channel_id = state.channel_id,
                     %error,
-                    "payment-channel lifecycle ownership changed during reconciliation"
+                    "tab lifecycle ownership changed during reconciliation"
                 );
             }
         }
@@ -872,7 +872,7 @@ impl SessionLifecycleRunloop {
         let states = match self.runtime.channel_store.list_channels().await {
             Ok(states) => states,
             Err(error) => {
-                tracing::warn!(%error, "failed to enumerate payment-channel lifecycle state");
+                tracing::warn!(%error, "failed to enumerate tab lifecycle state");
                 return;
             }
         };
@@ -913,10 +913,10 @@ impl SessionLifecycleRunloop {
             self.runtime.release_capacity(&channel_id);
             match close_result {
                 Ok(SessionCloseResult::Closed { settled }) => {
-                    tracing::info!(channel_id, settled, "operator auto-closed payment channel");
+                    tracing::info!(channel_id, settled, "operator auto-closed tab");
                 }
                 Ok(SessionCloseResult::AlreadyFinalized) => {
-                    tracing::debug!(channel_id, "payment channel already finalized");
+                    tracing::debug!(channel_id, "tab already finalized");
                 }
                 Err(error) => {
                     tracing::warn!(
@@ -928,7 +928,7 @@ impl SessionLifecycleRunloop {
                         tracing::warn!(
                             channel_id,
                             error = %touch_error,
-                            "failed to reschedule payment-channel close"
+                            "failed to reschedule tab close"
                         );
                     }
                 }
@@ -949,7 +949,7 @@ impl SessionLifecycleRunloop {
         let states = match self.runtime.channel_store.list_channels().await {
             Ok(states) => states,
             Err(error) => {
-                tracing::warn!(%error, "failed to enumerate active payment channels");
+                tracing::warn!(%error, "failed to enumerate active tabs");
                 self.next_settlement = Some(now + interval);
                 return;
             }
@@ -1045,7 +1045,7 @@ enum SessionCloseResult {
 /// Holds a [`SessionServer`] backed by an in-memory channel store.  For
 /// production, swap `MemoryChannelStore` with a persistent backend.
 ///
-/// Payment-channel sessions submit a client-signed open transaction that
+/// Tab sessions submit a client-signed open transaction that
 /// PayKit verifies against the challenge, broadcasts, and confirms.
 pub struct SessionMpp {
     server: Arc<SessionServer<Arc<dyn ChannelStore>>>,
@@ -1153,7 +1153,7 @@ impl SessionMpp {
     }
 
     /// Configure the operator signer used to co-sign client-provided
-    /// payment-channel open transactions and to submit close settlement txs.
+    /// tab open transactions and to submit close settlement txs.
     pub fn with_payment_channel_signer(self, signer: Arc<dyn SolanaSigner>) -> Self {
         if let Ok(mut payment_channel_signer) = self.payment_channel_signer.lock() {
             *payment_channel_signer = Some(signer);
@@ -1161,11 +1161,11 @@ impl SessionMpp {
         self
     }
 
-    /// Configure the signer that funds server-opened payment channels.
+    /// Configure the signer that funds server-opened tabs.
     ///
     /// When omitted, the settlement signer is reused for backwards
     /// compatibility. Server-opened client-voucher sessions normally set this
-    /// to a distinct funded payer because the payment-channel program rejects
+    /// to a distinct funded payer because the tab program rejects
     /// `payer == payee`.
     pub fn with_payment_channel_payer_signer(self, signer: Arc<dyn SolanaSigner>) -> Self {
         if let Ok(mut payment_channel_payer_signer) = self.payment_channel_payer_signer.lock() {
@@ -1393,7 +1393,7 @@ impl SessionMpp {
             && (state.sealed || state.close_requested_at.is_some())
         {
             return Err(Error::PaymentRejected(
-                "payment channel close is pending".to_string(),
+                "tab close is pending".to_string(),
             ));
         }
         Ok(())
@@ -1488,9 +1488,9 @@ impl SessionMpp {
 
     /// Process an `Authorization` header containing a [`SessionAction`].
     ///
-    /// For payment-channel `open` actions, the server either co-signs a
+    /// For tab `open` actions, the server either co-signs a
     /// client-provided open transaction or opens the channel itself from its
-    /// configured payment-channel signer, then stores the confirmed channel.
+    /// configured tab signer, then stores the confirmed channel.
     #[tracing::instrument(name = "session_process", skip_all)]
     pub async fn process(&self, auth_header: &str) -> Result<SessionOutcome> {
         let credential = parse_authorization(auth_header)
@@ -1732,7 +1732,7 @@ impl SessionMpp {
             })?;
         if state.sealed || state.close_requested_at.is_some() {
             return Err(Error::PaymentRejected(
-                "payment channel close is pending".to_string(),
+                "tab close is pending".to_string(),
             ));
         }
         // A record with no binding at all is not a mismatch: it either
@@ -1842,7 +1842,7 @@ fn spl_token_program() -> solana_pubkey::Pubkey {
 }
 
 /// Decode a client-built open transaction. Delegates to the shared
-/// payment-channels decoder, which accepts both legacy (pay Rust client) and v0
+/// tabs decoder, which accepts both legacy (pay Rust client) and v0
 /// versioned (canonical pay-kit JS client) wire formats.
 fn decode_base64_transaction(
     tx_base64: &str,

--- a/rust/crates/core/src/server/session_metering.rs
+++ b/rust/crates/core/src/server/session_metering.rs
@@ -1,4 +1,4 @@
-//! Integer metering primitives for payment-channel sessions.
+//! Integer metering primitives for tab sessions.
 //!
 //! This module is intentionally pure: it has no HTTP, provider, clock, or
 //! voucher dependencies. The proxy can feed it provider-specific observations

--- a/rust/crates/core/src/server/telemetry.rs
+++ b/rust/crates/core/src/server/telemetry.rs
@@ -38,7 +38,7 @@ pub fn record_metric_baselines() {
         channel_kind = "payment_channel",
         verification = "account_confirmed",
         metric = METRIC_PAYMENT_CHANNELS_OPENED,
-        "payment-channel open confirmed",
+        "tab open confirmed",
     );
     for retryable in [true, false] {
         tracing::info!(
@@ -406,12 +406,12 @@ pub fn record_payment_channel_closed(signature: &str, channel: &str) {
         monotonic_counter.pay_payment_channels_closed_total = 1_u64,
         protocol = "mpp/session",
         metric = METRIC_PAYMENT_CHANNELS_CLOSED,
-        "payment-channel settlement confirmed",
+        "tab settlement confirmed",
     );
     tracing::info!(
         signature = %signature,
         channel = %channel,
-        "payment-channel settlement details",
+        "tab settlement details",
     );
 }
 
@@ -429,7 +429,7 @@ pub fn record_payment_channel_opened(
         channel_kind = "payment_channel",
         verification = "account_confirmed",
         metric = METRIC_PAYMENT_CHANNELS_OPENED,
-        "payment-channel open confirmed",
+        "tab open confirmed",
     );
     tracing::info!(
         gauge.pay_payment_channel_escrowed_base_units = escrowed,
@@ -438,19 +438,19 @@ pub fn record_payment_channel_opened(
         network,
         protocol = "mpp/session",
         metric = METRIC_PAYMENT_CHANNEL_ESCROWED,
-        "payment-channel escrow confirmed",
+        "tab escrow confirmed",
     );
     tracing::info!(
         gauge.pay_payment_channel_client = 1_u64,
         client_id,
         protocol = "mpp/session",
         metric = METRIC_PAYMENT_CHANNEL_CLIENT,
-        "payment-channel client confirmed",
+        "tab client confirmed",
     );
     tracing::info!(
         signature = %signature,
         channel = %channel,
-        "payment-channel open details",
+        "tab open details",
     );
 }
 
@@ -471,7 +471,7 @@ pub fn record_payment_channel_voucher_cumulative(
         network,
         protocol = "mpp/session",
         metric = METRIC_PAYMENT_CHANNEL_VOUCHER_CUMULATIVE,
-        "payment-channel voucher persisted",
+        "tab voucher persisted",
     );
 }
 

--- a/rust/crates/core/tests/surfpool_tests.rs
+++ b/rust/crates/core/tests/surfpool_tests.rs
@@ -466,7 +466,7 @@ async fn push_session_full_flow() {
     // The final session wire makes the server the broadcaster of the client's
     // open transaction: `process_open` re-broadcasts the payload transaction
     // and verifies the resulting on-chain channel account. Surfpool cannot run
-    // the payment-channels program, so this test fronts the session server
+    // the tabs program, so this test fronts the session server
     // with a canned JSON-RPC endpoint (the same pattern as pay-kit's own
     // full-path open tests) while everything above it — pay's payment
     // middleware, the challenge binding, the real client-side opener,

--- a/rust/crates/pay-api-core/src/channel_state.rs
+++ b/rust/crates/pay-api-core/src/channel_state.rs
@@ -1,4 +1,4 @@
-//! Fetch and decode an MPP payment-channel account.
+//! Fetch and decode an MPP tab account.
 //!
 //! The Channel struct (auto-generated from the on-chain IDL) is laid out as:
 //!
@@ -82,7 +82,7 @@ impl ChannelStatus {
 }
 
 /// Resolve the channel account among a set of candidate addresses by querying
-/// the cluster for whichever one is owned by the payment-channels program.
+/// the cluster for whichever one is owned by the tabs program.
 ///
 /// `candidates` is typically the `accounts` list of the program instruction —
 /// we don't know which slot holds the channel PDA without the IDL, so we let

--- a/rust/crates/pay-api-core/src/receipt.rs
+++ b/rust/crates/pay-api-core/src/receipt.rs
@@ -27,7 +27,7 @@ use crate::token_metadata::{TokenMetadata, resolve_mints};
 pub const MEMO_PROGRAM: &str = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
 /// Original SPL memo program v1 (still observed on-chain).
 pub const MEMO_PROGRAM_V1: &str = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo";
-/// MPP payment-channels program. Re-exported from pay-kit so the receipt
+/// MPP tabs program. Re-exported from pay-kit so the receipt
 /// classifier always matches the deployed program id instead of drifting from a
 /// hand-copied constant.
 pub use pay_kit::core::payment_channels::PAYMENT_CHANNELS_PROGRAM_ID as PAYMENT_CHANNELS_PROGRAM;
@@ -480,7 +480,7 @@ pub fn build_receipt_skeleton(
     if transfers.is_empty() {
         // Some RPCs (e.g. Surfpool) return inner SPL transfers *unparsed*, so the
         // instruction walk finds nothing. Fall back to the net token-balance
-        // deltas the RPC always reports, so CPI-driven transfers — payment-channel
+        // deltas the RPC always reports, so CPI-driven transfers — tab
         // settle/distribute in particular — still surface instead of an empty receipt.
         transfers = extract_transfers_from_balances(rpc_value, stablecoins);
         balance_fallback_count = transfers.len();
@@ -1078,7 +1078,7 @@ fn extract_token_transfers(
 ///
 /// Used as a fallback when instruction-based extraction finds nothing — e.g.
 /// when the RPC returns inner SPL transfers unparsed (Surfpool does this for
-/// payment-channel settle/distribute CPIs). Balance deltas are always reported,
+/// tab settle/distribute CPIs). Balance deltas are always reported,
 /// so credits are paired against debits of the same mint instead of attributing
 /// every credit to one transaction-wide sender.
 fn extract_transfers_from_balances(
@@ -1858,7 +1858,7 @@ fn amount_from(raw: u128, sample: Option<&ReceiptTransfer>) -> Option<ReceiptAmo
     })
 }
 
-/// Heuristic channel discovery: scan the payment-channels instruction for an
+/// Heuristic channel discovery: scan the tabs instruction for an
 /// account that is not the fee-payer or a well-known program / sysvar.
 fn extract_session_channel(
     top: &[Value],

--- a/rust/crates/pay-api-types/src/lib.rs
+++ b/rust/crates/pay-api-types/src/lib.rs
@@ -102,7 +102,7 @@ pub struct Receipt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription: Option<ReceiptSubscription>,
     /// Programs invoked at the top level. Useful for callers that want to
-    /// surface "via payment-channels" / "memo" badges without re-parsing.
+    /// surface "via tabs" / "memo" badges without re-parsing.
     pub programs: Vec<String>,
     /// New SPL token accounts that were created in this transaction. Each
     /// entry costs the sender ~0.00204 SOL of rent so the UI can surface it.
@@ -159,7 +159,7 @@ pub struct ReceiptIntent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
     /// The on-chain program backing the intent when one applies
-    /// (payment-channels, multi-delegator).
+    /// (tabs, multi-delegator).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub program_id: Option<String>,
 }
@@ -182,7 +182,7 @@ pub enum ReceiptIntentKind {
     Transfer,
 }
 
-/// Lifecycle state of the underlying payment-channel account.
+/// Lifecycle state of the underlying tab account.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ChannelStatus {

--- a/rust/crates/pay-worker/README.md
+++ b/rust/crates/pay-worker/README.md
@@ -1,6 +1,6 @@
 # pay-worker
 
-Operator maintenance jobs for pay-kit payment-channel deployments.
+Operator maintenance jobs for pay-kit tab deployments.
 
 The crate ships two binaries:
 
@@ -8,7 +8,7 @@ The crate ships two binaries:
 - **`settle-sessions`** scans durable Redis session vouchers, compares them to
   on-chain state, and batches both newer watermarks and due idle closes.
 
-`close-channels` closes a list of on-chain payment channels (the MPP payment-channels program,
+`close-channels` closes a list of on-chain tabs (the MPP tabs program,
 `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX`) by driving each through the
 program's adaptive state machine, signing with a GCP-KMS-backed fee payer.
 
@@ -120,7 +120,7 @@ channel's **open** (creation) transaction:
 1. `getSignaturesForAddress(channel)`, paginated to the OLDEST signature — that
    is the `open`.
 2. `getTransaction(sig, base64)`, bincode-decoded; find the instruction whose
-   program id is the payment-channels program and whose `data[0] == 1` (the
+   program id is the tabs program and whose `data[0] == 1` (the
    `open` discriminator).
 3. The `open` ix data is `[disc(1)][salt(8)][deposit(8)][grace(4)][open_slot(8)][count(4)][entries(count×34)]`.
    The preimage = `ix_data[29..]` = `count || entries` (each entry =
@@ -145,7 +145,7 @@ The empty-plan case works naturally: `count = 0` → preimage = the 4 bytes
   overridable via `JOBS_TREASURY_OWNER`.
 - token program resolved from the mint account's owner (SPL Token vs Token-2022).
 - `event_authority` = PDA(`["event_authority"]`, program); `self_program` = the
-  payment-channels program id.
+  tabs program id.
 
 ## Example invocations
 

--- a/rust/crates/pay-worker/config/default.yaml
+++ b/rust/crates/pay-worker/config/default.yaml
@@ -20,7 +20,7 @@ networks:
   sandbox:
     rpc_url: "https://402.surfnet.dev"
 
-# Owner of the treasury ATA the payment-channels program pays protocol fees to.
+# Owner of the treasury ATA the tabs program pays protocol fees to.
 # Mainnet value baked into the deployed program. Overridable per-network via
 # JOBS_TREASURY_OWNER for non-mainnet deployments.
 treasury_owner: "Cs2zdfUNonRdRGsiZUQQLdTxzxVvJZmgiX2mpLYKuEqP"

--- a/rust/crates/pay-worker/src/bin/close_channels.rs
+++ b/rust/crates/pay-worker/src/bin/close_channels.rs
@@ -1,7 +1,7 @@
 //! `close-channels` — operator maintenance job.
 //!
-//! Given a list of payment-channel addresses, advance each toward closure via
-//! the payment-channels program's adaptive state machine, signing with a
+//! Given a list of tab addresses, advance each toward closure via
+//! the tabs program's adaptive state machine, signing with a
 //! GCP-KMS-backed fee payer.
 //!
 //! SAFETY: `DRY_RUN` defaults to `true`. Nothing is signed or sent unless

--- a/rust/crates/pay-worker/src/bin/settle_sessions.rs
+++ b/rust/crates/pay-worker/src/bin/settle_sessions.rs
@@ -1,4 +1,4 @@
-//! Reconcile durable MPP sessions with on-chain payment channels.
+//! Reconcile durable MPP sessions with on-chain tabs.
 //!
 //! Proxies persist each accepted cumulative voucher and a minute-bucketed idle
 //! deadline in Redis. This worker continuously pushes newer watermarks and
@@ -1540,7 +1540,7 @@ mod tests {
         state.open_slot = None;
         assert!(
             !channel_close_due(&state, 120_000),
-            "pull sessions do not have payment channels to close"
+            "pull sessions do not have tabs to close"
         );
     }
 

--- a/rust/crates/pay-worker/src/channel.rs
+++ b/rust/crates/pay-worker/src/channel.rs
@@ -1,5 +1,5 @@
 //! Channel decoding, distribution-preimage recovery, and instruction building
-//! for the payment-channels program.
+//! for the tabs program.
 //!
 //! Reuses pay-kit's Codama-generated [`Channel`] account (borsh-decoded via
 //! `Channel::from_bytes`) and its instruction builders, plus pay-api-core's
@@ -127,7 +127,7 @@ pub async fn discover_distributed_channels(
 }
 
 /// Fetch and borsh-decode a channel account. Returns `Ok(None)` when the
-/// account doesn't exist, isn't owned by the payment-channels program, or
+/// account doesn't exist, isn't owned by the tabs program, or
 /// isn't a decodable `Channel` (e.g. a 1-byte tombstone / `ClosedChannel`).
 pub async fn fetch_channel(
     rpc: &RpcClient,
@@ -239,7 +239,7 @@ async fn find_open_signature(
 }
 
 /// Decode a base64 bincode transaction and return the data bytes of the
-/// instruction whose program id is the payment-channels program and whose
+/// instruction whose program id is the tabs program and whose
 /// discriminator (`data[0]`) is `OPEN_DISCRIMINATOR` (1).
 ///
 /// Decodes as a `VersionedTransaction` so it handles both legacy and v0
@@ -320,7 +320,7 @@ fn decode_recipients(preimage: &[u8]) -> Result<Vec<DistributionEntry>, JobError
 
 // ── Instruction builders ────────────────────────────────────────────────────
 
-/// `event_authority` PDA for the payment-channels program.
+/// `event_authority` PDA for the tabs program.
 pub fn event_authority() -> Pubkey {
     find_event_authority_pda(&default_program_id()).0
 }

--- a/rust/crates/pay-worker/src/config.rs
+++ b/rust/crates/pay-worker/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     /// Supported networks → RPC config.
     pub networks: HashMap<String, NetworkConfig>,
 
-    /// Base58 owner of the treasury ATA the payment-channels program credits
+    /// Base58 owner of the treasury ATA the tabs program credits
     /// protocol fees to. `distribute` checks the treasury ATA against
     /// `ATA(treasury_owner, mint, token_program)`.
     pub treasury_owner: String,

--- a/rust/crates/pay-worker/src/lib.rs
+++ b/rust/crates/pay-worker/src/lib.rs
@@ -1,6 +1,6 @@
-//! Operator maintenance jobs for pay-kit payment-channel deployments.
+//! Operator maintenance jobs for pay-kit tab deployments.
 //!
-//! `close-channels` advances payment channels through closure and rent reclaim;
+//! `close-channels` advances tabs through closure and rent reclaim;
 //! `settle-sessions` reconciles Redis-backed MPP vouchers with on-chain
 //! watermarks. See the crate `README.md`.
 

--- a/rust/crates/pdb/src/correlation.rs
+++ b/rust/crates/pdb/src/correlation.rs
@@ -982,7 +982,7 @@ fn x402_scheme_from_required(encoded: &str) -> Option<String> {
 
 /// Scheme from a base64 `PAYMENT-SIGNATURE` payment envelope — `accepted.scheme`
 /// (canonical x402 v2), a top-level `scheme`, or `upto` inferred from a
-/// payment-channel payload (`channelId`/`profile`).
+/// tab payload (`channelId`/`profile`).
 fn x402_scheme_from_payment(encoded: &str) -> Option<String> {
     let json = decode_json_value(encoded)?;
     if let Some(scheme) = value_string(json.get("accepted").and_then(|a| a.get("scheme"))) {

--- a/rust/crates/types/src/metering.rs
+++ b/rust/crates/types/src/metering.rs
@@ -850,7 +850,7 @@ pub struct SessionSpec {
     /// effective timeout from `close_delay_ms`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_timeout_options_seconds: Option<Vec<u32>>,
-    /// Idle delay before the operator closes and settles the payment channel.
+    /// Idle delay before the operator closes and settles the tab.
     ///
     /// Defaults to `600000` (ten minutes) when omitted. Set to `0` to disable
     /// automatic close.
@@ -863,7 +863,7 @@ pub struct SessionSpec {
     #[serde(default = "default_session_close_batch_interval_ms")]
     pub close_batch_interval_ms: u64,
     /// Interval between operator pushes of the latest accepted cumulative
-    /// watermark to the payment-channel program.
+    /// watermark to the tab program.
     ///
     /// This keeps an active channel open while bounding the amount represented
     /// only by an off-chain voucher. Defaults to `5000` when omitted. Set to
@@ -872,7 +872,7 @@ pub struct SessionSpec {
     #[serde(default = "default_session_settlement_interval_ms")]
     pub settlement_interval_ms: u64,
     /// Channel settlement splits. Session splits are percentage-only and are
-    /// converted to basis points for the payment channel distribution.
+    /// converted to basis points for the tab distribution.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub splits: Vec<SplitRule>,
 }
@@ -1198,7 +1198,7 @@ pub enum Scheme {
 }
 
 impl Scheme {
-    /// Whether this scheme settles through an on-chain payment channel.
+    /// Whether this scheme settles through an on-chain tab.
     ///
     /// Channel/session schemes commit a `distributionSplits` preimage that the
     /// program rejects when it contains duplicate recipients
@@ -2132,7 +2132,7 @@ fn validate_tier_splits(
 /// `challenge_generation_failed` 500 (charge) or an on-chain channel `open`
 /// rejection (session).
 ///
-/// - **Session** endpoints settle through a payment channel whose
+/// - **Session** endpoints settle through a tab whose
 ///   `distributionSplits` preimage rejects duplicate recipients
 ///   (draft-solana-session-00). Uniqueness key: the **recipient account**.
 /// - **Charge** endpoints emit one transfer leg per split and allow a recipient
@@ -2199,7 +2199,7 @@ fn validate_split_recipient_uniqueness(
                     errs.push(format!(
                         "endpoint `{path}`{label}: session payments require unique split \
                          recipients, but account `{account}` (recipient `{}`) appears more than \
-                         once — the on-chain payment channel rejects duplicate `distributionSplits` \
+                         once — the on-chain tab rejects duplicate `distributionSplits` \
                          recipients. Aggregate these into a single split.",
                         split.recipient
                     ));

--- a/rust/playground-api.yaml
+++ b/rust/playground-api.yaml
@@ -62,7 +62,7 @@ recipients:
 # settles and closes the channel.
 #
 # The canonical pay-kit `session()` adapter (and the JS playground client) opens
-# a payment-channel session with the client signing each voucher — the
+# a tab session with the client signing each voucher — the
 # operator only fee-pays/settles. `voucher_signer` defaults to `client`, which
 # matches that, so it's left unset here.
 session:
@@ -191,7 +191,7 @@ endpoints:
   #     # plan_created_at: ...
 
   # ===========================================================================
-  # SESSION — open a payment channel, stream metered deliveries, settle on
+  # SESSION — open a tab, stream metered deliveries, settle on
   # idle-close. TS: stream → session(usd('1.00'), { unitPrice: usd('0.0001') }).
   # Channel cap + close delay come from the top-level `session:` block above;
   # the per-delivery price is the metering dimension here.


### PR DESCRIPTION
Prose and doc-comment rename as part of the org-wide **Payment Channels → Tabs** change.

Verified: `cargo check --workspace --all-targets` passes (exit 0).

Only the space- and hyphen-separated English forms are rewritten. Every breaking surface is untouched:

- the HTTP route `/__402/payment-channels/receipt/{channel_id}`
- the `PAY_PAYMENT_CHANNELS_PROGRAM_ID` env var
- the `pay_payment_channels_*` telemetry metrics and the `channel_kind="payment_channel"` label
- all `pay_kit::*::payment_channels` API paths

Note: `apps/docs/public/docs-assets/provider.schema.json` in pay-web-ui is generated from `rust/crates/types/src/metering.rs` doc comments in this repo — regenerate it there after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)