### PR TITLE
fix(mcp): support mpp payment sessions

### DIFF
--- a/rust/crates/cli/src/commands/payer_proxy.rs
+++ b/rust/crates/cli/src/commands/payer_proxy.rs
@@ -994,71 +994,15 @@ fn build_session_authorization(
     state: &PayerState,
     challenge: &pay_core::mpp::Challenge,
 ) -> pay_core::Result<(PaidHeaders, String)> {
-    use pay_kit::mpp::{SessionRequest, SessionVoucherSigner};
-
-    let request: SessionRequest = challenge
-        .request
-        .decode()
-        .map_err(|error| pay_core::Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
-    if request.method_details.voucher_signer != Some(SessionVoucherSigner::Operator) {
-        return Err(pay_core::Error::Mpp(
-            "agent payer requires an operator-signed MPP session".to_string(),
-        ));
-    }
-    if let Some(forced) = state.network_override.as_deref()
-        && forced != request.method_details.network
-    {
-        return Err(pay_core::Error::Mpp(format!(
-            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{}`",
-            request.method_details.network
-        )));
-    }
-
-    let minimum = request
-        .minimum_deposit
-        .as_deref()
-        .map(|value| {
-            value.parse::<u64>().map_err(|_| {
-                pay_core::Error::Mpp(format!(
-                    "MPP session challenge advertised a non-numeric minimumDeposit: {value}"
-                ))
-            })
-        })
-        .transpose()?
-        .unwrap_or(0);
-    let deposit = request
-        .suggested_deposit
-        .as_deref()
-        .map(|value| {
-            value.parse::<u64>().map_err(|_| {
-                pay_core::Error::Mpp(format!(
-                    "MPP session challenge advertised a non-numeric suggestedDeposit: {value}"
-                ))
-            })
-        })
-        .transpose()?
-        .unwrap_or(1_000_000)
-        .max(minimum)
-        .max(1);
-    let sandbox = state.network_override.as_deref() == Some("localnet");
-    let (handle, open_authorization) = pay_core::session::open_payment_channel_session_header(
-        challenge,
-        &request,
-        state.store.as_ref(),
-        state.network_override.as_deref(),
-        state.account_override.as_deref(),
-        deposit,
-        &state.authorization_url,
-        sandbox,
-    )?;
-
-    // Subsequent requests authenticate with the reusable payer proof bound at
-    // open; the operator meters delivered service and signs the vouchers.
-    let use_authorization = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| pay_core::Error::Mpp(format!("Failed to build runtime: {error}")))?
-        .block_on(handle.use_header())?;
+    let (open_authorization, use_authorization) =
+        pay_core::session::open_operator_signed_session_authorizations(
+            challenge,
+            state.store.as_ref(),
+            state.network_override.as_deref(),
+            state.account_override.as_deref(),
+            &state.authorization_url,
+            None,
+        )?;
 
     Ok((PaidHeaders::mpp(open_authorization), use_authorization))
 }

--- a/rust/crates/cli/src/commands/server/start.rs
+++ b/rust/crates/cli/src/commands/server/start.rs
@@ -1114,7 +1114,6 @@ impl StartCommand {
                 let session_secret = std::env::var("PAY_SESSION_SECRET")
                     .unwrap_or_else(|_| challenge_binding_secret.clone());
                 let channel_program_id = std::env::var("PAY_PAYMENT_CHANNELS_PROGRAM_ID")
-                    .or_else(|_| std::env::var("PAY_FIBER_PROGRAM_ID"))
                     .ok()
                     .and_then(|value| solana_pubkey::Pubkey::from_str(&value).ok())
                     .unwrap_or_else(pay_kit::mpp::program::payment_channels::default_program_id);

--- a/rust/crates/core/src/client/runner.rs
+++ b/rust/crates/core/src/client/runner.rs
@@ -47,7 +47,7 @@ pub enum RunOutcome {
         resource_url: String,
     },
     /// The server returned 402 with an MPP session challenge (intent="session").
-    /// Session payments require a stateful client with a Fiber channel.
+    /// Session payments require a stateful client with an MPP payment channel.
     SessionChallenge {
         challenge: Box<mpp::Challenge>,
         advertised_challenges: DecodedPaymentChallenges,

--- a/rust/crates/core/src/client/session.rs
+++ b/rust/crates/core/src/client/session.rs
@@ -271,6 +271,33 @@ pub fn open_payment_channel_session_header(
     resource_url: &str,
     sandbox: bool,
 ) -> Result<(SessionHandle, String)> {
+    open_payment_channel_session_header_with_override(
+        challenge,
+        request,
+        store,
+        network_override,
+        account_override,
+        deposit,
+        resource_url,
+        sandbox,
+        None,
+    )
+}
+
+/// Variant of [`open_payment_channel_session_header`] that lets an MCP host
+/// route the wallet approval through its own authenticated approval surface.
+#[allow(clippy::too_many_arguments)]
+pub fn open_payment_channel_session_header_with_override(
+    challenge: &PaymentChallenge,
+    request: &SessionRequest,
+    store: &dyn crate::accounts::AccountsStore,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    deposit: u64,
+    resource_url: &str,
+    sandbox: bool,
+    auth_override: crate::signer::AuthOverride,
+) -> Result<(SessionHandle, String)> {
     use pay_kit::mpp::client::{
         DerivePaymentChannelOpenParams, PaymentChannelOpenOptions,
         PaymentChannelSessionOpenOptions, create_payment_channel_session_opener,
@@ -291,12 +318,14 @@ pub fn open_payment_channel_session_header(
         &limit.display,
         &prompt_context.operator,
     );
-    let (signer, ephemeral_notice) = crate::signer::load_signer_for_network_with_intent(
-        &network,
-        store,
-        account_override,
-        &intent,
-    )?;
+    let (signer, ephemeral_notice) =
+        crate::signer::load_signer_for_network_with_intent_and_override(
+            &network,
+            store,
+            account_override,
+            &intent,
+            auth_override,
+        )?;
     let payer = signer.pubkey();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -416,6 +445,80 @@ pub fn open_payment_channel_session_header(
     Ok((handle, auth_header))
 }
 
+/// Open an operator-metered MPP payment-channel session and return its first
+/// `open` authorization plus the reusable `use` authorization.
+///
+/// Agent runtimes use this form because the operator, rather than the client,
+/// meters each response. Client-voucher sessions require the caller to advance
+/// a voucher by the delivered usage on every request.
+pub fn open_operator_signed_session_authorizations(
+    challenge: &PaymentChallenge,
+    store: &dyn crate::accounts::AccountsStore,
+    network_override: Option<&str>,
+    account_override: Option<&str>,
+    resource_url: &str,
+    auth_override: crate::signer::AuthOverride,
+) -> Result<(String, String)> {
+    let request: SessionRequest = challenge
+        .request
+        .decode()
+        .map_err(|error| Error::Mpp(format!("invalid MPP session challenge: {error}")))?;
+    if request.method_details.voucher_signer != Some(SessionVoucherSigner::Operator) {
+        return Err(Error::Mpp(
+            "agent payer requires an operator-signed MPP session".to_string(),
+        ));
+    }
+    if let Some(forced) = network_override
+        && forced != request.method_details.network
+    {
+        return Err(Error::Mpp(format!(
+            "MPP session network mismatch: payer requires `{forced}`, gateway offered `{}`",
+            request.method_details.network
+        )));
+    }
+
+    let minimum = request
+        .minimum_deposit
+        .as_deref()
+        .map(parse_session_deposit)
+        .transpose()?
+        .unwrap_or(0);
+    let deposit = request
+        .suggested_deposit
+        .as_deref()
+        .map(parse_session_deposit)
+        .transpose()?
+        .unwrap_or(1_000_000)
+        .max(minimum)
+        .max(1);
+    let sandbox = network_override == Some("localnet");
+    let (handle, open_authorization) = open_payment_channel_session_header_with_override(
+        challenge,
+        &request,
+        store,
+        network_override,
+        account_override,
+        deposit,
+        resource_url,
+        sandbox,
+        auth_override,
+    )?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| Error::Mpp(format!("Failed to build runtime: {error}")))?;
+    let use_authorization = runtime.block_on(handle.use_header())?;
+    Ok((open_authorization, use_authorization))
+}
+
+fn parse_session_deposit(value: &str) -> Result<u64> {
+    value.parse::<u64>().map_err(|_| {
+        Error::Mpp(format!(
+            "MPP session challenge advertised a non-numeric deposit: {value}"
+        ))
+    })
+}
+
 /// Build a voucher header for a subsequent call on an open session.
 pub fn voucher_header_sync(handle: &SessionHandle, amount: u64) -> Result<String> {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -427,7 +530,10 @@ pub fn voucher_header_sync(handle: &SessionHandle, amount: u64) -> Result<String
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-pub(crate) fn canonical_session_origin(resource_url: &str) -> Result<String> {
+/// Normalize an HTTP(S) resource URL to the origin used to scope a session.
+/// Credentials and paths are deliberately excluded so one session cannot be
+/// keyed by an unsafe or overly-specific URL representation.
+pub fn canonical_session_origin(resource_url: &str) -> Result<String> {
     let url = reqwest::Url::parse(resource_url)
         .map_err(|e| Error::Mpp(format!("invalid session authorization URL: {e}")))?;
     if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {

--- a/rust/crates/mcp/src/server.rs
+++ b/rust/crates/mcp/src/server.rs
@@ -5,12 +5,14 @@
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use std::sync::Arc;
 
 use crate::tools;
 
 pub struct PayMcp {
     #[allow(dead_code)]
     tool_router: rmcp::handler::server::router::tool::ToolRouter<Self>,
+    session_cache: Arc<tools::curl::SessionCache>,
 }
 
 impl Default for PayMcp {
@@ -24,6 +26,7 @@ impl PayMcp {
     pub fn new() -> Self {
         Self {
             tool_router: Self::tool_router(),
+            session_cache: Arc::new(tools::curl::SessionCache::default()),
         }
     }
 
@@ -60,7 +63,7 @@ and does not submit the request or payment.
         Parameters(params): Parameters<tools::curl::Params>,
         peer: rmcp::Peer<rmcp::service::RoleServer>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        tools::curl::run(params, peer).await
+        tools::curl::run(params, peer, self.session_cache.clone()).await
     }
 
     #[tool(

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -15,7 +15,8 @@ use std::time::SystemTime;
 /// Reusable MPP session authorizations for one MCP server connection.
 ///
 /// The `PayMcp` instance is created for one stdio MCP connection. Keys are
-/// normalized HTTP origins so sessions cannot cross providers or accounts.
+/// normalized HTTP method-and-path routes so sessions cannot cross providers,
+/// accounts, or metered endpoints.
 /// The mutex intentionally serializes session-backed requests: an operator
 /// meters each use against one channel's remaining capacity.
 #[derive(Default)]
@@ -40,6 +41,19 @@ impl SessionCache {
             authorizations.remove(origin);
         }
     }
+}
+
+/// Return the gateway route that owns an MPP session authorization.
+///
+/// Query parameters are excluded because the gateway resolves session pricing
+/// by the configured HTTP method and path. Including the method avoids the
+/// server's session-credential path fallback sharing a channel with another
+/// operation that happens to use the same path.
+fn session_cache_key(method: &str, resource_url: &str) -> Result<String, pay_core::Error> {
+    let origin = pay_core::session::canonical_session_origin(resource_url)?;
+    let url = reqwest::Url::parse(resource_url)
+        .map_err(|error| pay_core::Error::Mpp(format!("invalid MPP session URL: {error}")))?;
+    Ok(format!("{method} {origin}{}", url.path()))
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -936,12 +950,12 @@ fn do_paid_fetch(
         }
         _ => extra_headers.to_vec(),
     };
-    let session_origin = pay_core::session::canonical_session_origin(url).ok();
-    let cached_session = session_origin.as_deref().and_then(|origin| {
+    let session_key = session_cache_key(method, url).ok();
+    let cached_session = session_key.as_deref().and_then(|key| {
         (!initial_headers
             .iter()
             .any(|(name, _)| name.eq_ignore_ascii_case("authorization")))
-        .then(|| session_cache.authorization(origin))
+        .then(|| session_cache.authorization(key))
         .flatten()
     });
     if let Some(authorization) = cached_session.as_ref() {
@@ -953,8 +967,8 @@ fn do_paid_fetch(
     // A reused authorization that receives a 402 is no longer trustworthy.
     // Drop it before negotiating a fresh session from the server challenge.
     if cached_session.is_some() && !matches!(&outcome, RunOutcome::Completed { .. }) {
-        if let Some(origin) = session_origin.as_deref() {
-            session_cache.remove(origin);
+        if let Some(key) = session_key.as_deref() {
+            session_cache.remove(key);
         }
     }
 
@@ -1129,7 +1143,7 @@ fn do_paid_fetch(
             }
         }
         RunOutcome::SessionChallenge { challenge, .. } => {
-            let origin = session_origin.ok_or_else(|| {
+            let key = session_key.ok_or_else(|| {
                 pay_core::Error::Mpp(
                     "MPP session payments require an absolute HTTP(S) URL".to_string(),
                 )
@@ -1149,7 +1163,7 @@ fn do_paid_fetch(
             if matches!(&retry, RunOutcome::Completed { .. }) {
                 // Only retain a session after the gateway accepted its open
                 // request; otherwise the channel may not exist remotely.
-                session_cache.store(origin, use_authorization);
+                session_cache.store(key, use_authorization);
             }
             interpret_retry(retry)
         }
@@ -1573,6 +1587,20 @@ mod tests {
             &cache,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn session_cache_key_isolated_by_method_and_endpoint() {
+        let first = session_cache_key("POST", "https://api.example.com/v1/models?model=a").unwrap();
+        let same_endpoint =
+            session_cache_key("POST", "https://api.example.com/v1/models?model=b").unwrap();
+        let other_endpoint =
+            session_cache_key("POST", "https://api.example.com/v1/images").unwrap();
+        let other_method = session_cache_key("GET", "https://api.example.com/v1/models").unwrap();
+
+        assert_eq!(first, same_endpoint);
+        assert_ne!(first, other_endpoint);
+        assert_ne!(first, other_method);
     }
 
     #[test]

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -5,10 +5,42 @@ use rmcp::schemars;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
+
+/// Reusable MPP session authorizations for one MCP server connection.
+///
+/// The `PayMcp` instance is created for one stdio MCP connection. Keys are
+/// normalized HTTP origins so sessions cannot cross providers or accounts.
+/// The mutex intentionally serializes session-backed requests: an operator
+/// meters each use against one channel's remaining capacity.
+#[derive(Default)]
+pub(crate) struct SessionCache {
+    authorizations: Mutex<HashMap<String, String>>,
+    request_lock: Mutex<()>,
+}
+
+impl SessionCache {
+    fn authorization(&self, origin: &str) -> Option<String> {
+        self.authorizations.lock().ok()?.get(origin).cloned()
+    }
+
+    fn store(&self, origin: String, authorization: String) {
+        if let Ok(mut authorizations) = self.authorizations.lock() {
+            authorizations.insert(origin, authorization);
+        }
+    }
+
+    fn remove(&self, origin: &str) {
+        if let Ok(mut authorizations) = self.authorizations.lock() {
+            authorizations.remove(origin);
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -140,6 +172,7 @@ fn is_http_token_byte(byte: u8) -> bool {
 pub async fn run(
     params: Params,
     peer: rmcp::Peer<rmcp::service::RoleServer>,
+    session_cache: Arc<SessionCache>,
 ) -> Result<CallToolResult, rmcp::ErrorData> {
     if params.body.is_some() && params.body_file.is_some() {
         return Ok(super::tool_error(
@@ -189,6 +222,7 @@ pub async fn run(
             body.as_ref(),
             redirect_policy,
             Some(peer),
+            session_cache.as_ref(),
         )
     })
     .await
@@ -832,10 +866,18 @@ fn do_paid_fetch(
     body: Option<&RequestBody>,
     redirect_policy: RedirectPolicy,
     peer: Option<rmcp::Peer<rmcp::service::RoleServer>>,
+    session_cache: &SessionCache,
 ) -> Result<PaidFetchResult, pay_core::Error> {
     use pay_core::client::runner::RunOutcome;
 
     validate_cached_catalog_body(method, url, extra_headers, body)?;
+    // A channel's available capacity is consumed by each request. MCP clients
+    // may issue tool calls concurrently, so keep the full request/retry cycle
+    // serialized until the gateway has accepted and metered it.
+    let _session_request = session_cache
+        .request_lock
+        .lock()
+        .map_err(|_| pay_core::Error::Mpp("MPP session request lock poisoned".to_string()))?;
 
     let fetch_request = |headers: &[(String, String)]| {
         pay_core::client::fetch::fetch_request_with_body_for(
@@ -882,7 +924,7 @@ fn do_paid_fetch(
     // ID prompt, no extra round trip. On miss this is a no-op.
     let cached_auth_header =
         pay_core::client::authenticate::cached_header_for_resource(&store, url);
-    let initial_headers: Vec<(String, String)> = match cached_auth_header.as_deref() {
+    let mut initial_headers: Vec<(String, String)> = match cached_auth_header.as_deref() {
         Some(token)
             if !extra_headers
                 .iter()
@@ -894,8 +936,27 @@ fn do_paid_fetch(
         }
         _ => extra_headers.to_vec(),
     };
+    let session_origin = pay_core::session::canonical_session_origin(url).ok();
+    let cached_session = session_origin.as_deref().and_then(|origin| {
+        (!initial_headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("authorization")))
+        .then(|| session_cache.authorization(origin))
+        .flatten()
+    });
+    if let Some(authorization) = cached_session.as_ref() {
+        initial_headers.push(("Authorization".to_string(), authorization.clone()));
+    }
 
     let outcome = fetch_request(&initial_headers)?;
+
+    // A reused authorization that receives a 402 is no longer trustworthy.
+    // Drop it before negotiating a fresh session from the server challenge.
+    if cached_session.is_some() && !matches!(&outcome, RunOutcome::Completed { .. }) {
+        if let Some(origin) = session_origin.as_deref() {
+            session_cache.remove(origin);
+        }
+    }
 
     match outcome {
         RunOutcome::MppChallenge {
@@ -951,8 +1012,7 @@ fn do_paid_fetch(
                     );
                 }
                 ChosenPayment::X402Upto(challenge) => {
-                    let built_payment =
-                        pay_core::client::x402::build_upto_payment_with_override(
+                    let built_payment = pay_core::client::x402::build_upto_payment_with_override(
                         challenge.as_ref(),
                         &store,
                         network_override.as_deref(),
@@ -1068,9 +1128,31 @@ fn do_paid_fetch(
                 ))
             }
         }
-        RunOutcome::SessionChallenge { .. } => Err(pay_core::Error::Mpp(
-            "402 Payment Required (MPP session) — session payments require a stateful client with a Fiber channel".to_string(),
-        )),
+        RunOutcome::SessionChallenge { challenge, .. } => {
+            let origin = session_origin.ok_or_else(|| {
+                pay_core::Error::Mpp(
+                    "MPP session payments require an absolute HTTP(S) URL".to_string(),
+                )
+            })?;
+            let (open_authorization, use_authorization) =
+                pay_core::session::open_operator_signed_session_authorizations(
+                    &challenge,
+                    &store,
+                    network_override.as_deref(),
+                    account_override.as_deref(),
+                    url,
+                    make_auth_override(),
+                )?;
+            let mut headers = extra_headers.to_vec();
+            headers.push(("Authorization".to_string(), open_authorization));
+            let retry = fetch_request(&headers)?;
+            if matches!(&retry, RunOutcome::Completed { .. }) {
+                // Only retain a session after the gateway accepted its open
+                // request; otherwise the channel may not exist remotely.
+                session_cache.store(origin, use_authorization);
+            }
+            interpret_retry(retry)
+        }
         RunOutcome::SubscriptionChallenge {
             challenge,
             authenticate,
@@ -1119,9 +1201,7 @@ fn do_paid_fetch(
             "402 Payment Required but no recognized protocol".to_string(),
         )),
         RunOutcome::Completed {
-            body,
-            content_type,
-            ..
+            body, content_type, ..
         } => Ok((body.unwrap_or_default(), content_type)),
     }
 }
@@ -1482,7 +1562,16 @@ mod tests {
 
     #[test]
     fn do_paid_fetch_returns_error_for_invalid_url() {
-        let result = do_paid_fetch("GET", "not-a-url", &[], None, RedirectPolicy::Follow, None);
+        let cache = SessionCache::default();
+        let result = do_paid_fetch(
+            "GET",
+            "not-a-url",
+            &[],
+            None,
+            RedirectPolicy::Follow,
+            None,
+            &cache,
+        );
         assert!(result.is_err());
     }
 

--- a/rust/crates/mcp/src/tools/curl.rs
+++ b/rust/crates/mcp/src/tools/curl.rs
@@ -966,10 +966,11 @@ fn do_paid_fetch(
 
     // A reused authorization that receives a 402 is no longer trustworthy.
     // Drop it before negotiating a fresh session from the server challenge.
-    if cached_session.is_some() && !matches!(&outcome, RunOutcome::Completed { .. }) {
-        if let Some(key) = session_key.as_deref() {
-            session_cache.remove(key);
-        }
+    if cached_session.is_some()
+        && !matches!(&outcome, RunOutcome::Completed { .. })
+        && let Some(key) = session_key.as_deref()
+    {
+        session_cache.remove(key);
     }
 
     match outcome {


### PR DESCRIPTION
## Summary
- add stateful operator-metered MPP payment-channel support to the Pay MCP curl tool
- scope reusable session authorizations to the HTTP method and configured endpoint path
- share session opening and reusable authorization construction between MCP and the payer proxy

## Test Plan
- cargo fmt --all --check
- cargo test -p pay-mcp
- cargo test -p pay payer_proxy