### PR TITLE
fix(core): add machine-readable code to FindReferenceError

### DIFF
--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -146,7 +146,7 @@ const instructions = await client.pay.createTransfer({ recipient, amount: 1 });
 ### Transfers
 
 - **`createTransfer(rpc, sender, fields)`** — Create transfer `Instruction[]` for a payment.
-- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address.
+- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address. Throws `FindReferenceError` with machine-readable `code` (`'not found'` if the RPC returned no signatures — an inconclusive read that can't tell "never paid" from "not indexed yet" or "aged out of a non-archival node", `'aborted'` when a `watchReference` subscription is cancelled) so callers never have to string-match the message.
 - **`validateTransfer(rpc, signature, fields, options?)`** — Validate that a confirmed transaction matches the expected payment.
 
 ### Transaction Requests

--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -146,7 +146,7 @@ const instructions = await client.pay.createTransfer({ recipient, amount: 1 });
 ### Transfers
 
 - **`createTransfer(rpc, sender, fields)`** — Create transfer `Instruction[]` for a payment.
-- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address. Throws `FindReferenceError` with machine-readable `code` (`'not found'` when no transaction was seen — the RPC returned no signatures, or a `watchReference` subscription ended before any notification arrived; an inconclusive read that can't tell "never paid" from "not indexed yet" or "aged out of a non-archival node" — or `'aborted'` when a `watchReference` subscription is cancelled) so callers never have to string-match the message.
+- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address. Throws `FindReferenceError` with machine-readable `code` (`'inconclusive'` when no transaction was seen — the RPC returned no signatures, or a `watchReference` subscription ended before any notification arrived; an empty read that can't tell "never paid" from "not indexed yet" or "aged out of a non-archival node", so the code claims nothing further — or `'aborted'` when a `watchReference` subscription is cancelled) so callers never have to string-match the message.
 - **`validateTransfer(rpc, signature, fields, options?)`** — Validate that a confirmed transaction matches the expected payment.
 
 ### Transaction Requests

--- a/typescript/packages/solana-pay/core/README.md
+++ b/typescript/packages/solana-pay/core/README.md
@@ -146,7 +146,7 @@ const instructions = await client.pay.createTransfer({ recipient, amount: 1 });
 ### Transfers
 
 - **`createTransfer(rpc, sender, fields)`** — Create transfer `Instruction[]` for a payment.
-- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address. Throws `FindReferenceError` with machine-readable `code` (`'not found'` if the RPC returned no signatures — an inconclusive read that can't tell "never paid" from "not indexed yet" or "aged out of a non-archival node", `'aborted'` when a `watchReference` subscription is cancelled) so callers never have to string-match the message.
+- **`findReference(rpc, reference, options?)`** — Find a transaction signature by reference address. Throws `FindReferenceError` with machine-readable `code` (`'not found'` when no transaction was seen — the RPC returned no signatures, or a `watchReference` subscription ended before any notification arrived; an inconclusive read that can't tell "never paid" from "not indexed yet" or "aged out of a non-archival node" — or `'aborted'` when a `watchReference` subscription is cancelled) so callers never have to string-match the message.
 - **`validateTransfer(rpc, signature, fields, options?)`** — Validate that a confirmed transaction matches the expected payment.
 
 ### Transaction Requests

--- a/typescript/packages/solana-pay/core/src/findReference.ts
+++ b/typescript/packages/solana-pay/core/src/findReference.ts
@@ -6,14 +6,16 @@ import type { Reference } from './types.js';
 /**
  * A machine-readable reason for a {@link FindReferenceError}.
  *
- * `'not found'` means no transaction was seen: `findReference` got an RPC
+ * `'inconclusive'` means no transaction was seen: `findReference` got an RPC
  * response with no signatures, or a `watchReference` subscription ended
- * before any notification arrived. Both reads are inconclusive: the customer
- * may never have paid, the transaction may not be indexed by this node yet,
- * or it may have aged out of a non-archival node's history. `'aborted'` means
- * a `watchReference` subscription was cancelled before a transaction was seen.
+ * before any notification arrived. Both reads carry no verdict on why: the
+ * customer may never have paid, the transaction may not be indexed by this
+ * node yet, or it may have aged out of a non-archival node's history — the
+ * RPC response cannot distinguish them, so the code claims nothing further.
+ * `'aborted'` means a `watchReference` subscription was cancelled before a
+ * transaction was seen.
  */
-export type FindReferenceErrorCode = 'aborted' | 'not found';
+export type FindReferenceErrorCode = 'aborted' | 'inconclusive';
 
 /**
  * Thrown when no transaction signature can be found referencing a given address.
@@ -23,14 +25,20 @@ export class FindReferenceError extends Error {
 
     /**
      * Machine-readable reason, so callers can branch without string-matching {@link Error.message}.
-     * Only set when the library itself threw the error; instances constructed with any other
-     * message carry no code.
+     * `'inconclusive'` for the library's `'not found'` message — an empty read that cannot
+     * distinguish never-paid from not-yet-indexed or aged-out — `'aborted'` for a cancelled
+     * `watchReference` subscription. Only set when the library itself threw the error; instances
+     * constructed with any other message carry no code.
      */
     readonly code: FindReferenceErrorCode | undefined;
 
     constructor(message?: string, options?: ErrorOptions) {
         super(message, options);
-        this.code = message === 'not found' || message === 'aborted' ? message : undefined;
+        if (message === 'not found' || message === 'aborted') {
+            this.code = message === 'not found' ? 'inconclusive' : 'aborted';
+        } else {
+            this.code = undefined;
+        }
     }
 }
 

--- a/typescript/packages/solana-pay/core/src/findReference.ts
+++ b/typescript/packages/solana-pay/core/src/findReference.ts
@@ -4,10 +4,29 @@ import type { Commitment, Signature } from '@solana/kit';
 import type { Reference } from './types.js';
 
 /**
+ * A machine-readable reason for a {@link FindReferenceError}.
+ *
+ * `'not found'` means the RPC returned no signatures for the reference, which is
+ * inconclusive: the customer may never have paid, the transaction may not be
+ * indexed by this node yet, or it may have aged out of a non-archival node's
+ * history. `'aborted'` means the subscription was cancelled before any
+ * transaction was seen.
+ */
+export type FindReferenceErrorCode = 'aborted' | 'not found';
+
+/**
  * Thrown when no transaction signature can be found referencing a given address.
  */
 export class FindReferenceError extends Error {
     name = 'FindReferenceError';
+
+    /** Machine-readable reason, so callers can branch without string-matching {@link Error.message}. */
+    readonly code: FindReferenceErrorCode;
+
+    constructor(message: FindReferenceErrorCode) {
+        super(message);
+        this.code = message;
+    }
 }
 
 /** Options for {@link findReference}. */

--- a/typescript/packages/solana-pay/core/src/findReference.ts
+++ b/typescript/packages/solana-pay/core/src/findReference.ts
@@ -6,11 +6,12 @@ import type { Reference } from './types.js';
 /**
  * A machine-readable reason for a {@link FindReferenceError}.
  *
- * `'not found'` means the RPC returned no signatures for the reference, which is
- * inconclusive: the customer may never have paid, the transaction may not be
- * indexed by this node yet, or it may have aged out of a non-archival node's
- * history. `'aborted'` means the subscription was cancelled before any
- * transaction was seen.
+ * `'not found'` means no transaction was seen: `findReference` got an RPC
+ * response with no signatures, or a `watchReference` subscription ended
+ * before any notification arrived. Both reads are inconclusive: the customer
+ * may never have paid, the transaction may not be indexed by this node yet,
+ * or it may have aged out of a non-archival node's history. `'aborted'` means
+ * a `watchReference` subscription was cancelled before a transaction was seen.
  */
 export type FindReferenceErrorCode = 'aborted' | 'not found';
 
@@ -20,12 +21,16 @@ export type FindReferenceErrorCode = 'aborted' | 'not found';
 export class FindReferenceError extends Error {
     name = 'FindReferenceError';
 
-    /** Machine-readable reason, so callers can branch without string-matching {@link Error.message}. */
-    readonly code: FindReferenceErrorCode;
+    /**
+     * Machine-readable reason, so callers can branch without string-matching {@link Error.message}.
+     * Only set when the library itself threw the error; instances constructed with any other
+     * message carry no code.
+     */
+    readonly code: FindReferenceErrorCode | undefined;
 
-    constructor(message: FindReferenceErrorCode) {
-        super(message);
-        this.code = message;
+    constructor(message?: string, options?: ErrorOptions) {
+        super(message, options);
+        this.code = message === 'not found' || message === 'aborted' ? message : undefined;
     }
 }
 

--- a/typescript/packages/solana-pay/core/test/findReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/findReference.test.ts
@@ -36,7 +36,7 @@ describe('findReference', () => {
         await expect(findReference(rpc, unknownRef)).rejects.toThrow('not found');
     });
 
-    it('should set code to "not found" when the RPC returns no signatures', async () => {
+    it('should set code to "inconclusive" when the RPC returns no signatures', async () => {
         expect.assertions(2);
 
         const unknownRef = address('2jDmYQMRCBnXUQeFRvQABcU6hLcvjVTdG7AoHravxWJX');
@@ -44,8 +44,8 @@ describe('findReference', () => {
         const error = await findReference(rpc, unknownRef).catch((thrown: unknown) => thrown);
 
         expect(error).toBeInstanceOf(FindReferenceError);
-        // An empty result is inconclusive, but it is reported as 'not found', never as 'aborted'.
-        expect((error as FindReferenceError).code).toBe('not found');
+        // An empty result carries no verdict on why: never paid, not indexed yet, or aged out.
+        expect((error as FindReferenceError).code).toBe('inconclusive');
     });
 });
 
@@ -69,7 +69,7 @@ describe('FindReferenceError', () => {
         expect(subclass).toBeInstanceOf(FindReferenceError);
         expect(subclass.attempts).toBe(3);
         expect(subclass.code).toBeUndefined();
-        expect(new FindReferenceError('not found').code).toBe('not found');
+        expect(new FindReferenceError('not found').code).toBe('inconclusive');
         expect(new FindReferenceError('aborted').code).toBe('aborted');
     });
 });

--- a/typescript/packages/solana-pay/core/test/findReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/findReference.test.ts
@@ -48,3 +48,28 @@ describe('findReference', () => {
         expect((error as FindReferenceError).code).toBe('not found');
     });
 });
+
+describe('FindReferenceError', () => {
+    it('should keep the Error-compatible constructor surface', () => {
+        const noArg = new FindReferenceError();
+        const customMessage = new FindReferenceError('terminal offline, retry later');
+        const withCause = new FindReferenceError('rpc down', { cause: new Error('socket closed') });
+        class RetriedFindReferenceError extends FindReferenceError {
+            attempts: number;
+            constructor(attempts: number) {
+                super(`gave up after ${attempts} attempts`);
+                this.attempts = attempts;
+            }
+        }
+        const subclass = new RetriedFindReferenceError(3);
+
+        expect(noArg.message).toBe('');
+        expect(customMessage.code).toBeUndefined();
+        expect((withCause.cause as Error).message).toBe('socket closed');
+        expect(subclass).toBeInstanceOf(FindReferenceError);
+        expect(subclass.attempts).toBe(3);
+        expect(subclass.code).toBeUndefined();
+        expect(new FindReferenceError('not found').code).toBe('not found');
+        expect(new FindReferenceError('aborted').code).toBe('aborted');
+    });
+});

--- a/typescript/packages/solana-pay/core/test/findReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/findReference.test.ts
@@ -1,7 +1,7 @@
 import { address } from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 
-import { findReference } from '../src/index.js';
+import { FindReferenceError, findReference } from '../src/index.js';
 
 const reference = address('9aE476sH92Vz7DMPyq5WLPkrKWivxeuTKEFKd2sZZcde');
 
@@ -34,5 +34,17 @@ describe('findReference', () => {
         const unknownRef = address('2jDmYQMRCBnXUQeFRvQABcU6hLcvjVTdG7AoHravxWJX');
 
         await expect(findReference(rpc, unknownRef)).rejects.toThrow('not found');
+    });
+
+    it('should set code to "not found" when the RPC returns no signatures', async () => {
+        expect.assertions(2);
+
+        const unknownRef = address('2jDmYQMRCBnXUQeFRvQABcU6hLcvjVTdG7AoHravxWJX');
+
+        const error = await findReference(rpc, unknownRef).catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(FindReferenceError);
+        // An empty result is inconclusive, but it is reported as 'not found', never as 'aborted'.
+        expect((error as FindReferenceError).code).toBe('not found');
     });
 });

--- a/typescript/packages/solana-pay/core/test/watchReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/watchReference.test.ts
@@ -172,4 +172,17 @@ describe('watchReference', () => {
         // An abort is a caller action, not an inconclusive read; it must not read as 'not found'.
         expect((error as FindReferenceError).code).toBe('aborted');
     });
+
+    it('should set code to "not found" when the subscription ends without a notification', async () => {
+        expect.assertions(2);
+
+        const rpcSubscriptions = createMockRpcSubscriptions([]);
+
+        const error = await watchReference(rpcSubscriptions, reference).catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(FindReferenceError);
+        // A subscription that ends normally saw no transaction; it is the same inconclusive read as
+        // an empty getSignaturesForAddress response, not a caller abort.
+        expect((error as FindReferenceError).code).toBe('not found');
+    });
 });

--- a/typescript/packages/solana-pay/core/test/watchReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/watchReference.test.ts
@@ -146,4 +146,30 @@ describe('watchReference', () => {
             FindReferenceError,
         );
     });
+
+    it('should set code to "aborted" when the subscription is aborted', async () => {
+        expect.assertions(2);
+
+        const abortController = new AbortController();
+        const rpcSubscriptions = {
+            logsNotifications() {
+                return {
+                    async subscribe({ abortSignal }: { abortSignal: AbortSignal }) {
+                        return new Promise((_resolve, reject) => {
+                            abortSignal.addEventListener('abort', () => reject(abortSignal.reason));
+                        });
+                    },
+                };
+            },
+        } as any;
+
+        const promise = watchReference(rpcSubscriptions, reference, { abortSignal: abortController.signal });
+        abortController.abort();
+
+        const error = await promise.catch((thrown: unknown) => thrown);
+
+        expect(error).toBeInstanceOf(FindReferenceError);
+        // An abort is a caller action, not an inconclusive read; it must not read as 'not found'.
+        expect((error as FindReferenceError).code).toBe('aborted');
+    });
 });

--- a/typescript/packages/solana-pay/core/test/watchReference.test.ts
+++ b/typescript/packages/solana-pay/core/test/watchReference.test.ts
@@ -173,7 +173,7 @@ describe('watchReference', () => {
         expect((error as FindReferenceError).code).toBe('aborted');
     });
 
-    it('should set code to "not found" when the subscription ends without a notification', async () => {
+    it('should set code to "inconclusive" when the subscription ends without a notification', async () => {
         expect.assertions(2);
 
         const rpcSubscriptions = createMockRpcSubscriptions([]);
@@ -183,6 +183,6 @@ describe('watchReference', () => {
         expect(error).toBeInstanceOf(FindReferenceError);
         // A subscription that ends normally saw no transaction; it is the same inconclusive read as
         // an empty getSignaturesForAddress response, not a caller abort.
-        expect((error as FindReferenceError).code).toBe('not found');
+        expect((error as FindReferenceError).code).toBe('inconclusive');
     });
 });

--- a/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
+++ b/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
@@ -238,6 +238,9 @@ If a transaction with the given reference can't be found, the `findReference` fu
 
 -   Transaction is not yet confirmed
 -   Customer is yet to approve/complete the transaction
+-   The transaction has aged out of a non-archival RPC node's history
+
+An empty result is inconclusive: it can't distinguish a customer who never paid from a payment this node hasn't indexed yet, or no longer serves. Treat the error as "not found yet" and decide on your own timeout, not on the error itself. To branch on the reason programmatically, read the machine-readable `code` property of `FindReferenceError`: it is `'not found'` here, and `'aborted'` when a `watchReference` subscription is cancelled before a transaction is seen.
 
 <details>
     <summary>

--- a/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
+++ b/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
@@ -240,7 +240,7 @@ If a transaction with the given reference can't be found, the `findReference` fu
 -   Customer is yet to approve/complete the transaction
 -   The transaction has aged out of a non-archival RPC node's history
 
-An empty result is inconclusive: it can't distinguish a customer who never paid from a payment this node hasn't indexed yet, or no longer serves. Treat the error as "not found yet" and decide on your own timeout, not on the error itself. To branch on the reason programmatically, read the machine-readable `code` property of `FindReferenceError`: it is `'not found'` here, and `'aborted'` when a `watchReference` subscription is cancelled before a transaction is seen.
+An empty result is inconclusive: it can't distinguish a customer who never paid from a payment this node hasn't indexed yet, or no longer serves. Treat the error as "not found yet" and decide on your own timeout, not on the error itself. To branch on the reason programmatically, read the machine-readable `code` property of `FindReferenceError`: it is `'not found'` here and from a `watchReference` subscription that ends before a transaction is seen, and `'aborted'` when a `watchReference` subscription is cancelled.
 
 <details>
     <summary>

--- a/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
+++ b/typescript/packages/solana-pay/docs/src/core/transfer-request/MERCHANT_INTEGRATION.md
@@ -240,7 +240,7 @@ If a transaction with the given reference can't be found, the `findReference` fu
 -   Customer is yet to approve/complete the transaction
 -   The transaction has aged out of a non-archival RPC node's history
 
-An empty result is inconclusive: it can't distinguish a customer who never paid from a payment this node hasn't indexed yet, or no longer serves. Treat the error as "not found yet" and decide on your own timeout, not on the error itself. To branch on the reason programmatically, read the machine-readable `code` property of `FindReferenceError`: it is `'not found'` here and from a `watchReference` subscription that ends before a transaction is seen, and `'aborted'` when a `watchReference` subscription is cancelled.
+An empty result is inconclusive: it can't distinguish a customer who never paid from a payment this node hasn't indexed yet, or no longer serves. Treat the error as "not found yet" and decide on your own timeout, not on the error itself. To branch on the reason programmatically, read the machine-readable `code` property of `FindReferenceError`: it is `'inconclusive'` here and from a `watchReference` subscription that ends before a transaction is seen — the error message is still `'not found'`, but the code names what the read actually established — and `'aborted'` when a `watchReference` subscription is cancelled.
 
 <details>
     <summary>


### PR DESCRIPTION
## Summary

`FindReferenceError` now carries a machine-readable `code` property, so a polling merchant can branch on the reason without string-matching `error.message`.

The message, `name`, and `instanceof` identity are unchanged, so every existing `catch` keeps working.

## Problem

`findReference` throws the same error for an empty `getSignaturesForAddress` result, whatever the cause (#456):

- the customer never paid
- the customer paid, but this RPC node hasn't indexed the transaction yet
- the customer paid, but the signature aged out of a non-archival node's history

An empty response from `getSignaturesForAddress` is a bare array with no metadata (checked against `@solana/rpc-api` 8.2.0), so these three states can't be separated from the RPC data itself. What the library can do is stop conflating the reasons it does know about, and be precise about what an empty read established.

This adds:

- `FindReferenceError.code`: `'inconclusive'` or `'aborted'`. `'inconclusive'` is what an empty read actually established: no transaction was seen, and the response carries nothing that would tell never-paid from not-yet-indexed or aged-out. The error `message` is still `'not found'`, so existing catches and string matches keep working. `'aborted'` means a `watchReference` subscription was cancelled by the caller.
- a note in the merchant integration docs that an empty result is inconclusive, plus the aged-out reason in the list of causes
- a README line for the new property

## Verification

- before, on current `main`: `just ts test`: the new cases fail (`code` is `undefined` on `FindReferenceError`)
- after: `just ts test`: 165 passed (161 existing + 4 new covering both codes and the constructor surface)
- `just ts typecheck` and `just ts lint` pass

Fixes #456
