### PR TITLE
fix(mcp): align provider guidance with catalog format

### DIFF
--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -157,14 +157,15 @@ a purchase; it only renders the QR PNG and returns the funding address.
 
 Use this when a developer wants to publish a payment-gated API in
 https://github.com/solana-foundation/pay-skills. Pass the complete provider
-markdown file as `content`: YAML frontmatter between `---` delimiters followed
+`PAY.md` file as `content`: YAML frontmatter between `---` delimiters followed
 by optional execution notes. The tool validates required metadata, endpoint
 shape, URL safety, pricing precision, and paid-endpoint expectations.
 
 Before calling, inspect real code, OpenAPI specs, deployed routes, or
 `pay gate api` YAML. Do not invent endpoints, prices, supported networks,
-or payment protocols. If runtime YAML exists, use `pay skills provider sync`
-as a starting point, then validate the generated markdown with this tool.
+or payment protocols. If an OpenAPI document exists, commit a reviewed copy
+beside `PAY.md` and use `openapi: { path: openapi.json }`; public registry
+entries must not depend on a remote OpenAPI URL.
 
 For detailed authoring guidance, use the Pay skill reference
 `references/monetize-api.md`.

--- a/rust/crates/mcp/src/tools/create_skill.rs
+++ b/rust/crates/mcp/src/tools/create_skill.rs
@@ -6,15 +6,15 @@ use std::path::{Component, Path};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Params {
-    /// The full `.md` file content (YAML frontmatter + markdown body).
+    /// The full `PAY.md` file content (YAML frontmatter + markdown body).
     #[schemars(
-        description = "Full .md file content with YAML frontmatter between --- delimiters, followed by markdown body"
+        description = "Full PAY.md file content with YAML frontmatter between --- delimiters, followed by markdown body"
     )]
     pub content: String,
 
     /// Optional path to write the validated file to disk.
     #[schemars(
-        description = "Optional: pay-skills provider path to write after validation. Use providers/<operator>/<name>.md for native APIs or providers/<operator>/<origin>/<name>.md for proxied APIs; filename must match the frontmatter name."
+        description = "Optional: pay-skills provider path to write after validation. Use providers/<operator>/<name>/PAY.md for native APIs or providers/<operator>/<origin>/<name>/PAY.md for proxied APIs; the parent directory must match the frontmatter name."
     )]
     pub output_path: Option<String>,
 }
@@ -74,8 +74,8 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
                             response.push_str(&format!(
                             "\n## Validate before PR\n\n\
                              ```bash\n\
-                             pay skills build . --output /tmp/pay-skills-dist\n\
-                             pay skills probe . --files {path} --currencies USDC,USDT --timeout 15 --concurrency 5\n\
+                             pay catalog check {path} --no-probe\n\
+                             pay catalog check {path} --currencies USDC,USDT --probe-timeout 15 --probe-concurrency 5\n\
                              ```\n"
                         ));
                         }
@@ -93,11 +93,12 @@ pub async fn run(params: Params) -> Result<CallToolResult, rmcp::ErrorData> {
                      ```text\n{}\n```\n\n\
                      3. Run:\n\n\
                      ```bash\n\
-                     pay skills build . --output /tmp/pay-skills-dist\n\
-                     pay skills probe . --files providers/<operator>/{}.md --currencies USDC,USDT --timeout 15 --concurrency 5\n\
+                     pay catalog check providers/<operator>/{}/PAY.md --no-probe\n\
+                     pay catalog check providers/<operator>/{}/PAY.md --currencies USDC,USDT --probe-timeout 15 --probe-concurrency 5\n\
                      ```\n\n\
                      4. Open a PR. CI will validate the YAML and probe changed paid endpoints.\n",
                     recommended_paths(&validated.spec.name),
+                    validated.spec.name,
                     validated.spec.name
                 ));
             }
@@ -199,32 +200,36 @@ fn endpoint_counts(spec: &pay_types::registry::ProviderFrontmatter) -> (usize, u
 }
 
 fn recommended_paths(name: &str) -> String {
-    format!("providers/<operator>/{name}.md\nproviders/<operator>/<origin>/{name}.md")
+    format!("providers/<operator>/{name}/PAY.md\nproviders/<operator>/<origin>/{name}/PAY.md")
 }
 
 fn validate_output_path(path: &str, name: &str) -> Vec<String> {
     let mut errors = Vec::new();
     let path_ref = Path::new(path);
 
-    if path_ref.extension().and_then(|e| e.to_str()) != Some("md") {
-        errors.push("output_path must end in `.md`".to_string());
+    if path_ref.file_name().and_then(|e| e.to_str()) != Some("PAY.md") {
+        errors.push("output_path must end in `PAY.md`".to_string());
     }
 
-    match path_ref.file_stem().and_then(|s| s.to_str()) {
-        Some(stem) if stem == name => {}
-        Some(stem) => errors.push(format!(
-            "filename `{stem}.md` must match frontmatter name `{name}`"
+    match path_ref
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|s| s.to_str())
+    {
+        Some(directory) if directory == name => {}
+        Some(directory) => errors.push(format!(
+            "parent directory `{directory}` must match frontmatter name `{name}`"
         )),
-        None => errors.push("output_path must include a filename".to_string()),
+        None => errors.push("output_path must include a provider directory".to_string()),
     }
 
     let components = normal_components(path_ref);
     match components.iter().position(|c| c == "providers") {
         Some(idx) => {
             let tail_len = components.len().saturating_sub(idx + 1);
-            if tail_len < 2 {
+            if !matches!(tail_len, 3 | 4) {
                 errors.push(
-                    "output_path must be providers/<operator>/<name>.md or providers/<operator>/<origin>/<name>.md"
+                    "output_path must be providers/<operator>/<name>/PAY.md or providers/<operator>/<origin>/<name>/PAY.md"
                         .to_string(),
                 );
             }
@@ -386,21 +391,32 @@ mod tests {
 
     #[test]
     fn output_path_accepts_native_and_proxied_provider_paths() {
-        assert!(validate_output_path("providers/acme/search.md", "search").is_empty());
-        assert!(validate_output_path("providers/acme/google/search.md", "search").is_empty());
+        assert!(validate_output_path("providers/acme/search/PAY.md", "search").is_empty());
+        assert!(validate_output_path("providers/acme/google/search/PAY.md", "search").is_empty());
     }
 
     #[test]
     fn output_path_reports_contributor_path_issues() {
         let errs = validate_output_path("tmp/search.yml", "search");
-        assert!(errs.iter().any(|e| e.contains("`.md`")));
+        assert!(errs.iter().any(|e| e.contains("`PAY.md`")));
         assert!(errs.iter().any(|e| e.contains("providers/")));
 
-        let errs = validate_output_path("providers/acme/wrong.md", "search");
-        assert!(errs.iter().any(|e| e.contains("must match")));
+        let errs = validate_output_path("providers/acme/wrong/PAY.md", "search");
+        assert!(errs.iter().any(|e| e.contains("directory `wrong`")));
 
-        let errs = validate_output_path("providers/search.md", "search");
+        let errs = validate_output_path("providers/search/PAY.md", "search");
         assert!(errs.iter().any(|e| e.contains("providers/<operator>")));
+
+        let errs = validate_output_path("providers/acme/search.md", "search");
+        assert!(errs.iter().any(|e| e.contains("`PAY.md`")));
+    }
+
+    #[test]
+    fn recommended_paths_use_pay_md_layout() {
+        assert_eq!(
+            recommended_paths("search"),
+            "providers/<operator>/search/PAY.md\nproviders/<operator>/<origin>/search/PAY.md"
+        );
     }
 
     #[test]

--- a/skills/pay/references/monetize-api.md
+++ b/skills/pay/references/monetize-api.md
@@ -281,8 +281,8 @@ After the runtime YAML works, add a provider markdown file in the
 `https://github.com/solana-foundation/pay-skills` repository:
 
 ```text
-providers/<operator>/<name>.md
-providers/<operator>/<origin>/<name>.md
+providers/<operator>/<name>/PAY.md
+providers/<operator>/<origin>/<name>/PAY.md
 ```
 
 Use the two-level path when you operate the API directly. Use the three-level
@@ -325,12 +325,13 @@ Use `v1/search` for direct lookup. Include filters in the first request and keep
 - Ask before broad crawls, bulk enrichment, dynamic pricing, or purchases.
 ```
 
-### `openapi:` form (recommended when you serve `/openapi.json`)
+### `openapi:` form (recommended when an OpenAPI document exists)
 
-If your gateway serves `/openapi.json` (see "Serving `/openapi.json`"
-above), drop the inline `endpoints[]` from the registry markdown and point
-`openapi:` at the doc instead. `pay skills build` resolves it at build
-time, walks `paths × methods`, probes each endpoint, and reconstructs
+Fetch and review the OpenAPI document once, trim it to the operations exposed
+through the gateway, and commit it next to `PAY.md`. Drop the inline
+`endpoints[]` from the registry markdown and point `openapi:` at the committed
+sidecar. `pay catalog check` resolves it relative to `PAY.md`, walks
+`paths × methods`, probes each endpoint, and reconstructs
 pricing/protocol/`supported_usd` from the live 402 challenge:
 
 ```markdown
@@ -342,27 +343,24 @@ use_case: "..."
 category: data
 service_url: https://my-api.example.com
 openapi:
-  url: openapi.json
+  path: openapi.json
 ---
 
 ## Usage Notes
 ...
 ```
 
-`openapi:` accepts two forms in the registry:
+`openapi:` accepts two forms in the public registry:
 
-- `openapi: { url: https://my-api.example.com/openapi.json }` —
-  fully-qualified `https://` URL, fetched as-is at build time. This is
-  the recommended form when your gateway exposes `/openapi.json` itself.
+- `openapi: { path: openapi.json }` — a relative path resolved from the
+  directory containing `PAY.md`. Commit the sidecar in that directory. Paths
+  must not be absolute or escape the provider directory.
 - `openapi: { content: | ... }` — inline JSON body via a YAML literal
   block. Useful for small specs that change rarely.
 
-The registry validator requires the `url:` value to be a fully-qualified
-`https://` URL — relative URLs are not accepted because the registry is
-consumed remotely and resolving against `service_url` would be ambiguous.
-`openapi: { path: ... }` is **not** valid in the registry either —
-`path:` is filesystem-only and reserved for `pay gate api --openapi
-<file>`, where the doc is co-located with the YAML on disk.
+`openapi.url` is rejected in the public registry. A remote document can change
+without review and would make builds depend on mutable external state. Fetch it
+for authoring, then commit a reviewed `openapi.json` sidecar instead.
 
 Specs must declare exactly one of `endpoints:` or `openapi:`. Inline
 `endpoints:` is fine for tiny APIs and when you don't have an OpenAPI
@@ -372,15 +370,15 @@ metadata each time the upstream API changes.
 
 ## Frontmatter Best Practices
 
-- `name` must match the filename without `.md`.
+- `name` must match the directory containing `PAY.md`.
 - `title` is the human-readable provider name.
 - `description` is required, 64-255 characters. It should say what the service
   is and what it returns. Do not start it with `Use for`.
 - `use_case` is required, 32-255 characters. Start with `Use for` or `Use when`
   and include task phrases agents will see from users.
 - `category` must be one of the registry categories:
-  `ai_ml analytics cloud compute data devtools finance identity iot maps media
-  messaging other productivity search security storage translation`.
+  `ai_ml cloud compute data devtools finance identity maps media messaging
+  other productivity search security shopping storage translation`.
 - `service_url` must be production HTTPS with a domain name, not localhost or an
   IP address.
 - Add `sandbox_service_url` when available; configure sandbox services to use
@@ -415,49 +413,33 @@ optimize execution and reduce wasted paid calls:
 From a local checkout of `https://github.com/solana-foundation/pay-skills`:
 
 ```sh
-# Static + structural validation; --no-probe skips the network round-trip.
-pay skills build . --output /tmp/pay-skills-dist --no-probe
+# Fast static and structural validation of one provider.
+pay catalog check providers/<operator>/<name>/PAY.md --no-probe
 
-# Probe-driven validation: hit each endpoint, classify, surface the result.
-pay skills probe . \
-  --files providers/<operator>/<name>.md \
+# Probe the provider and calculate the Solana compatibility verdict.
+pay catalog check providers/<operator>/<name>/PAY.md \
   --currencies USDC,USDT \
-  --timeout 15 \
-  --concurrency 5
+  --probe-timeout 15 \
+  --probe-concurrency 5
 
-# Solana-compat gate: warns per non-Solana endpoint, errors when zero
-# classifiable endpoints accept Solana stables.
-pay skills validate . \
-  --files providers/<operator>/<name>.md \
-  --currencies USDC,USDT
+# Run the same changed-provider selection used for local PR preparation.
+pay catalog check . --changed-from origin/main --format github
 ```
 
-`pay skills validate` is the CI gate. Pass `--changed-from origin/main` to
-auto-detect changed providers via git diff, and `--format github` to emit
-`::warning::` / `::error::` workflow-command annotations that surface
-inline on the PR. `--strict` upgrades non-Solana warnings to blocking
-errors when you want zero tolerance.
+`pay catalog check` is the read-only validation command. It parses frontmatter,
+resolves a committed OpenAPI sidecar when present, probes endpoints unless
+`--no-probe` is set, and calculates the Solana compatibility verdict. Use
+`--strict` when every non-Solana endpoint should block. `--format github`
+emits workflow annotations for CI.
 
-If you already have runtime YAML, generate provider markdown from it:
-
-```sh
-pay skills provider sync path/to/*.yml \
-  --operator <operator> \
-  --origin <origin> \
-  --service-url 'https://production-{name}.example.com' \
-  --sandbox-service-url 'https://sandbox-{name}.example.com' \
-  --out providers
-```
-
-The sync command creates a starting point from runtime YAML. Before running
-`pay skills build`, inspect the generated markdown and add registry-only fields
-such as `use_case` plus spend-aware usage notes when they were not present in
-the YAML.
+If you already have runtime YAML, use it as evidence for routes and prices, but
+write the public `PAY.md` in the contributor layout above and validate it with
+`pay catalog check`. Do not publish secrets or unresolved environment values.
 
 ### Partial rebuild on merge
 
-Full rebuilds re-probe every provider and take 5-15 minutes for a registry
-of 30 providers. `pay skills build` accepts `--only` and `--previous-dist`
+Full rebuilds re-probe every provider and take longer as the registry grows.
+`pay catalog build` accepts `--only` and `--previous-dist`
 so a merge-time CI job only re-probes what actually changed:
 
 ```sh
@@ -465,7 +447,7 @@ so a merge-time CI job only re-probes what actually changed:
 gcloud storage rsync gs://pay-skills/v1/ ./prev-dist --recursive
 
 # Rebuild just the providers that changed in this merge; copy the rest verbatim
-pay skills build . \
+pay catalog build . \
   --only operator/foo,operator/bar \
   --previous-dist ./prev-dist \
   --output ./dist
@@ -480,8 +462,8 @@ exists (first run, manual dispatch).
 
 Before opening a PR:
 
-- `pay skills build --no-probe` succeeds.
-- `pay skills validate --files <changed>` either passes or emits warnings
+- `pay catalog check <changed PAY.md> --no-probe` succeeds.
+- `pay catalog check . --changed-from origin/main` either passes or emits warnings
   you've reviewed; nothing should be marked `block`.
 - Paid endpoints return HTTP 402 before payment.
 - Challenges are MPP, MPP session, or x402.
@@ -491,8 +473,8 @@ Before opening a PR:
 - Provider descriptions and endpoint descriptions meet length limits.
 
 Open the PR against `https://github.com/solana-foundation/pay-skills`. CI runs
-static validation and probes changed providers via `pay skills validate`,
+static validation and probes changed providers via `pay catalog check`,
 posting per-endpoint warnings inline. After merge, the partial-rebuild
 workflow re-probes only the providers in the diff, merges them into the
 prior `dist/`, and republishes. Agents discover the updated provider
-through `pay skills search` and Pay MCP `search_catalog`.
+through the Pay catalog and Pay MCP `search_catalog`.


### PR DESCRIPTION
## Summary
- make create_skill accept the current provider directory layout ending in PAY.md
- emit current pay catalog check commands instead of removed pay skills commands
- update the bundled monetization reference for committed OpenAPI sidecars, current categories, and catalog validation
- remove the obsolete provider sync recommendation from the MCP tool description

## Problem
The MCP helper still generated and validated the legacy flat provider layout. A contributor following it would produce paths and commands rejected by the current pay-skills catalog workflow.

## Verification
- cargo test -p pay-mcp: 107 passed, 3 ignored
- cargo test -p pay-mcp --doc
- cargo fmt --all --check
- git diff --check

The output-path tests were updated first and failed against the old implementation, then passed with this change.