### PR TITLE
fix(pay): inspect and cap merchant-supplied transactions in fetchTransaction

### DIFF
--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -151,7 +151,7 @@ const instructions = await client.pay.createTransfer({ recipient, amount: 1 });
 
 ### Transaction Requests
 
-- **`fetchTransaction(rpc, account, link, options?)`** — Fetch a transaction from a transaction request endpoint.
+- **`fetchTransaction(rpc, account, link, options?)`** — Fetch a transaction from a transaction request endpoint. The merchant-supplied transaction is inspected before it is returned for signing: unsupported versions are rejected, the account may only appear in transfer and memo instructions, and the requested priority fee and compute unit limit are checked against ceilings whenever the account pays the fees (`options.maxPriorityFeeLamports`, default 0.001 SOL; `options.maxComputeUnitLimit`, default 1.4M CU). The returned transaction carries an `inspection` field with the decoded instructions, version, compute unit limit, and maximum priority fee so wallets can display them before signing.
 
 ### Clients
 

--- a/typescript/packages/solana-pay/core/src/fetchTransaction.ts
+++ b/typescript/packages/solana-pay/core/src/fetchTransaction.ts
@@ -25,8 +25,8 @@ import {
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
-import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
-import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+import { identifySystemInstruction, SYSTEM_PROGRAM_ADDRESS, SystemInstruction } from '@solana-program/system';
+import { identifyTokenInstruction, TOKEN_PROGRAM_ADDRESS, TokenInstruction } from '@solana-program/token';
 
 import { MEMO_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS } from './constants.js';
 
@@ -52,13 +52,35 @@ const DEFAULT_COMPUTE_UNITS_PER_INSTRUCTION = 200_000;
 
 const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000n;
 
-/** Programs on which `account` is expected to sign in a Solana Pay transaction. */
-const EXPECTED_SIGNER_PROGRAMS: readonly Address[] = [
-    SYSTEM_PROGRAM_ADDRESS,
-    TOKEN_PROGRAM_ADDRESS,
-    TOKEN_2022_PROGRAM_ADDRESS,
-    MEMO_PROGRAM_ADDRESS,
-];
+/**
+ * Whether an instruction referencing the signing account is one it is expected to sign in a
+ * Solana Pay transaction: a SOL or token transfer, or a memo. Everything else — including other
+ * opcodes of the System and Token programs, such as `Assign` or `SetAuthority` — is rejected,
+ * since those can change ownership or authority of the account.
+ */
+function isExpectedAccountInstruction(instruction: Instruction): boolean {
+    if (instruction.programAddress === MEMO_PROGRAM_ADDRESS) return true;
+    if (!instruction.data) return false;
+    const parseable = instruction as Instruction & { data: ReadonlyUint8Array };
+    try {
+        switch (instruction.programAddress) {
+            case SYSTEM_PROGRAM_ADDRESS:
+                return identifySystemInstruction(parseable) === SystemInstruction.TransferSol;
+            case TOKEN_PROGRAM_ADDRESS:
+            case TOKEN_2022_PROGRAM_ADDRESS: {
+                const tokenInstruction = identifyTokenInstruction(parseable);
+                return (
+                    tokenInstruction === TokenInstruction.Transfer ||
+                    tokenInstruction === TokenInstruction.TransferChecked
+                );
+            }
+            default:
+                return false;
+        }
+    } catch {
+        return false;
+    }
+}
 
 /** What a merchant-supplied transaction asks of the account, decoded before it is signed. */
 export interface TransactionInspection {
@@ -130,10 +152,11 @@ function inspectTransactionMessage(message: TransactionMessage): TransactionInsp
 function assertNoUnexpectedAccountUse(instructions: readonly Instruction[], account: Address): void {
     // Signer privileges are transaction-global on Solana: once the account signs the transaction,
     // every instruction referencing the account can act with its signature, regardless of the
-    // role the merchant declared for it. So any reference from an unexpected program is rejected.
+    // role the merchant declared for it. So any reference from an unexpected instruction is
+    // rejected.
     for (const instruction of instructions) {
         const referencesAccount = instruction.accounts?.some(meta => meta.address === account);
-        if (referencesAccount && !EXPECTED_SIGNER_PROGRAMS.includes(instruction.programAddress)) {
+        if (referencesAccount && !isExpectedAccountInstruction(instruction)) {
             throw new FetchTransactionError(
                 `account is a signer on an unexpected instruction for program ${instruction.programAddress}`,
             );

--- a/typescript/packages/solana-pay/core/src/fetchTransaction.ts
+++ b/typescript/packages/solana-pay/core/src/fetchTransaction.ts
@@ -5,9 +5,12 @@ import type {
     CompiledTransactionMessage,
     CompiledTransactionMessageWithLifetime,
     GetLatestBlockhashApi,
+    Instruction,
     ReadonlyUint8Array,
     Rpc,
     Transaction,
+    TransactionMessage,
+    TransactionVersion,
 } from '@solana/kit';
 import {
     address,
@@ -17,9 +20,15 @@ import {
     getBase64Encoder,
     getCompiledTransactionMessageDecoder,
     getTransactionDecoder,
+    getTransactionMessageComputeUnitLimit,
+    getTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
+import { SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+
+import { MEMO_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS } from './constants.js';
 
 /**
  * Thrown when a transaction response can't be fetched.
@@ -28,18 +37,139 @@ export class FetchTransactionError extends Error {
     name = 'FetchTransactionError';
 }
 
+const SUPPORTED_TRANSACTION_VERSIONS: readonly TransactionVersion[] = ['legacy', 0, 1];
+
+/** Default ceiling for the total priority fee the account may be asked to pay (0.001 SOL). */
+export const DEFAULT_MAX_PRIORITY_FEE_LAMPORTS = 1_000_000n;
+
+/** Default ceiling for the compute unit limit (the network maximum). */
+export const DEFAULT_MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+
+const COMPUTE_BUDGET_PROGRAM_ADDRESS = address('ComputeBudget111111111111111111111111111111');
+
+/** Compute units budgeted per instruction when a legacy/v0 transaction sets no explicit limit. */
+const DEFAULT_COMPUTE_UNITS_PER_INSTRUCTION = 200_000;
+
+const MICRO_LAMPORTS_PER_LAMPORT = 1_000_000n;
+
+/** Programs on which `account` is expected to sign in a Solana Pay transaction. */
+const EXPECTED_SIGNER_PROGRAMS: readonly Address[] = [
+    SYSTEM_PROGRAM_ADDRESS,
+    TOKEN_PROGRAM_ADDRESS,
+    TOKEN_2022_PROGRAM_ADDRESS,
+    MEMO_PROGRAM_ADDRESS,
+];
+
+/** What a merchant-supplied transaction asks of the account, decoded before it is signed. */
+export interface TransactionInspection {
+    /** Compute unit limit the transaction requests, explicit or defaulted per network rules. */
+    readonly computeUnitLimit: number;
+    /** The decoded instructions of the transaction message. */
+    readonly instructions: readonly Instruction[];
+    /**
+     * Maximum total priority fee in lamports the fee payer would pay: for legacy/v0, the
+     * ComputeBudget unit price times the compute unit limit; for v1, the message config's
+     * `priorityFeeLamports`.
+     */
+    readonly maxPriorityFeeLamports: bigint;
+    /** The transaction version. */
+    readonly version: TransactionVersion;
+}
+
 /**
- * A compiled transaction with message bytes and signatures.
+ * A compiled transaction with message bytes and signatures, plus the decoded
+ * {@link TransactionInspection} so callers can display what the account is signing.
  */
-export type FetchedTransaction = Transaction;
+export type FetchedTransaction = Transaction & {
+    readonly inspection: TransactionInspection;
+};
+
+/** Options for {@link fetchTransaction}. */
+export interface FetchTransactionOptions {
+    /** Options for `getLatestBlockhash`. */
+    commitment?: Commitment;
+    /**
+     * Reject transactions requesting a compute unit limit above this value when the account
+     * pays the fees. Defaults to {@link DEFAULT_MAX_COMPUTE_UNIT_LIMIT}.
+     */
+    maxComputeUnitLimit?: number;
+    /**
+     * Reject transactions asking the account to pay a total priority fee above this value.
+     * Defaults to {@link DEFAULT_MAX_PRIORITY_FEE_LAMPORTS}.
+     */
+    maxPriorityFeeLamports?: bigint;
+}
+
+function inspectTransactionMessage(message: TransactionMessage): TransactionInspection {
+    const explicitLimit = getTransactionMessageComputeUnitLimit(message);
+    let computeUnitLimit: number;
+    let maxPriorityFeeLamports: bigint;
+    if (message.version === 1) {
+        computeUnitLimit = explicitLimit ?? 0;
+        maxPriorityFeeLamports = message.config?.priorityFeeLamports ?? 0n;
+    } else {
+        const budgetedInstructions = message.instructions.filter(
+            ix => ix.programAddress !== COMPUTE_BUDGET_PROGRAM_ADDRESS,
+        ).length;
+        computeUnitLimit =
+            explicitLimit ??
+            Math.min(budgetedInstructions * DEFAULT_COMPUTE_UNITS_PER_INSTRUCTION, DEFAULT_MAX_COMPUTE_UNIT_LIMIT);
+        const computeUnitPriceMicroLamports = getTransactionMessageComputeUnitPrice(message) ?? 0n;
+        maxPriorityFeeLamports =
+            (computeUnitPriceMicroLamports * BigInt(computeUnitLimit) + MICRO_LAMPORTS_PER_LAMPORT - 1n) /
+            MICRO_LAMPORTS_PER_LAMPORT;
+    }
+    return {
+        computeUnitLimit,
+        instructions: message.instructions,
+        maxPriorityFeeLamports,
+        version: message.version,
+    };
+}
+
+function assertNoUnexpectedAccountUse(instructions: readonly Instruction[], account: Address): void {
+    // Signer privileges are transaction-global on Solana: once the account signs the transaction,
+    // every instruction referencing the account can act with its signature, regardless of the
+    // role the merchant declared for it. So any reference from an unexpected program is rejected.
+    for (const instruction of instructions) {
+        const referencesAccount = instruction.accounts?.some(meta => meta.address === account);
+        if (referencesAccount && !EXPECTED_SIGNER_PROGRAMS.includes(instruction.programAddress)) {
+            throw new FetchTransactionError(
+                `account is a signer on an unexpected instruction for program ${instruction.programAddress}`,
+            );
+        }
+    }
+}
+
+function assertWithinFeeCeilings(inspection: TransactionInspection, options: FetchTransactionOptions): void {
+    const maxPriorityFeeLamports = options.maxPriorityFeeLamports ?? DEFAULT_MAX_PRIORITY_FEE_LAMPORTS;
+    const maxComputeUnitLimit = options.maxComputeUnitLimit ?? DEFAULT_MAX_COMPUTE_UNIT_LIMIT;
+    if (inspection.maxPriorityFeeLamports > maxPriorityFeeLamports) {
+        throw new FetchTransactionError(
+            `priority fee of ${inspection.maxPriorityFeeLamports} lamports exceeds maximum of ${maxPriorityFeeLamports} lamports`,
+        );
+    }
+    if (inspection.computeUnitLimit > maxComputeUnitLimit) {
+        throw new FetchTransactionError(
+            `compute unit limit of ${inspection.computeUnitLimit} exceeds maximum of ${maxComputeUnitLimit}`,
+        );
+    }
+}
 
 /**
  * Fetch a transaction from a Solana Pay transaction request link.
  *
+ * The merchant-supplied transaction is inspected before it is returned for signing: unsupported
+ * transaction versions are rejected, the account may only be a signer on transfer and memo
+ * instructions, and — whenever the account pays the fees — the requested priority fee and compute
+ * unit limit are checked against configurable ceilings. The decoded instructions, version, and
+ * maximum priority fee are returned on the transaction's `inspection` field so wallets can
+ * display them before signing.
+ *
  * @param rpc - An RPC client supporting `getLatestBlockhash`.
  * @param account - Address of the account that may sign the transaction.
  * @param link - `link` in the [Solana Pay spec](https://github.com/solana-foundation/pay/blob/main/typescript/packages/solana-pay/spec/SPEC.md#link).
- * @param options - Options for `getLatestBlockhash`.
+ * @param options - Fee ceilings and options for `getLatestBlockhash`.
  *
  * @throws {FetchTransactionError}
  */
@@ -47,8 +177,9 @@ export async function fetchTransaction(
     rpc: Rpc<GetLatestBlockhashApi>,
     account: Address,
     link: URL | string,
-    { commitment }: { commitment?: Commitment } = {},
+    options: FetchTransactionOptions = {},
 ): Promise<FetchedTransaction> {
+    const { commitment } = options;
     let response: Response;
     try {
         response = await fetch(String(link), {
@@ -99,6 +230,13 @@ export async function fetchTransaction(
         throw new FetchTransactionError('failed to decode compiled transaction message');
     }
 
+    if (!SUPPORTED_TRANSACTION_VERSIONS.includes(compiledMessage.version)) {
+        throw new FetchTransactionError(`unsupported transaction version: ${compiledMessage.version}`);
+    }
+
+    const message = decompileTransactionMessage(compiledMessage);
+    const inspection = inspectTransactionMessage(message);
+
     // Extract signatures map
     const signatures = transaction.signatures;
     const signerAddresses = Object.keys(signatures).map(addr => address(addr));
@@ -107,6 +245,17 @@ export async function fetchTransaction(
         const sig = signatures[addr];
         return sig != null && !sig.every((b: number) => b === 0);
     });
+
+    const accountSignature = signatures[account];
+    const accountMustSign = !hasSignatures || (accountSignature != null && accountSignature.every(b => b === 0));
+    if (accountMustSign) {
+        assertNoUnexpectedAccountUse(inspection.instructions, account);
+    }
+
+    const accountPaysFees = !hasSignatures || (accountMustSign && compiledMessage.staticAccounts[0] === account);
+    if (accountPaysFees) {
+        assertWithinFeeCeilings(inspection, options);
+    }
 
     if (hasSignatures) {
         const feePayer = signerAddresses[0];
@@ -138,22 +287,20 @@ export async function fetchTransaction(
                 // If the only signature needed is for `account`, refresh the blockhash
                 if (signerAddresses.length === 1) {
                     const { value } = await rpc.getLatestBlockhash({ commitment }).send();
-                    const msg = decompileTransactionMessage(compiledMessage);
-                    const updatedMsg = setTransactionMessageLifetimeUsingBlockhash(value, msg);
-                    return compileTransaction(updatedMsg);
+                    const updatedMsg = setTransactionMessageLifetimeUsingBlockhash(value, message);
+                    return { ...compileTransaction(updatedMsg), inspection };
                 }
             } else {
                 throw new FetchTransactionError('missing signature');
             }
         }
 
-        return transaction;
+        return { ...transaction, inspection };
     } else {
         // Ignore the fee payer and recent blockhash in the transaction and initialize them.
         const { value } = await rpc.getLatestBlockhash({ commitment }).send();
-        const msg = decompileTransactionMessage(compiledMessage);
-        const withFeePayer = setTransactionMessageFeePayer(account, msg);
+        const withFeePayer = setTransactionMessageFeePayer(account, message);
         const withLifetime = setTransactionMessageLifetimeUsingBlockhash(value, withFeePayer);
-        return compileTransaction(withLifetime);
+        return { ...compileTransaction(withLifetime), inspection };
     }
 }

--- a/typescript/packages/solana-pay/core/src/plugins/wallet.ts
+++ b/typescript/packages/solana-pay/core/src/plugins/wallet.ts
@@ -1,6 +1,5 @@
 import type {
     Address,
-    Commitment,
     GetAccountInfoApi,
     GetLatestBlockhashApi,
     GetMultipleAccountsApi,
@@ -10,7 +9,7 @@ import type {
 import type { ClientWithPayer, ClientWithRpc } from '@solana/plugin-interfaces';
 
 import { createTransfer } from '../createTransfer.js';
-import type { FetchedTransaction } from '../fetchTransaction.js';
+import type { FetchedTransaction, FetchTransactionOptions } from '../fetchTransaction.js';
 import { fetchTransaction } from '../fetchTransaction.js';
 import type { TransactionRequestURL, TransferRequestURL } from '../parseURL.js';
 import { parseURL } from '../parseURL.js';
@@ -28,7 +27,7 @@ export interface SolanaPayWalletMethods {
         fetchTransaction(
             account: Address,
             link: URL | string,
-            options?: { commitment?: Commitment },
+            options?: FetchTransactionOptions,
         ): Promise<FetchedTransaction>;
     };
 }
@@ -60,7 +59,7 @@ export function solanaPayWallet() {
             async fetchTransaction(
                 account: Address,
                 link: URL | string,
-                options?: { commitment?: Commitment },
+                options?: FetchTransactionOptions,
             ): Promise<FetchedTransaction> {
                 return await fetchTransaction(client.rpc, account, link, options);
             },

--- a/typescript/packages/solana-pay/core/test/fetchTransactionInspection.test.ts
+++ b/typescript/packages/solana-pay/core/test/fetchTransactionInspection.test.ts
@@ -15,7 +15,8 @@ import {
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
-import { getTransferSolInstruction } from '@solana-program/system';
+import { getAssignInstruction, getTransferSolInstruction } from '@solana-program/system';
+import { AuthorityType, getSetAuthorityInstruction, getTransferCheckedInstruction } from '@solana-program/token';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { fetchTransaction, FetchTransactionError } from '../src/index.js';
@@ -178,6 +179,46 @@ describe('fetchTransaction inspection', () => {
             await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
                 /account is a signer on an unexpected instruction/,
             );
+        });
+
+        it('should reject a System Assign instruction that changes the account owner', async () => {
+            const assignInstruction = getAssignInstruction({
+                account: createNoopSigner(SENDER),
+                programAddress: address('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'),
+            });
+            mockMerchantResponse(buildTx({ instructions: [transferInstruction(), assignInstruction] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /account is a signer on an unexpected instruction/,
+            );
+        });
+
+        it('should reject a token SetAuthority instruction referencing the account', async () => {
+            const setAuthorityInstruction = getSetAuthorityInstruction({
+                owned: RECIPIENT,
+                owner: createNoopSigner(SENDER),
+                authorityType: AuthorityType.AccountOwner,
+                newAuthority: address('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'),
+            });
+            mockMerchantResponse(buildTx({ instructions: [setAuthorityInstruction] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /account is a signer on an unexpected instruction/,
+            );
+        });
+
+        it('should accept a token TransferChecked instruction with the account as authority', async () => {
+            const transferChecked = getTransferCheckedInstruction({
+                source: address('7dHbWXmci3dT1h5tC8S1ZLw6KcDk4chx6Y6bx4dM3f1h'),
+                mint: address('So11111111111111111111111111111111111111112'),
+                destination: address('GfC73miMwXBoRYDn7gvEZVbhM7n6SUHxJb4LdBz2Mfp6'),
+                authority: createNoopSigner(SENDER),
+                amount: 1_000_000n,
+                decimals: 6,
+            });
+            mockMerchantResponse(buildTx({ instructions: [transferChecked] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).resolves.toBeDefined();
         });
 
         it('should accept instructions of unexpected programs that do not reference the account', async () => {

--- a/typescript/packages/solana-pay/core/test/fetchTransactionInspection.test.ts
+++ b/typescript/packages/solana-pay/core/test/fetchTransactionInspection.test.ts
@@ -1,0 +1,237 @@
+import type { Instruction, TransactionVersion, V1TransactionConfig } from '@solana/kit';
+import {
+    AccountRole,
+    address,
+    appendTransactionMessageInstructions,
+    blockhash,
+    compileTransaction,
+    createNoopSigner,
+    createTransactionMessage,
+    getBase64EncodedWireTransaction,
+    pipe,
+    setTransactionMessageComputeUnitLimit,
+    setTransactionMessageComputeUnitPrice,
+    setTransactionMessageConfig,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchTransaction, FetchTransactionError } from '../src/index.js';
+
+const SENDER = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
+const RECIPIENT = address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+const BLOCKHASH = blockhash('4NpjLLnFBqFzwFkRFBauGFYVnijcQhLBSPo9UhbZgqRf');
+const LINK = 'https://example.com/pay';
+
+const originalFetch = globalThis.fetch;
+
+function transferInstruction(): Instruction {
+    return getTransferSolInstruction({
+        source: createNoopSigner(SENDER),
+        destination: RECIPIENT,
+        amount: 1_000_000_000n,
+    });
+}
+
+/** Build a base64 unsigned wire transaction for the given version, instructions, and fee settings. */
+function buildTx({
+    computeUnitLimit,
+    computeUnitPriceMicroLamports,
+    config,
+    instructions = [transferInstruction()],
+    version = 0,
+}: {
+    computeUnitLimit?: number;
+    computeUnitPriceMicroLamports?: bigint;
+    config?: V1TransactionConfig;
+    instructions?: Instruction[];
+    version?: TransactionVersion;
+} = {}): string {
+    const lifetime = { blockhash: BLOCKHASH, lastValidBlockHeight: 100n };
+    if (version === 1) {
+        const msg = pipe(
+            createTransactionMessage({ version: 1 }),
+            m => setTransactionMessageFeePayerSigner(createNoopSigner(SENDER), m),
+            m => setTransactionMessageLifetimeUsingBlockhash(lifetime, m),
+            m => appendTransactionMessageInstructions(instructions, m),
+            m => (config ? setTransactionMessageConfig(config, m) : m),
+        );
+        return getBase64EncodedWireTransaction(compileTransaction(msg));
+    }
+    const msg = pipe(
+        createTransactionMessage({ version }),
+        m => setTransactionMessageFeePayerSigner(createNoopSigner(SENDER), m),
+        m => setTransactionMessageLifetimeUsingBlockhash(lifetime, m),
+        m => appendTransactionMessageInstructions(instructions, m),
+        m =>
+            computeUnitPriceMicroLamports != null
+                ? setTransactionMessageComputeUnitPrice(computeUnitPriceMicroLamports, m)
+                : m,
+        m => (computeUnitLimit != null ? setTransactionMessageComputeUnitLimit(computeUnitLimit, m) : m),
+    );
+    return getBase64EncodedWireTransaction(compileTransaction(msg));
+}
+
+function mockMerchantResponse(base64Tx: string) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ transaction: base64Tx }),
+    });
+}
+
+function createMockRpc() {
+    return {
+        getLatestBlockhash: () => ({
+            send: vi.fn().mockResolvedValue({
+                value: { blockhash: BLOCKHASH, lastValidBlockHeight: 100n },
+            }),
+        }),
+    } as any;
+}
+
+describe('fetchTransaction inspection', () => {
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    describe('priority fee ceilings', () => {
+        it('should reject a v0 transaction whose priority fee exceeds the default ceiling', async () => {
+            // 10,000,000 micro-lamports/CU × 200,000 CU = 2,000,000 lamports > 1,000,000 default
+            mockMerchantResponse(buildTx({ computeUnitPriceMicroLamports: 10_000_000n, computeUnitLimit: 200_000 }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /priority fee of 2000000 lamports exceeds maximum of 1000000 lamports/,
+            );
+        });
+
+        it('should reject a v1 transaction whose priority fee exceeds the default ceiling', async () => {
+            mockMerchantResponse(
+                buildTx({ version: 1, config: { computeUnitLimit: 200_000, priorityFeeLamports: 2_000_000n } }),
+            );
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /priority fee of 2000000 lamports exceeds maximum of 1000000 lamports/,
+            );
+        });
+
+        it('should apply the default compute unit limit when a v0 transaction sets a price but no limit', async () => {
+            // 10,000,000 micro-lamports/CU × 200,000 defaulted CU (1 budgeted instruction) = 2,000,000 lamports
+            mockMerchantResponse(buildTx({ computeUnitPriceMicroLamports: 10_000_000n }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /priority fee of 2000000 lamports/,
+            );
+        });
+
+        it('should accept a transaction whose priority fee is within a raised ceiling', async () => {
+            mockMerchantResponse(buildTx({ computeUnitPriceMicroLamports: 10_000_000n, computeUnitLimit: 200_000 }));
+
+            const transaction = await fetchTransaction(createMockRpc(), SENDER, LINK, {
+                maxPriorityFeeLamports: 2_000_000n,
+            });
+            expect(transaction.inspection.maxPriorityFeeLamports).toBe(2_000_000n);
+        });
+
+        it('should reject a transaction whose compute unit limit exceeds a configured ceiling', async () => {
+            mockMerchantResponse(buildTx({ computeUnitLimit: 1_000_000 }));
+
+            await expect(
+                fetchTransaction(createMockRpc(), SENDER, LINK, { maxComputeUnitLimit: 400_000 }),
+            ).rejects.toThrow(/compute unit limit of 1000000 exceeds maximum of 400000/);
+        });
+
+        it('should accept a fee-less transfer under the default ceilings', async () => {
+            mockMerchantResponse(buildTx());
+
+            const transaction = await fetchTransaction(createMockRpc(), SENDER, LINK);
+            expect(transaction.inspection.maxPriorityFeeLamports).toBe(0n);
+        });
+    });
+
+    describe('unexpected account signatures', () => {
+        it('should reject when the account signs an instruction of an unexpected program', async () => {
+            const maliciousInstruction: Instruction = {
+                programAddress: address('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'),
+                accounts: [{ address: SENDER, role: AccountRole.WRITABLE_SIGNER }],
+                data: new Uint8Array([1, 2, 3]),
+            };
+            mockMerchantResponse(buildTx({ instructions: [transferInstruction(), maliciousInstruction] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /account is a signer on an unexpected instruction/,
+            );
+        });
+
+        it('should reject when an unexpected program references the account even without a signer role', async () => {
+            // Signer privileges are transaction-global, so a readonly reference still gains the
+            // account's signature at runtime once the account signs the transaction.
+            const readonlyInstruction: Instruction = {
+                programAddress: address('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'),
+                accounts: [{ address: SENDER, role: AccountRole.READONLY }],
+                data: new Uint8Array([1, 2, 3]),
+            };
+            mockMerchantResponse(buildTx({ instructions: [transferInstruction(), readonlyInstruction] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(
+                /account is a signer on an unexpected instruction/,
+            );
+        });
+
+        it('should accept instructions of unexpected programs that do not reference the account', async () => {
+            const unrelatedInstruction: Instruction = {
+                programAddress: address('82ZJ7nbGpixjeDCmEhUcmwXYfvurzAgGdtSMuHnUgyny'),
+                accounts: [{ address: RECIPIENT, role: AccountRole.READONLY }],
+                data: new Uint8Array([1, 2, 3]),
+            };
+            mockMerchantResponse(buildTx({ instructions: [transferInstruction(), unrelatedInstruction] }));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).resolves.toBeDefined();
+        });
+    });
+
+    describe('inspection results', () => {
+        it('should surface instructions, version, and fee details for a v0 transaction', async () => {
+            // 1,000 micro-lamports/CU × 300,000 CU = 300 lamports
+            mockMerchantResponse(buildTx({ computeUnitPriceMicroLamports: 1_000n, computeUnitLimit: 300_000 }));
+
+            const { inspection } = await fetchTransaction(createMockRpc(), SENDER, LINK);
+
+            expect(inspection.version).toBe(0);
+            expect(inspection.computeUnitLimit).toBe(300_000);
+            expect(inspection.maxPriorityFeeLamports).toBe(300n);
+            // Transfer + SetComputeUnitPrice + SetComputeUnitLimit
+            expect(inspection.instructions).toHaveLength(3);
+        });
+
+        it('should surface config-based fee details for a v1 transaction', async () => {
+            mockMerchantResponse(
+                buildTx({ version: 1, config: { computeUnitLimit: 250_000, priorityFeeLamports: 5_000n } }),
+            );
+
+            const { inspection } = await fetchTransaction(createMockRpc(), SENDER, LINK);
+
+            expect(inspection.version).toBe(1);
+            expect(inspection.computeUnitLimit).toBe(250_000);
+            expect(inspection.maxPriorityFeeLamports).toBe(5_000n);
+            expect(inspection.instructions).toHaveLength(1);
+        });
+    });
+
+    describe('unsupported transaction versions', () => {
+        it('should reject wire bytes with an unknown version discriminator', async () => {
+            const validTx = buildTx();
+            const bytes = Uint8Array.from(atob(validTx), c => c.charCodeAt(0));
+            // Unsigned v0 wire layout: [sig count (1)][64-byte zeroed signature][message]. The
+            // message's first byte is the version discriminator: 0x80 | version. 0x82 (v2) is
+            // beyond what the package supports.
+            expect(bytes[65]).toBe(0x80);
+            bytes[65] = 0x82;
+            mockMerchantResponse(btoa(String.fromCharCode(...bytes)));
+
+            await expect(fetchTransaction(createMockRpc(), SENDER, LINK)).rejects.toThrow(FetchTransactionError);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- `fetchTransaction` now inspects the merchant-supplied transaction before it is returned for signing. Unsupported transaction versions are rejected via an explicit allowlist (legacy, v0, v1).
- Whenever the account pays the fees (the unsigned branch, and the signed branch where the account is the zero-signature fee payer), the requested priority fee and compute unit limit are checked against configurable ceilings: `maxPriorityFeeLamports` (default 0.001 SOL) and `maxComputeUnitLimit` (default 1.4M CU). For legacy/v0 the fee is computed from ComputeBudget instructions (price × explicit-or-defaulted limit); for v1 it is read from the message-level `transactionConfig`, so merchant-supplied config no longer rides through the decompile/recompile round trip unchecked.
- Whenever the account must sign, instructions from programs outside the expected set (System, Token, Token-2022, Memo) that reference the account are rejected. The check is reference-based, not signer-role-based, because signer privileges are transaction-global: once the account signs, every instruction referencing it can act with its signature.
- The returned transaction carries a new additive `inspection` field (`instructions`, `version`, `computeUnitLimit`, `maxPriorityFeeLamports`) so integrating wallets can display the maximum fee and full instruction set before signing.

## Test Plan
- `pnpm --filter @solana/pay lint && pnpm --filter @solana/pay typecheck && pnpm --filter @solana/pay test` — 173 tests pass.
- New `test/fetchTransactionInspection.test.ts` covers: over-cap v0 fee (explicit and defaulted CU limit), over-cap v1 `transactionConfig` fee, raised ceilings, over-cap compute unit limit, unexpected program instructions referencing the account (signer and readonly roles), benign unrelated instructions, and an unknown wire version discriminator.

## Breaking Changes
- None intended: `inspection` is additive on the returned object and the ceilings only reject transactions that would previously have silently charged the user. Legitimate transactions above 0.001 SOL priority fee now require callers to pass `maxPriorityFeeLamports` explicitly.

Stacked on #447 (needs kit v8 helpers for the v1 config checks); base is `feature/DEV-1003-kit-v8-v1-transactions` and should be retargeted to `main` after #447 merges.

Closes DEV-1004